### PR TITLE
Fix ambiguous format_to() in gcc 13

### DIFF
--- a/src/Utilities/PublicHeader/include/crane/Logger.h
+++ b/src/Utilities/PublicHeader/include/crane/Logger.h
@@ -159,7 +159,7 @@ struct formatter<cpu_t> {
 
   template <typename FormatContext>
   auto format(const cpu_t &v, FormatContext &ctx) {
-    return format_to(ctx.out(), "{:.2f}", static_cast<double>(v));
+    return fmt::format_to(ctx.out(), "{:.2f}", static_cast<double>(v));
   }
 };
 


### PR DESCRIPTION
Fix ambiguous format_to() in gcc 13