### PR TITLE
bugfix: fix change timelimit have no effect for running task.

### DIFF
--- a/src/CraneCtld/TaskScheduler.cpp
+++ b/src/CraneCtld/TaskScheduler.cpp
@@ -943,7 +943,6 @@ std::future<task_id_t> TaskScheduler::SubmitTaskAsync(
 CraneErr TaskScheduler::ChangeTaskTimeLimit(task_id_t task_id, int64_t secs) {
   if (secs <= kTaskMinDuration) return CraneErr::kInvalidParam;
 
-  bool found_running{false};
   std::vector<CranedId> craned_ids;
 
   {
@@ -976,8 +975,6 @@ CraneErr TaskScheduler::ChangeTaskTimeLimit(task_id_t task_id, int64_t secs) {
     g_embedded_db_client->UpdateTaskToCtld(0, task->TaskDbId(),
                                            task->TaskToCtld());
   }
-
-  if (!found_running) return CraneErr::kOk;
 
   // Only send request to the executing node
   for (const CranedId& craned_id : craned_ids) {

--- a/src/Craned/TaskManager.cpp
+++ b/src/Craned/TaskManager.cpp
@@ -1287,7 +1287,10 @@ void TaskManager::EvChangeTaskTimeLimitCb_(int, short events, void* user_data) {
 
       if (absl::Now() - start_time >= new_time_limit) {
         // If the task times out, terminate it.
-        EvQueueTaskTerminate ev_task_terminate{elem.task_id};
+        EvQueueTaskTerminate ev_task_terminate{
+            .task_id = elem.task_id,
+            .terminated_by_timeout = true,
+        };
         this_->m_task_terminate_queue_.enqueue(ev_task_terminate);
         event_active(this_->m_ev_task_terminate_, 0, 0);
 


### PR DESCRIPTION
修复 running 任务修改 timelimit 无效的 bug
修正将修改 timelimit 后直接超时的任务标记为 Failed 而不是 ExceedTimeLimit 的问题