### PR TITLE
fix: Skip Link-Local IPv6 Address

### DIFF
--- a/src/CraneCtld/CraneCtld.cpp
+++ b/src/CraneCtld/CraneCtld.cpp
@@ -696,7 +696,7 @@ void InitializeCtldGlobalVariables() {
   g_craned_keeper = std::make_unique<CranedKeeper>(g_config.Nodes.size());
 
   g_craned_keeper->SetCranedIsUpCb([](const CranedId& craned_id) {
-    CRANE_TRACE(
+    CRANE_DEBUG(
         "A new node #{} is up now. Add its resource to the global resource "
         "pool.",
         craned_id);
@@ -706,7 +706,7 @@ void InitializeCtldGlobalVariables() {
   });
 
   g_craned_keeper->SetCranedIsDownCb([](const CranedId& craned_id) {
-    CRANE_TRACE(
+    CRANE_DEBUG(
         "CranedNode #{} is down now. "
         "Remove its resource from the global resource pool.",
         craned_id);

--- a/src/Utilities/PublicHeader/Network.cpp
+++ b/src/Utilities/PublicHeader/Network.cpp
@@ -18,9 +18,6 @@
 
 #include "crane/Network.h"
 
-#include <net/if.h>
-#include <sys/ioctl.h>
-
 #include "crane/Logger.h"
 
 namespace crane {

--- a/src/Utilities/PublicHeader/OS.cpp
+++ b/src/Utilities/PublicHeader/OS.cpp
@@ -104,7 +104,7 @@ void SetCloseOnExecFromFd(int fd_begin) {
 }
 
 bool SetMaxFileDescriptorNumber(unsigned long num) {
-  struct rlimit rlim {};
+  struct rlimit rlim{};
   rlim.rlim_cur = num;
   rlim.rlim_max = num;
 

--- a/src/Utilities/PublicHeader/include/crane/Network.h
+++ b/src/Utilities/PublicHeader/include/crane/Network.h
@@ -63,4 +63,6 @@ int GetIpAddrVer(const std::string& ip);
 
 bool FindTcpInodeByPort(const std::string& tcp_path, int port, ino_t* inode);
 
+bool CheckIpv6Support();
+
 }  // namespace crane

--- a/src/Utilities/PublicHeader/include/crane/Network.h
+++ b/src/Utilities/PublicHeader/include/crane/Network.h
@@ -63,6 +63,4 @@ int GetIpAddrVer(const std::string& ip);
 
 bool FindTcpInodeByPort(const std::string& tcp_path, int port, ino_t* inode);
 
-bool CheckIpv6Support();
-
 }  // namespace crane


### PR DESCRIPTION
`fe80::` is link local address which requires scope id to work. We don't need to handle these ip, just skip them. 