### PR TITLE
ccontrol update node功能：

### DIFF
--- a/protos/Crane.proto
+++ b/protos/Crane.proto
@@ -278,6 +278,17 @@ message ModifyTaskReply {
   string reason = 2;
 }
 
+message ModifyNodeRequest{
+  string name = 1;
+  bool drain = 2;
+  string reason = 3;
+}
+
+message ModifyNodeReply{
+  bool ok = 1;
+  string reason = 2;
+}
+
 message AddAccountRequest {
   uint32 uid = 1;
   AccountInfo account = 2;
@@ -587,6 +598,7 @@ service CraneCtld {
   rpc QueryCranedInfo(QueryCranedInfoRequest) returns (QueryCranedInfoReply);
   rpc QueryPartitionInfo(QueryPartitionInfoRequest) returns (QueryPartitionInfoReply);
   rpc ModifyTask(ModifyTaskRequest) returns (ModifyTaskReply);
+  rpc ModifyNode(ModifyNodeRequest) returns (ModifyNodeReply);
 
   /* RPCs called from cacctmgr */
   rpc AddAccount(AddAccountRequest) returns (AddAccountReply);

--- a/protos/Crane.proto
+++ b/protos/Crane.proto
@@ -278,13 +278,13 @@ message ModifyTaskReply {
   string reason = 2;
 }
 
-message ModifyNodeRequest{
-  string name = 1;
-  bool drain = 2;
+message ModifyCranedStateRequest{
+  string craned_id = 1;
+  CranedState new_state = 2;
   string reason = 3;
 }
 
-message ModifyNodeReply{
+message ModifyCranedStateReply{
   bool ok = 1;
   string reason = 2;
 }
@@ -598,7 +598,7 @@ service CraneCtld {
   rpc QueryCranedInfo(QueryCranedInfoRequest) returns (QueryCranedInfoReply);
   rpc QueryPartitionInfo(QueryPartitionInfoRequest) returns (QueryPartitionInfoReply);
   rpc ModifyTask(ModifyTaskRequest) returns (ModifyTaskReply);
-  rpc ModifyNode(ModifyNodeRequest) returns (ModifyNodeReply);
+  rpc ModifyNode(ModifyCranedStateRequest) returns (ModifyCranedStateReply);
 
   /* RPCs called from cacctmgr */
   rpc AddAccount(AddAccountRequest) returns (AddAccountReply);

--- a/protos/PublicDefs.proto
+++ b/protos/PublicDefs.proto
@@ -52,6 +52,7 @@ enum CranedState{
   CRANE_MIX = 1;
   CRANE_ALLOC = 2;
   CRANE_DOWN = 3;
+  CRANE_DRAIN = 4;
 }
 
 enum TaskStatus {

--- a/src/CraneCtld/CranedMetaContainer.cpp
+++ b/src/CraneCtld/CranedMetaContainer.cpp
@@ -597,12 +597,12 @@ CranedMetaContainerSimpleImpl::ChangeNodeState(
 
   if (request.new_state() == crane::grpc::CranedState::CRANE_DRAIN) {
     craned_meta->drain = true;
-    craned_meta->drain_reason = request.reason();
+    craned_meta->state_reason = request.reason();
     reply.set_ok(true);
   } else if (request.new_state() == crane::grpc::CranedState::CRANE_IDLE) {
     if (craned_meta->alive) {
       craned_meta->drain = false;
-      craned_meta->drain_reason.clear();
+      craned_meta->state_reason.clear();
 
       reply.set_ok(true);
     } else {

--- a/src/CraneCtld/CranedMetaContainer.cpp
+++ b/src/CraneCtld/CranedMetaContainer.cpp
@@ -284,7 +284,10 @@ CranedMetaContainerSimpleImpl::QueryAllCranedInfo() {
     craned_info->set_running_task_num(
         craned_meta->running_task_resource_map.size());
     if (craned_meta->alive) {
-      if (craned_meta->res_in_use.allocatable_resource.cpu_count == cpu_t(0) &&
+      if (craned_meta->drain){
+        craned_info->set_state(crane::grpc::CranedState::CRANE_DRAIN);
+      }
+      else if (craned_meta->res_in_use.allocatable_resource.cpu_count == cpu_t(0) &&
           craned_meta->res_in_use.allocatable_resource.memory_bytes == 0)
         craned_info->set_state(crane::grpc::CranedState::CRANE_IDLE);
       else if (craned_meta->res_avail.allocatable_resource.cpu_count ==
@@ -330,7 +333,10 @@ CranedMetaContainerSimpleImpl::QueryCranedInfo(const std::string& node_name) {
   craned_info->set_running_task_num(
       craned_meta->running_task_resource_map.size());
   if (craned_meta->alive) {
-    if (craned_meta->res_in_use.allocatable_resource.cpu_count == cpu_t(0) &&
+    if (craned_meta->drain){
+      craned_info->set_state(crane::grpc::CranedState::CRANE_DRAIN);
+    }
+    else if (craned_meta->res_in_use.allocatable_resource.cpu_count == cpu_t(0) &&
         craned_meta->res_in_use.allocatable_resource.memory_bytes == 0)
       craned_info->set_state(crane::grpc::CranedState::CRANE_IDLE);
     else if (craned_meta->res_avail.allocatable_resource.cpu_count ==

--- a/src/CraneCtld/CranedMetaContainer.cpp
+++ b/src/CraneCtld/CranedMetaContainer.cpp
@@ -592,17 +592,23 @@ CranedMetaContainerSimpleImpl::ChangeNodeState(
     reply.set_reason("Invalid node name specified.");
     return reply;
   }
+
   auto crane_meta = craned_meta_map_[request.craned_id()];
 
   if (request.new_state() == crane::grpc::CranedState::CRANE_DRAIN) {
     crane_meta->drain = true;
     crane_meta->drain_reason = request.reason();
+    reply.set_ok(true);
   } else if (request.new_state() == crane::grpc::CranedState::CRANE_IDLE) {
-    crane_meta->drain = false;
-    crane_meta->drain_reason = "";
+    if (crane_meta->alive) {
+      crane_meta->drain = false;
+      reply.set_ok(true);
+    } else {
+      reply.set_ok(false);
+      reply.set_reason("Can't change the state of a DOWN node!");
+    }
   }
 
-  reply.set_ok(true);
   return reply;
 }
 

--- a/src/CraneCtld/CranedMetaContainer.cpp
+++ b/src/CraneCtld/CranedMetaContainer.cpp
@@ -558,7 +558,7 @@ CranedMetaContainerSimpleImpl::QueryClusterInfo(
           mix_craned_name_list.emplace_back(craned_meta->static_meta.hostname);
           mix_craned_list->set_count(mix_craned_name_list.size());
         }
-      } else if (craned_meta->alive && craned_meta->drain) {
+      } else if (filter_drain && craned_meta->alive && craned_meta->drain) {
         drain_craned_name_list.emplace_back(craned_meta->static_meta.hostname);
         drain_craned_list->set_count(drain_craned_name_list.size());
       } else if (filter_down) {

--- a/src/CraneCtld/CranedMetaContainer.cpp
+++ b/src/CraneCtld/CranedMetaContainer.cpp
@@ -614,20 +614,22 @@ CranedMetaContainerSimpleImpl::ChangeNodeState(
 
   auto craned_meta = craned_meta_map_[request.craned_id()];
 
-  if (request.new_state() == crane::grpc::CranedState::CRANE_DRAIN) {
-    craned_meta->drain = true;
-    craned_meta->state_reason = request.reason();
-    reply.set_ok(true);
-  } else if (request.new_state() == crane::grpc::CranedState::CRANE_IDLE) {
-    if (craned_meta->alive) {
+  if (craned_meta->alive) {
+    if (request.new_state() == crane::grpc::CranedState::CRANE_DRAIN) {
+      craned_meta->drain = true;
+      craned_meta->state_reason = request.reason();
+      reply.set_ok(true);
+    } else if (request.new_state() == crane::grpc::CranedState::CRANE_IDLE) {
       craned_meta->drain = false;
       craned_meta->state_reason.clear();
-
       reply.set_ok(true);
     } else {
       reply.set_ok(false);
-      reply.set_reason("Can't change the state of a DOWN node!");
+      reply.set_reason("Invalid state.");
     }
+  } else {
+    reply.set_ok(false);
+    reply.set_reason("Can't change the state of a DOWN node!");
   }
 
   return reply;

--- a/src/CraneCtld/CranedMetaContainer.cpp
+++ b/src/CraneCtld/CranedMetaContainer.cpp
@@ -582,21 +582,22 @@ CranedMetaContainerSimpleImpl::QueryClusterInfo(
   return reply;
 }
 
-crane::grpc::ModifyNodeReply CranedMetaContainerSimpleImpl::ChangeNodeState(
-    const crane::grpc::ModifyNodeRequest& request) {
-  crane::grpc::ModifyNodeReply reply;
+crane::grpc::ModifyCranedStateReply
+CranedMetaContainerSimpleImpl::ChangeNodeState(
+    const crane::grpc::ModifyCranedStateRequest& request) {
+  crane::grpc::ModifyCranedStateReply reply;
 
-  if (!craned_meta_map_.Contains(request.name())) {
+  if (!craned_meta_map_.Contains(request.craned_id())) {
     reply.set_ok(false);
     reply.set_reason("Invalid node name specified.");
     return reply;
   }
-  auto crane_meta = craned_meta_map_[request.name()];
+  auto crane_meta = craned_meta_map_[request.craned_id()];
 
-  if (request.drain()) {
+  if (request.new_state() == crane::grpc::CranedState::CRANE_DRAIN) {
     crane_meta->drain = true;
     crane_meta->drain_reason = request.reason();
-  } else {
+  } else if (request.new_state() == crane::grpc::CranedState::CRANE_IDLE) {
     crane_meta->drain = false;
     crane_meta->drain_reason = "";
   }

--- a/src/CraneCtld/CranedMetaContainer.cpp
+++ b/src/CraneCtld/CranedMetaContainer.cpp
@@ -593,15 +593,17 @@ CranedMetaContainerSimpleImpl::ChangeNodeState(
     return reply;
   }
 
-  auto crane_meta = craned_meta_map_[request.craned_id()];
+  auto craned_meta = craned_meta_map_[request.craned_id()];
 
   if (request.new_state() == crane::grpc::CranedState::CRANE_DRAIN) {
-    crane_meta->drain = true;
-    crane_meta->drain_reason = request.reason();
+    craned_meta->drain = true;
+    craned_meta->drain_reason = request.reason();
     reply.set_ok(true);
   } else if (request.new_state() == crane::grpc::CranedState::CRANE_IDLE) {
-    if (crane_meta->alive) {
-      crane_meta->drain = false;
+    if (craned_meta->alive) {
+      craned_meta->drain = false;
+      craned_meta->drain_reason.clear();
+
       reply.set_ok(true);
     } else {
       reply.set_ok(false);

--- a/src/CraneCtld/CranedMetaContainer.cpp
+++ b/src/CraneCtld/CranedMetaContainer.cpp
@@ -284,11 +284,11 @@ CranedMetaContainerSimpleImpl::QueryAllCranedInfo() {
     craned_info->set_running_task_num(
         craned_meta->running_task_resource_map.size());
     if (craned_meta->alive) {
-      if (craned_meta->drain){
+      if (craned_meta->drain) {
         craned_info->set_state(crane::grpc::CranedState::CRANE_DRAIN);
-      }
-      else if (craned_meta->res_in_use.allocatable_resource.cpu_count == cpu_t(0) &&
-          craned_meta->res_in_use.allocatable_resource.memory_bytes == 0)
+      } else if (craned_meta->res_in_use.allocatable_resource.cpu_count ==
+                     cpu_t(0) &&
+                 craned_meta->res_in_use.allocatable_resource.memory_bytes == 0)
         craned_info->set_state(crane::grpc::CranedState::CRANE_IDLE);
       else if (craned_meta->res_avail.allocatable_resource.cpu_count ==
                    cpu_t(0) ||
@@ -333,11 +333,11 @@ CranedMetaContainerSimpleImpl::QueryCranedInfo(const std::string& node_name) {
   craned_info->set_running_task_num(
       craned_meta->running_task_resource_map.size());
   if (craned_meta->alive) {
-    if (craned_meta->drain){
+    if (craned_meta->drain) {
       craned_info->set_state(crane::grpc::CranedState::CRANE_DRAIN);
-    }
-    else if (craned_meta->res_in_use.allocatable_resource.cpu_count == cpu_t(0) &&
-        craned_meta->res_in_use.allocatable_resource.memory_bytes == 0)
+    } else if (craned_meta->res_in_use.allocatable_resource.cpu_count ==
+                   cpu_t(0) &&
+               craned_meta->res_in_use.allocatable_resource.memory_bytes == 0)
       craned_info->set_state(crane::grpc::CranedState::CRANE_IDLE);
     else if (craned_meta->res_avail.allocatable_resource.cpu_count ==
                  cpu_t(0) ||
@@ -551,25 +551,38 @@ CranedMetaContainerSimpleImpl::QueryClusterInfo(
       auto& res_in_use = craned_meta->res_in_use.allocatable_resource;
       auto& res_avail = craned_meta->res_avail.allocatable_resource;
       if (craned_meta->alive) {
-        if (filter_idle && res_in_use.cpu_count == cpu_t(0) &&
-            res_in_use.memory_bytes == 0) {
-          idle_craned_name_list.emplace_back(craned_meta->static_meta.hostname);
-          idle_craned_list->set_count(idle_craned_name_list.size());
-        } else if (filter_alloc && res_avail.cpu_count == cpu_t(0) ||
+        if (craned_meta->drain) {
+          if (filter_drain) {
+            drain_craned_name_list.emplace_back(
+                craned_meta->static_meta.hostname);
+            drain_craned_list->set_count(drain_craned_name_list.size());
+          }
+        } else if (res_in_use.cpu_count == cpu_t(0) &&
+                   res_in_use.memory_bytes == 0) {
+          if (filter_idle) {
+            idle_craned_name_list.emplace_back(
+                craned_meta->static_meta.hostname);
+            idle_craned_list->set_count(idle_craned_name_list.size());
+          }
+        } else if (res_avail.cpu_count == cpu_t(0) ||
                    res_avail.memory_bytes == 0) {
-          alloc_craned_name_list.emplace_back(
-              craned_meta->static_meta.hostname);
-          alloc_craned_list->set_count(alloc_craned_name_list.size());
-        } else if (filter_mix) {
-          mix_craned_name_list.emplace_back(craned_meta->static_meta.hostname);
-          mix_craned_list->set_count(mix_craned_name_list.size());
+          if (filter_alloc) {
+            alloc_craned_name_list.emplace_back(
+                craned_meta->static_meta.hostname);
+            alloc_craned_list->set_count(alloc_craned_name_list.size());
+          }
+        } else {
+          if (filter_mix) {
+            mix_craned_name_list.emplace_back(
+                craned_meta->static_meta.hostname);
+            mix_craned_list->set_count(mix_craned_name_list.size());
+          }
         }
-      } else if (filter_drain && craned_meta->alive && craned_meta->drain) {
-        drain_craned_name_list.emplace_back(craned_meta->static_meta.hostname);
-        drain_craned_list->set_count(drain_craned_name_list.size());
-      } else if (filter_down) {
-        down_craned_name_list.emplace_back(craned_meta->static_meta.hostname);
-        down_craned_list->set_count(down_craned_name_list.size());
+      } else {
+        if (filter_down) {
+          down_craned_name_list.emplace_back(craned_meta->static_meta.hostname);
+          down_craned_list->set_count(down_craned_name_list.size());
+        }
       }
     });
 

--- a/src/CraneCtld/CranedMetaContainer.h
+++ b/src/CraneCtld/CranedMetaContainer.h
@@ -91,8 +91,8 @@ class CranedMetaContainerInterface {
   virtual crane::grpc::QueryClusterInfoReply QueryClusterInfo(
       const crane::grpc::QueryClusterInfoRequest& request) = 0;
 
-  virtual crane::grpc::ModifyNodeReply ChangeNodeState(
-      const crane::grpc::ModifyNodeRequest& request) = 0;
+  virtual crane::grpc::ModifyCranedStateReply ChangeNodeState(
+      const crane::grpc::ModifyCranedStateRequest& request) = 0;
 
   virtual void MallocResourceFromNode(CranedId node_id, uint32_t task_id,
                                       const Resources& resources) = 0;
@@ -135,8 +135,8 @@ class CranedMetaContainerSimpleImpl final
   crane::grpc::QueryClusterInfoReply QueryClusterInfo(
       const crane::grpc::QueryClusterInfoRequest& request) override;
 
-  crane::grpc::ModifyNodeReply ChangeNodeState(
-      const crane::grpc::ModifyNodeRequest& request) override;
+  crane::grpc::ModifyCranedStateReply ChangeNodeState(
+      const crane::grpc::ModifyCranedStateRequest& request) override;
 
   void CranedUp(const CranedId& craned_id) override;
 

--- a/src/CraneCtld/CranedMetaContainer.h
+++ b/src/CraneCtld/CranedMetaContainer.h
@@ -91,6 +91,9 @@ class CranedMetaContainerInterface {
   virtual crane::grpc::QueryClusterInfoReply QueryClusterInfo(
       const crane::grpc::QueryClusterInfoRequest& request) = 0;
 
+  virtual crane::grpc::ModifyNodeReply ChangeNodeState(
+      const crane::grpc::ModifyNodeRequest& request) = 0;
+
   virtual void MallocResourceFromNode(CranedId node_id, uint32_t task_id,
                                       const Resources& resources) = 0;
   virtual void FreeResourceFromNode(CranedId node_id, uint32_t task_id) = 0;
@@ -131,6 +134,9 @@ class CranedMetaContainerSimpleImpl final
 
   crane::grpc::QueryClusterInfoReply QueryClusterInfo(
       const crane::grpc::QueryClusterInfoRequest& request) override;
+
+  crane::grpc::ModifyNodeReply ChangeNodeState(
+      const crane::grpc::ModifyNodeRequest& request) override;
 
   void CranedUp(const CranedId& craned_id) override;
 

--- a/src/CraneCtld/CtldGrpcServer.cpp
+++ b/src/CraneCtld/CtldGrpcServer.cpp
@@ -180,6 +180,14 @@ grpc::Status CraneCtldServiceImpl::ModifyTask(
   return grpc::Status::OK;
 }
 
+grpc::Status CraneCtldServiceImpl::ModifyNode(
+    grpc::ServerContext *context, const crane::grpc::ModifyNodeRequest *request,
+    crane::grpc::ModifyNodeReply *response) {
+  *response = g_meta_container->ChangeNodeState(*request);
+
+  return grpc::Status::OK;
+}
+
 grpc::Status CraneCtldServiceImpl::QueryTasksInfo(
     grpc::ServerContext *context,
     const crane::grpc::QueryTasksInfoRequest *request,

--- a/src/CraneCtld/CtldGrpcServer.cpp
+++ b/src/CraneCtld/CtldGrpcServer.cpp
@@ -181,8 +181,9 @@ grpc::Status CraneCtldServiceImpl::ModifyTask(
 }
 
 grpc::Status CraneCtldServiceImpl::ModifyNode(
-    grpc::ServerContext *context, const crane::grpc::ModifyNodeRequest *request,
-    crane::grpc::ModifyNodeReply *response) {
+    grpc::ServerContext *context,
+    const crane::grpc::ModifyCranedStateRequest *request,
+    crane::grpc::ModifyCranedStateReply *response) {
   *response = g_meta_container->ChangeNodeState(*request);
 
   return grpc::Status::OK;

--- a/src/CraneCtld/CtldGrpcServer.h
+++ b/src/CraneCtld/CtldGrpcServer.h
@@ -214,9 +214,10 @@ class CraneCtldServiceImpl final : public crane::grpc::CraneCtld::Service {
                           const crane::grpc::ModifyTaskRequest *request,
                           crane::grpc::ModifyTaskReply *response) override;
 
-  grpc::Status ModifyNode(grpc::ServerContext *context,
-                          const crane::grpc::ModifyNodeRequest *request,
-                          crane::grpc::ModifyNodeReply *response) override;
+  grpc::Status ModifyNode(
+      grpc::ServerContext *context,
+      const crane::grpc::ModifyCranedStateRequest *request,
+      crane::grpc::ModifyCranedStateReply *response) override;
 
   grpc::Status AddAccount(grpc::ServerContext *context,
                           const crane::grpc::AddAccountRequest *request,

--- a/src/CraneCtld/CtldGrpcServer.h
+++ b/src/CraneCtld/CtldGrpcServer.h
@@ -214,6 +214,10 @@ class CraneCtldServiceImpl final : public crane::grpc::CraneCtld::Service {
                           const crane::grpc::ModifyTaskRequest *request,
                           crane::grpc::ModifyTaskReply *response) override;
 
+  grpc::Status ModifyNode(grpc::ServerContext *context,
+                          const crane::grpc::ModifyNodeRequest *request,
+                          crane::grpc::ModifyNodeReply *response) override;
+
   grpc::Status AddAccount(grpc::ServerContext *context,
                           const crane::grpc::AddAccountRequest *request,
                           crane::grpc::AddAccountReply *response) override;

--- a/src/CraneCtld/CtldPublicDefs.h
+++ b/src/CraneCtld/CtldPublicDefs.h
@@ -167,6 +167,8 @@ struct CranedMeta {
   // just for convenience.
   Resources res_avail;
   Resources res_in_use;
+  bool drain{false};
+  std::string drain_reason;
 
   // Store the information of the slices of allocated resource.
   // One task id owns one shard of allocated resource.

--- a/src/CraneCtld/CtldPublicDefs.h
+++ b/src/CraneCtld/CtldPublicDefs.h
@@ -168,7 +168,7 @@ struct CranedMeta {
   Resources res_avail;
   Resources res_in_use;
   bool drain{false};
-  std::string drain_reason;
+  std::string state_reason;
 
   // Store the information of the slices of allocated resource.
   // One task id owns one shard of allocated resource.

--- a/src/CraneCtld/TaskScheduler.cpp
+++ b/src/CraneCtld/TaskScheduler.cpp
@@ -1571,7 +1571,7 @@ void MinLoadFirst::CalculateNodeSelectionInfoOfPartition_(
     auto craned_meta = craned_meta_ptr.GetExclusivePtr();
 
     // An offline craned shouldn't be scheduled.
-    if (!craned_meta->alive) continue;
+    if (!craned_meta->alive || craned_meta->drain) continue;
 
     // Sort all running task in this node by ending time.
     std::vector<std::pair<absl::Time, uint32_t>> end_time_task_id_vec;


### PR DESCRIPTION
更改节点状态为drain，该节点不会有新的作业被调度，当前运行的作业不受影响；
-n指定节点名
--state指定状态为drain/resume，指定为drain时需用--reason说明原因。
--state=resume恢复节点drain之前的状态
cinfo查询节点状态时增加状态drain，state过滤也增加drain