### PR TITLE
feat: Add CRANE_USE_SYSTEM_LIBCGROUP

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -59,6 +59,8 @@ option(CRANE_NATIVE_ARCH_OPT "Enable -march=native compile option" ON)
 
 option(CRANE_USE_GITEE_SOURCE "Enable the Gitee repository as the download source" OFF)
 
+option(CRANE_USE_SYSTEM_LIBCGROUP "Use libcgroup from system instead of building from source" OFF)
+
 option(CRANE_FULL_DYNAMIC "Enable dynamic libs" OFF)
 
 option(CRANE_ADDRESS_SANITIZER "Enable address sanitizer" OFF)

--- a/dependencies/cmake/libcgroup/CMakeLists.txt
+++ b/dependencies/cmake/libcgroup/CMakeLists.txt
@@ -1,3 +1,27 @@
+if (${CRANE_USE_SYSTEM_LIBCGROUP})
+    message(STATUS "Using libcgroup from system.")
+
+    find_package(PkgConfig REQUIRED)
+    pkg_check_modules(libcgroup REQUIRED IMPORTED_TARGET libcgroup>=0.41)
+
+    if (libcgroup_FOUND)
+        message(STATUS "Found libcgroup ${libcgroup_VERSION} in system using pkg-config.")
+    else()
+        message(FATAL_ERROR "libcgroup in system is not found using pkg-config.")
+    endif()
+
+    add_library(libcgroup INTERFACE)
+    target_link_libraries(libcgroup INTERFACE PkgConfig::libcgroup)
+    target_include_directories(libcgroup INTERFACE ${libcgroup_INCLUDE_DIRS})
+
+    # libcgroup in system is a shared library
+    set(LIBCGROUP_BUILD_PRODUCTS ${libcgroup_LIBRARY_DIRS}/libcgroup.so CACHE STRING "Path to libcgroup library" FORCE)
+    message(STATUS "Using libcgroup from system at ${LIBCGROUP_BUILD_PRODUCTS}.")
+    return()
+endif ()
+
+message(STATUS "Building libcgroup from source.")
+
 include(FetchContent)
 include(ExternalProject)
 


### PR DESCRIPTION
Use `-DCMAKE_USE_SYSTEM_LIBCGROUP` to build with shared library from package manager (Required by CentOS 7).  