### PR TITLE
feat: add CranedControlState (NONE, DRAIN)

### DIFF
--- a/protos/Crane.proto
+++ b/protos/Crane.proto
@@ -214,7 +214,7 @@ message ModifyTaskReply {
 
 message ModifyCranedStateRequest{
   string craned_id = 1;
-  CranedState new_state = 2;
+  CranedControlState new_state = 2;
   string reason = 3;
 }
 
@@ -329,7 +329,8 @@ message MigrateSshProcToCgroupReply {
 message QueryClusterInfoRequest {
   repeated string filter_partitions = 1;
   repeated string filter_nodes = 2;
-  repeated CranedState filter_craned_states = 3;
+  repeated CranedResourceState filter_craned_resource_states = 3;
+  repeated CranedControlState filter_craned_control_states = 4;
 }
 
 message QueryClusterInfoReply {

--- a/protos/PublicDefs.proto
+++ b/protos/PublicDefs.proto
@@ -47,12 +47,16 @@ enum PartitionState {
   PARTITION_DOWN = 1;
 }
 
-enum CranedState {
+enum CranedResourceState {
   CRANE_IDLE = 0;
   CRANE_MIX = 1;
   CRANE_ALLOC = 2;
   CRANE_DOWN = 3;
-  CRANE_DRAIN = 4;
+}
+
+enum CranedControlState {
+  CRANE_NONE = 0;
+  CRANE_DRAIN = 1;
 }
 
 enum TaskStatus {
@@ -243,22 +247,24 @@ message PartitionInfo {
 
 message CranedInfo {
   string hostname = 1;
-  CranedState state = 2;
-  double cpu = 3;
-  double alloc_cpu = 4;
-  double free_cpu = 5;
-  uint64 real_mem = 6;
-  uint64 alloc_mem = 7;
-  uint64 free_mem = 8;
-  repeated string partition_names = 9;
-  uint32 running_task_num = 10;
+  CranedResourceState resource_state = 2;
+  CranedControlState control_state = 3;
+  double cpu = 4;
+  double alloc_cpu = 5;
+  double free_cpu = 6;
+  uint64 real_mem = 7;
+  uint64 alloc_mem = 8;
+  uint64 free_mem = 9;
+  repeated string partition_names = 10;
+  uint32 running_task_num = 11;
 }
 
 message TrimmedPartitionInfo {
   message TrimmedCranedInfo {
-    CranedState state = 1;
-    uint32 count = 2;
-    string craned_list_regex = 3;
+    CranedResourceState resource_state = 1;
+    CranedControlState control_state = 2;
+    uint32 count = 3;
+    string craned_list_regex = 4;
   }
 
   string name = 1;


### PR DESCRIPTION
将 drain 这一状态与资源状态 (idle, mix, alloc, down）分离，独立为控制状态（none, drain）。
查询时支持按照两类状态分别筛选，单种状态内取并集，两种状态间取交集。
修改节点时只使用控制状态。

本 pr 应取代 #288