### PR TITLE
Remove unnecessary RPC.

### DIFF
--- a/protos/Crane.proto
+++ b/protos/Crane.proto
@@ -401,7 +401,6 @@ message QueryClusterInfoRequest {
 message QueryClusterInfoReply {
   bool ok = 1;
   repeated TrimmedPartitionInfo partitions = 2;
-  repeated string nodes = 3;
 }
 
 message QueryTasksInfoRequest{

--- a/src/CraneCtld/CranedMetaContainer.cpp
+++ b/src/CraneCtld/CranedMetaContainer.cpp
@@ -449,8 +449,11 @@ CranedMetaContainerSimpleImpl::QueryClusterInfo(
                part_meta->partition_global_meta.name);
   };
 
-  std::unordered_set<std::string> req_nodes(request.filter_nodes().begin(),
-                                            request.filter_nodes().end());
+  std::string hosts = absl::StrJoin(request.filter_nodes(), ",");
+  std::list<std::string> hosts_list;
+  util::ParseHostList(hosts, &hosts_list);
+  std::unordered_set<std::string> req_nodes;
+  for (auto& host : hosts_list) req_nodes.insert(std::move(host));
 
   bool no_craned_hostname_constraint = request.filter_nodes().empty();
   auto craned_rng_filter_hostname = [&](CranedMetaRawMap::const_iterator it) {

--- a/src/CraneCtld/CranedMetaContainer.cpp
+++ b/src/CraneCtld/CranedMetaContainer.cpp
@@ -596,17 +596,6 @@ CranedMetaContainerSimpleImpl::QueryClusterInfo(
         util::HostNameListToStr(down_craned_name_list));
     drain_craned_list->set_craned_list_regex(
         util::HostNameListToStr(drain_craned_name_list));
-
-    reply.mutable_nodes()->Add(idle_craned_name_list.begin(),
-                               idle_craned_name_list.end());
-    reply.mutable_nodes()->Add(mix_craned_name_list.begin(),
-                               mix_craned_name_list.end());
-    reply.mutable_nodes()->Add(alloc_craned_name_list.begin(),
-                               alloc_craned_name_list.end());
-    reply.mutable_nodes()->Add(down_craned_name_list.begin(),
-                               down_craned_name_list.end());
-    reply.mutable_nodes()->Add(drain_craned_name_list.begin(),
-                               drain_craned_name_list.end());
   });
 
   return reply;


### PR DESCRIPTION
之前处理 cinfo -n= 不存在节点报错时不是从原本返回的 grpc 查询，而是额外返回所有存在的节点名并筛选，通信开销巨大，故修改，同时输出按询问顺序排序。