### PR TITLE
Dev/cacct db query

### DIFF
--- a/src/CraneCtld/CtldGrpcServer.cpp
+++ b/src/CraneCtld/CtldGrpcServer.cpp
@@ -23,7 +23,6 @@
 #include "CranedMetaContainer.h"
 #include "EmbeddedDbClient.h"
 #include "TaskScheduler.h"
-#include "crane/Logger.h"
 #include "crane/String.h"
 
 namespace Ctld {

--- a/src/CraneCtld/CtldGrpcServer.cpp
+++ b/src/CraneCtld/CtldGrpcServer.cpp
@@ -23,6 +23,7 @@
 #include "CranedMetaContainer.h"
 #include "EmbeddedDbClient.h"
 #include "TaskScheduler.h"
+#include "crane/Logger.h"
 #include "crane/String.h"
 
 namespace Ctld {
@@ -236,7 +237,9 @@ grpc::Status CraneCtldServiceImpl::QueryTasksInfo(
   };
 
   if (task_list->size() >= num_limit ||
-      !request->option_include_completed_tasks()) {
+      !request->option_include_completed_tasks() ||
+      (!request->filter_task_ids().empty() &&
+       task_list->size() == request->filter_task_ids_size())) {
     sort_and_truncate(task_list, num_limit);
     response->set_ok(true);
     return grpc::Status::OK;
@@ -244,140 +247,10 @@ grpc::Status CraneCtldServiceImpl::QueryTasksInfo(
 
   // Query completed tasks in Mongodb
   // (only for cacct, which sets `option_include_completed_tasks` to true)
-  std::vector<std::unique_ptr<TaskInDb>> db_ended_list;
-  if (!g_db_client->FetchJobRecords(&db_ended_list,
-                                    num_limit - task_list->size(), true)) {
+  if (!g_db_client->FetchJobRecords(request, response, num_limit - task_list->size())) {
     CRANE_ERROR("Failed to call g_db_client->FetchJobRecords");
     return grpc::Status::OK;
   }
-
-  auto db_ended_append_fn = [&](std::unique_ptr<TaskInDb> const &task) {
-    auto *task_it = task_list->Add();
-
-    task_it->set_type(task->type);
-    task_it->set_task_id(task->task_id);
-    task_it->set_name(task->name);
-    task_it->set_partition(task->partition_id);
-    task_it->set_uid(task->uid);
-
-    task_it->set_gid(task->gid);
-    task_it->mutable_time_limit()->set_seconds(
-        ToInt64Seconds(task->time_limit));
-    task_it->mutable_submit_time()->CopyFrom(task->submit_time);
-    task_it->mutable_start_time()->CopyFrom(task->start_time);
-    task_it->mutable_end_time()->CopyFrom(task->end_time);
-    task_it->set_account(task->account);
-
-    task_it->set_node_num(task->node_num);
-    task_it->set_cmd_line(task->cmd_line);
-    task_it->set_cwd(task->cwd);
-    task_it->set_username(task->username);
-    task_it->set_qos(task->qos);
-
-    task_it->set_alloc_cpu(
-        static_cast<double>(task->resources.allocatable_resource.cpu_count) *
-        task->node_num);
-    task_it->set_exit_code(task->exit_code);
-
-    task_it->set_status(task->status);
-    task_it->set_craned_list(task->allocated_craneds_regex);
-  };
-
-  auto db_task_rng_filter_time = [&](std::unique_ptr<TaskInDb> const &task) {
-    bool has_submit_time_interval = request->has_filter_submit_time_interval();
-    bool has_start_time_interval = request->has_filter_start_time_interval();
-    bool has_end_time_interval = request->has_filter_end_time_interval();
-
-    bool valid = true;
-    if (has_submit_time_interval) {
-      const auto &interval = request->filter_submit_time_interval();
-      valid &= !interval.has_lower_bound() ||
-               task->submit_time >= interval.lower_bound();
-      valid &= !interval.has_upper_bound() ||
-               task->submit_time <= interval.upper_bound();
-    }
-
-    if (has_start_time_interval) {
-      const auto &interval = request->filter_start_time_interval();
-      valid &= !interval.has_lower_bound() ||
-               task->start_time >= interval.lower_bound();
-      valid &= !interval.has_upper_bound() ||
-               task->start_time <= interval.upper_bound();
-    }
-
-    if (has_end_time_interval) {
-      const auto &interval = request->filter_end_time_interval();
-      valid &= !interval.has_lower_bound() ||
-               task->end_time >= interval.lower_bound();
-      valid &= !interval.has_upper_bound() ||
-               task->end_time <= interval.upper_bound();
-    }
-
-    return valid;
-  };
-
-  bool no_accounts_constraint = request->filter_accounts().empty();
-  std::unordered_set<std::string> req_accounts(
-      request->filter_accounts().begin(), request->filter_accounts().end());
-  auto db_task_rng_filter_account = [&](std::unique_ptr<TaskInDb> const &task) {
-    return no_accounts_constraint || req_accounts.contains(task->account);
-  };
-
-  bool no_username_constraint = request->filter_users().empty();
-  std::unordered_set<std::string> req_users(request->filter_users().begin(),
-                                            request->filter_users().end());
-  auto db_task_rng_filter_user = [&](std::unique_ptr<TaskInDb> const &task) {
-    return no_username_constraint || req_users.contains(task->username);
-  };
-
-  bool no_task_names_constraint = request->filter_task_names().empty();
-  std::unordered_set<std::string> req_task_names(
-      request->filter_task_names().begin(), request->filter_task_names().end());
-  auto db_task_rng_filter_name = [&](std::unique_ptr<TaskInDb> const &task) {
-    return no_task_names_constraint || req_task_names.contains(task->name);
-  };
-
-  bool no_qos_constraint = request->filter_qos().empty();
-  std::unordered_set<std::string> req_qos(request->filter_qos().begin(),
-                                          request->filter_qos().end());
-  auto db_task_rng_filter_qos = [&](std::unique_ptr<TaskInDb> const &task) {
-    return no_qos_constraint || req_qos.contains(task->qos);
-  };
-
-  bool no_partitions_constraint = request->filter_partitions().empty();
-  std::unordered_set<std::string> req_partitions(
-      request->filter_partitions().begin(), request->filter_partitions().end());
-  auto db_task_rng_filter_partition =
-      [&](std::unique_ptr<TaskInDb> const &task) {
-        return no_partitions_constraint ||
-               req_partitions.contains(task->partition_id);
-      };
-
-  bool no_task_ids_constraint = request->filter_task_ids().empty();
-  std::unordered_set<uint32_t> req_task_ids(request->filter_task_ids().begin(),
-                                            request->filter_task_ids().end());
-  auto db_task_rng_filter_id = [&](std::unique_ptr<TaskInDb> const &task) {
-    return no_task_ids_constraint || req_task_ids.contains(task->task_id);
-  };
-
-  bool no_task_states_constraint = request->filter_task_states().empty();
-  std::unordered_set<int> req_task_states(request->filter_task_states().begin(),
-                                          request->filter_task_states().end());
-  auto db_task_rng_filter_state = [&](std::unique_ptr<TaskInDb> const &task) {
-    return no_task_states_constraint || req_task_states.contains(task->status);
-  };
-
-  auto db_ended_rng = db_ended_list |
-                      ranges::views::filter(db_task_rng_filter_account) |
-                      ranges::views::filter(db_task_rng_filter_name) |
-                      ranges::views::filter(db_task_rng_filter_partition) |
-                      ranges::views::filter(db_task_rng_filter_id) |
-                      ranges::views::filter(db_task_rng_filter_state) |
-                      ranges::views::filter(db_task_rng_filter_user) |
-                      ranges::views::filter(db_task_rng_filter_time) |
-                      ranges::views::filter(db_task_rng_filter_qos) |
-                      ranges::views::take(num_limit - task_list->size());
-  ranges::for_each(db_ended_rng, db_ended_append_fn);
 
   sort_and_truncate(task_list, num_limit);
   response->set_ok(true);

--- a/src/CraneCtld/CtldPublicDefs.h
+++ b/src/CraneCtld/CtldPublicDefs.h
@@ -466,37 +466,6 @@ struct TaskInCtld {
   }
 };
 
-struct TaskInDb {
-  crane::grpc::TaskType type;
-  task_id_t task_id;
-  std::string name;
-  PartitionId partition_id;
-  uid_t uid;
-
-  gid_t gid;
-  absl::Duration time_limit;
-  google::protobuf::Timestamp submit_time;
-  google::protobuf::Timestamp start_time;
-  google::protobuf::Timestamp end_time;
-  std::string account;
-
-  uint32_t node_num{0};
-  std::string cmd_line;
-  std::string cwd;
-  std::string username;
-  std::string qos;
-
-  Resources resources;
-  uint32_t exit_code;
-  crane::grpc::TaskStatus status;
-  std::string allocated_craneds_regex;
-
-  void SetSubmitTimeByUnixSecond(uint64_t val) { submit_time.set_seconds(val); }
-  void SetStartTimeByUnixSecond(uint64_t val) { start_time.set_seconds(val); }
-
-  void SetEndTimeByUnixSecond(uint64_t val) { end_time.set_seconds(val); }
-};
-
 struct Qos {
   bool deleted = false;
   std::string name;

--- a/src/CraneCtld/DbClient.h
+++ b/src/CraneCtld/DbClient.h
@@ -56,7 +56,8 @@ class MongodbClient {
   bool InsertJobs(const std::vector<TaskInCtld*>& tasks);
 
   bool FetchJobRecords(const crane::grpc::QueryTasksInfoRequest* request,
-                       crane::grpc::QueryTasksInfoReply* response, int limit);
+                       crane::grpc::QueryTasksInfoReply* response,
+                       size_t limit);
 
   bool CheckTaskDbIdExisted(int64_t task_db_id);
 

--- a/src/CraneCtld/DbClient.h
+++ b/src/CraneCtld/DbClient.h
@@ -55,8 +55,8 @@ class MongodbClient {
   bool InsertJob(TaskInCtld* task);
   bool InsertJobs(const std::vector<TaskInCtld*>& tasks);
 
-  bool FetchJobRecords(std::vector<std::unique_ptr<TaskInDb>>* task_list,
-                       size_t limit, bool reverse);
+  bool FetchJobRecords(const crane::grpc::QueryTasksInfoRequest* request,
+                       crane::grpc::QueryTasksInfoReply* response, int limit);
 
   bool CheckTaskDbIdExisted(int64_t task_db_id);
 

--- a/src/Craned/TaskManager.cpp
+++ b/src/Craned/TaskManager.cpp
@@ -1022,10 +1022,9 @@ void TaskManager::EvTaskStatusChangeCb_(int efd, short events,
 
     // Clean task scripts.
     if (iter->second->task.type() == crane::grpc::Batch) {
-      g_thread_pool->detach_task(
-          [p = iter->second->batch_meta.parsed_sh_script_path]() {
-            util::os::DeleteFile(p);
-          });
+      const std::string& path = iter->second->batch_meta.parsed_sh_script_path;
+      if (!path.empty())
+        g_thread_pool->detach_task([p = path]() { util::os::DeleteFile(p); });
     }
 
     // Free the TaskInstance structure


### PR DESCRIPTION
问题见测试表问题 88，当任务较多时，即使使用 -j 也查不到靠前的任务。
在先前实现中，查询数据库时，先取出数目限制内的任务，再使用 filter 筛选，导致实际需要的任务没有查到。
实际上应当在数据库中查询满足 filter 的任务，同时添加数目限制。
此外，直接将任务信息写入 TaskInfo，不再需要 TaskInDb。