### PR TITLE
Fix InvalidNodeNum error when resources not enough

### DIFF
--- a/src/CraneCtld/CtldGrpcServer.cpp
+++ b/src/CraneCtld/CtldGrpcServer.cpp
@@ -1304,16 +1304,22 @@ CtldServer::SubmitTaskToScheduler(std::unique_ptr<TaskInCtld> task) {
     return result::fail("Partition doesn't exist!");
   } else if (err == CraneErr::kInvalidNodeNum) {
     CRANE_DEBUG(
-        "Task submission failed. Reason: --node is either invalid or "
-        "greater than the number of alive nodes in its partition.");
+        "Task submission failed. Reason: --node is either invalid or greater "
+        "than the number of nodes in its partition.");
     return result::fail(
-        "--node is either invalid or greater than "
-        "the number of alive nodes in its partition.");
+        "--node is either invalid or greater than the number of nodes in its "
+        "partition.");
   } else if (err == CraneErr::kNoResource) {
     CRANE_DEBUG(
         "Task submission failed. "
         "Reason: The resources of the partition are insufficient.");
     return result::fail("The resources of the partition are insufficient");
+  } else if (err == CraneErr::kNoAvailNode) {
+    CRANE_DEBUG(
+        "Task submission failed. "
+        "Reason: Nodes satisfying the requirements of task are insufficient");
+    return result::fail(
+        "Nodes satisfying the requirements of task are insufficient.");
   } else if (err == CraneErr::kInvalidParam) {
     CRANE_DEBUG(
         "Task submission failed. "

--- a/src/CraneCtld/TaskScheduler.cpp
+++ b/src/CraneCtld/TaskScheduler.cpp
@@ -2346,6 +2346,14 @@ CraneErr TaskScheduler::CheckTaskValidity(TaskInCtld* task) {
       return CraneErr::kNoResource;
     }
 
+    if (task->node_num > metas_ptr->craned_ids.size()) {
+      CRANE_TRACE(
+          "Nodes not enough for task #{}. "
+          "Partition total Nodes: {}",
+          task->TaskId(), metas_ptr->craned_ids.size());
+      return CraneErr::kInvalidNodeNum;
+    }
+
     auto craned_meta_map = g_meta_container->GetCranedMetaMapConstPtr();
     for (const auto& craned_id : metas_ptr->craned_ids) {
       auto craned_meta = craned_meta_map->at(craned_id).GetExclusivePtr();
@@ -2365,7 +2373,7 @@ CraneErr TaskScheduler::CheckTaskValidity(TaskInCtld* task) {
         "Resource not enough. Task #{} needs {} nodes, while only {} "
         "nodes satisfy its requirement.",
         task->TaskId(), task->node_num, avail_nodes.size());
-    return CraneErr::kInvalidNodeNum;
+    return CraneErr::kNoAvailNode;
   }
 
   return CraneErr::kOk;

--- a/src/Utilities/PublicHeader/include/crane/PublicHeader.h
+++ b/src/Utilities/PublicHeader/include/crane/PublicHeader.h
@@ -30,6 +30,7 @@ enum class CraneErr : uint16_t {
   kNoResource,
   kNonExistent,
   kInvalidNodeNum,
+  kNoAvailNode,
 
   kSystemErr,  // represent the error which sets errno
   kExistingTask,


### PR DESCRIPTION
见飞书测试文档 32，后端判断方式是比较满足资源要求的节点数和申请节点数大小，当申请资源不超过分区总资源，但符合条件的节点数不够时触发此错误。新增判断节点总数不足和满足要求节点数不足两种报错。