### PR TITLE
feat: diff drain state.

### DIFF
--- a/protos/PublicDefs.proto
+++ b/protos/PublicDefs.proto
@@ -52,7 +52,9 @@ enum CranedState {
   CRANE_MIX = 1;
   CRANE_ALLOC = 2;
   CRANE_DOWN = 3;
-  CRANE_DRAIN = 4;
+  CRANE_DRAIN_IDLE = 4;
+  CRANE_DRAIN_MIX = 5;
+  CRANE_DRAIN_ALLOC = 6;
 }
 
 enum TaskStatus {


### PR DESCRIPTION
区分了 drain 状态下的 idle/mix/alloc 节点（不区分 down 节点），查询时支持使用 drain 筛选所有 drain 节点或使用 drain_idle 筛选所有 drain 且无任务节点。