### PR TITLE
ccontrol update node功能：

### DIFF
--- a/protos/Crane.proto
+++ b/protos/Crane.proto
@@ -287,6 +287,17 @@ message ModifyTaskReply {
   string reason = 2;
 }
 
+message ModifyNodeRequest{
+  string name = 1;
+  bool drain = 2;
+  string reason = 3;
+}
+
+message ModifyNodeReply{
+  bool ok = 1;
+  string reason = 2;
+}
+
 message AddAccountRequest {
   uint32 uid = 1;
   AccountInfo account = 2;
@@ -597,6 +608,7 @@ service CraneCtld {
   rpc QueryCranedInfo(QueryCranedInfoRequest) returns (QueryCranedInfoReply);
   rpc QueryPartitionInfo(QueryPartitionInfoRequest) returns (QueryPartitionInfoReply);
   rpc ModifyTask(ModifyTaskRequest) returns (ModifyTaskReply);
+  rpc ModifyNode(ModifyNodeRequest) returns (ModifyNodeReply);
 
   /* RPCs called from cacctmgr */
   rpc AddAccount(AddAccountRequest) returns (AddAccountReply);

--- a/protos/PublicDefs.proto
+++ b/protos/PublicDefs.proto
@@ -52,6 +52,7 @@ enum CranedState{
   CRANE_MIX = 1;
   CRANE_ALLOC = 2;
   CRANE_DOWN = 3;
+  CRANE_DRAIN = 4;
 }
 
 enum TaskStatus {

--- a/src/CraneCtld/CranedMetaContainer.h
+++ b/src/CraneCtld/CranedMetaContainer.h
@@ -69,6 +69,9 @@ class CranedMetaContainerInterface {
   virtual crane::grpc::QueryClusterInfoReply QueryClusterInfo(
       const crane::grpc::QueryClusterInfoRequest& request) = 0;
 
+  virtual crane::grpc::ModifyNodeReply ChangeNodeState(
+      const crane::grpc::ModifyNodeRequest& request) = 0;
+
   virtual void MallocResourceFromNode(CranedId node_id, uint32_t task_id,
                                       const Resources& resources) = 0;
   virtual void FreeResourceFromNode(CranedId node_id, uint32_t task_id) = 0;
@@ -112,6 +115,9 @@ class CranedMetaContainerSimpleImpl final
 
   crane::grpc::QueryClusterInfoReply QueryClusterInfo(
       const crane::grpc::QueryClusterInfoRequest& request) override;
+
+  crane::grpc::ModifyNodeReply ChangeNodeState(
+      const crane::grpc::ModifyNodeRequest& request) override;
 
   void CranedUp(const CranedId& craned_id) override;
 

--- a/src/CraneCtld/CtldGrpcServer.cpp
+++ b/src/CraneCtld/CtldGrpcServer.cpp
@@ -142,6 +142,14 @@ grpc::Status CraneCtldServiceImpl::ModifyTask(
   return grpc::Status::OK;
 }
 
+grpc::Status CraneCtldServiceImpl::ModifyNode(
+    grpc::ServerContext *context, const crane::grpc::ModifyNodeRequest *request,
+    crane::grpc::ModifyNodeReply *response) {
+  *response = g_meta_container->ChangeNodeState(*request);
+
+  return grpc::Status::OK;
+}
+
 grpc::Status CraneCtldServiceImpl::QueryTasksInfo(
     grpc::ServerContext *context,
     const crane::grpc::QueryTasksInfoRequest *request,

--- a/src/CraneCtld/CtldGrpcServer.h
+++ b/src/CraneCtld/CtldGrpcServer.h
@@ -208,6 +208,10 @@ class CraneCtldServiceImpl final : public crane::grpc::CraneCtld::Service {
                           const crane::grpc::ModifyTaskRequest *request,
                           crane::grpc::ModifyTaskReply *response) override;
 
+  grpc::Status ModifyNode(grpc::ServerContext *context,
+                          const crane::grpc::ModifyNodeRequest *request,
+                          crane::grpc::ModifyNodeReply *response) override;
+
   grpc::Status AddAccount(grpc::ServerContext *context,
                           const crane::grpc::AddAccountRequest *request,
                           crane::grpc::AddAccountReply *response) override;

--- a/src/CraneCtld/CtldPublicDefs.h
+++ b/src/CraneCtld/CtldPublicDefs.h
@@ -134,6 +134,8 @@ struct CranedMeta {
   // just for convenience.
   Resources res_avail;
   Resources res_in_use;
+  bool drain{false};
+  std::string drain_reason;
 
   // Store the information of the slices of allocated resource.
   // One task id owns one shard of allocated resource.

--- a/src/CraneCtld/TaskScheduler.cpp
+++ b/src/CraneCtld/TaskScheduler.cpp
@@ -1176,7 +1176,7 @@ void MinLoadFirst::CalculateNodeSelectionInfoOfPartition_(
     CranedMeta const& craned_meta = craned_meta_map.at(craned_id);
 
     // An offline craned shouldn't be scheduled.
-    if (!craned_meta.alive) continue;
+    if (!craned_meta.alive || craned_meta.drain) continue;
 
     // Sort all running task in this node by ending time.
     std::vector<std::pair<absl::Time, uint32_t>> end_time_task_id_vec;


### PR DESCRIPTION
更改节点状态为drain，该节点不会有新的作业被调度，当前运行的作业不受影响；
-n指定节点名
--state指定状态为drain/resume，指定为drain时需用--reason说明原因。
--state=resume恢复节点drain之前的状态
cinfo查询节点状态时增加状态drain，state过滤也增加drain