### PR TITLE
Dev/partition allow accounts

### DIFF
--- a/etc/config.yaml
+++ b/etc/config.yaml
@@ -98,6 +98,8 @@ Partitions:
     DefaultMemPerCpu: 0
     # Optional maximum memory per cpu in MB, 0 indicates no limit
     MaxMemPerCpu: 0
+    AllowedAccounts: ac1, ac2
+    DeniedAccounts: ac1, ac2
 
 DefaultPartition: CPU
 

--- a/etc/config.yaml
+++ b/etc/config.yaml
@@ -98,8 +98,10 @@ Partitions:
     DefaultMemPerCpu: 0
     # Optional maximum memory per cpu in MB, 0 indicates no limit
     MaxMemPerCpu: 0
-    AllowedAccounts: ac1, ac2
-    DeniedAccounts: ac1, ac2
+    # AllowedAccounts and DeniedAccounts are mutually exclusive, only one should be configured.
+    # If AllowedAccounts is set, any DeniedAccounts configuration will be ignored.
+    # AllowedAccounts: ac1, ac2
+    # DeniedAccounts: ac1, ac2
 
 DefaultPartition: CPU
 

--- a/protos/Crane.proto
+++ b/protos/Crane.proto
@@ -396,7 +396,7 @@ message ModifyPartitionAclRequest {
 
 message ModifyPartitionAclReply {
   bool ok = 1;
-  ErrCode err_code = 2;
+  ErrCode code = 2;
 }
 
 message MigrateSshProcToCgroupRequest {

--- a/protos/Crane.proto
+++ b/protos/Crane.proto
@@ -386,15 +386,15 @@ message BlockAccountOrUserReply {
   ErrCode code = 2;
 }
 
-message ModifyPartitionAllowedOrDeniedAccountsRequest {
+message ModifyPartitionAclRequest {
   uint32 uid = 1;
-  string partition_name = 2;
-  bool is_modify_allowed = 3;
+  string partition = 2;
+  bool is_allowed_list = 3;
   repeated string accounts = 4;
 }
 
 
-message ModifyPartitionAllowedOrDeniedAccountsReply {
+message ModifyPartitionAclReply {
   bool ok = 1;
   ErrCode err_code = 2;
 }
@@ -781,7 +781,7 @@ service CraneCtld {
   rpc QueryPartitionInfo(QueryPartitionInfoRequest) returns (QueryPartitionInfoReply);
   rpc ModifyTask(ModifyTaskRequest) returns (ModifyTaskReply);
   rpc ModifyNode(ModifyCranedStateRequest) returns (ModifyCranedStateReply);
-  rpc ModifyPartitionAllowedOrDeniedAccounts(ModifyPartitionAllowedOrDeniedAccountsRequest) returns (ModifyPartitionAllowedOrDeniedAccountsReply);
+  rpc ModifyPartitionAcl(ModifyPartitionAclRequest) returns (ModifyPartitionAclReply);
 
   /* RPCs called from cacctmgr */
   rpc AddAccount(AddAccountRequest) returns (AddAccountReply);

--- a/protos/Crane.proto
+++ b/protos/Crane.proto
@@ -386,16 +386,17 @@ message BlockAccountOrUserReply {
   ErrCode code = 2;
 }
 
-message ModifyPartitionAllowedAccountsRequest {
+message ModifyPartitionAllowedOrDeniedAccountsRequest {
   uint32 uid = 1;
   string partition_name = 2;
-  repeated string allowed_accounts = 3;
+  bool is_modify_allowed = 3;
+  repeated string accounts = 4;
 }
 
 
-message ModifyPartitionAllowedAccountsReply {
+message ModifyPartitionAllowedOrDeniedAccountsReply {
   bool ok = 1;
-  ErrCode reason = 2;
+  ErrCode err_code = 2;
 }
 
 message MigrateSshProcToCgroupRequest {
@@ -780,7 +781,7 @@ service CraneCtld {
   rpc QueryPartitionInfo(QueryPartitionInfoRequest) returns (QueryPartitionInfoReply);
   rpc ModifyTask(ModifyTaskRequest) returns (ModifyTaskReply);
   rpc ModifyNode(ModifyCranedStateRequest) returns (ModifyCranedStateReply);
-  rpc ModifyPartitionAllowedAccounts(ModifyPartitionAllowedAccountsRequest) returns (ModifyPartitionAllowedAccountsReply);
+  rpc ModifyPartitionAllowedOrDeniedAccounts(ModifyPartitionAllowedOrDeniedAccountsRequest) returns (ModifyPartitionAllowedOrDeniedAccountsReply);
 
   /* RPCs called from cacctmgr */
   rpc AddAccount(AddAccountRequest) returns (AddAccountReply);

--- a/protos/Crane.proto
+++ b/protos/Crane.proto
@@ -386,14 +386,14 @@ message BlockAccountOrUserReply {
   ErrCode code = 2;
 }
 
-message ModifyPartitionAllowAccountsRequest { 
+message ModifyPartitionAllowedAccountsRequest {
   uint32 uid = 1;
   string partition_name = 2;
-  repeated string allow_accounts = 3;
+  repeated string allowed_accounts = 3;
 }
 
 
-message ModifyPartitionAllowAccountsReply {
+message ModifyPartitionAllowedAccountsReply {
   bool ok = 1;
   ErrCode reason = 2;
 }
@@ -780,7 +780,7 @@ service CraneCtld {
   rpc QueryPartitionInfo(QueryPartitionInfoRequest) returns (QueryPartitionInfoReply);
   rpc ModifyTask(ModifyTaskRequest) returns (ModifyTaskReply);
   rpc ModifyNode(ModifyCranedStateRequest) returns (ModifyCranedStateReply);
-  rpc ModifyPartitionAllowAccounts(ModifyPartitionAllowAccountsRequest) returns (ModifyPartitionAllowAccountsReply);
+  rpc ModifyPartitionAllowedAccounts(ModifyPartitionAllowedAccountsRequest) returns (ModifyPartitionAllowedAccountsReply);
 
   /* RPCs called from cacctmgr */
   rpc AddAccount(AddAccountRequest) returns (AddAccountReply);

--- a/protos/Crane.proto
+++ b/protos/Crane.proto
@@ -386,14 +386,14 @@ message BlockAccountOrUserReply {
   ErrCode code = 2;
 }
 
-message ModifyPartitionAllowedAccountsRequest { 
+message ModifyPartitionAllowAccountsRequest { 
   uint32 uid = 1;
   string partition_name = 2;
-  repeated string allowed_accounts = 3;
+  repeated string allow_accounts = 3;
 }
 
 
-message ModifyPartitionAllowedAccountsReply {
+message ModifyPartitionAllowAccountsReply {
   bool ok = 1;
   ErrCode reason = 2;
 }
@@ -780,7 +780,7 @@ service CraneCtld {
   rpc QueryPartitionInfo(QueryPartitionInfoRequest) returns (QueryPartitionInfoReply);
   rpc ModifyTask(ModifyTaskRequest) returns (ModifyTaskReply);
   rpc ModifyNode(ModifyCranedStateRequest) returns (ModifyCranedStateReply);
-  rpc ModifyPartitionAllowedAccounts(ModifyPartitionAllowedAccountsRequest) returns (ModifyPartitionAllowedAccountsReply);
+  rpc ModifyPartitionAllowAccounts(ModifyPartitionAllowAccountsRequest) returns (ModifyPartitionAllowAccountsReply);
 
   /* RPCs called from cacctmgr */
   rpc AddAccount(AddAccountRequest) returns (AddAccountReply);

--- a/protos/Crane.proto
+++ b/protos/Crane.proto
@@ -386,6 +386,18 @@ message BlockAccountOrUserReply {
   ErrCode code = 2;
 }
 
+message ModifyPartitionAllowedAccountsRequest { 
+  uint32 uid = 1;
+  string partition_name = 2;
+  repeated string allowed_accounts = 3;
+}
+
+
+message ModifyPartitionAllowedAccountsReply {
+  bool ok = 1;
+  ErrCode reason = 2;
+}
+
 message MigrateSshProcToCgroupRequest {
   int32 pid = 1;
   uint32 task_id = 2;
@@ -768,6 +780,7 @@ service CraneCtld {
   rpc QueryPartitionInfo(QueryPartitionInfoRequest) returns (QueryPartitionInfoReply);
   rpc ModifyTask(ModifyTaskRequest) returns (ModifyTaskReply);
   rpc ModifyNode(ModifyCranedStateRequest) returns (ModifyCranedStateReply);
+  rpc ModifyPartitionAllowedAccounts(ModifyPartitionAllowedAccountsRequest) returns (ModifyPartitionAllowedAccountsReply);
 
   /* RPCs called from cacctmgr */
   rpc AddAccount(AddAccountRequest) returns (AddAccountReply);

--- a/protos/PublicDefs.proto
+++ b/protos/PublicDefs.proto
@@ -415,8 +415,8 @@ enum ErrCode {
 
   ERR_MAX_JOB_COUNT_PER_USER = 65;
   ERR_USER_NO_PRIVILEGE = 66;
-  ERR_ALLOWEDLIST_MISSING = 67;  // The current account is not in the allowed account list for the partition.
-  ERR_DENYLIST_HIT = 68;  // The current account has been explicitly added to the deny list for the partition.
+  ERR_NOT_IN_ALLOWED_LIST = 67;  // The current account is not in the allowed account list for the partition.
+  ERR_IN_DENIED_LIST = 68;  // The current account has been explicitly added to the deny list for the partition.
 }
 
 enum EntityType {

--- a/protos/PublicDefs.proto
+++ b/protos/PublicDefs.proto
@@ -297,7 +297,7 @@ message PartitionInfo {
   ResourceView res_avail = 7;
   ResourceView res_alloc = 8;
 
-  repeated string allowed_accounts = 9;
+  repeated string allow_accounts = 9;
 }
 
 message CranedInfo {

--- a/protos/PublicDefs.proto
+++ b/protos/PublicDefs.proto
@@ -415,6 +415,8 @@ enum ErrCode {
 
   ERR_MAX_JOB_COUNT_PER_USER = 65;
   ERR_USER_NO_PRIVILEGE = 66;
+  ERR_ALLOWEDLIST_MISSING = 67;  // The current account is not in the allowed account list for the partition.
+  ERR_DENYLIST_HIT = 68;  // The current account has been explicitly added to the deny list for the partition.
 }
 
 enum EntityType {

--- a/protos/PublicDefs.proto
+++ b/protos/PublicDefs.proto
@@ -296,6 +296,8 @@ message PartitionInfo {
   ResourceView res_total = 6;
   ResourceView res_avail = 7;
   ResourceView res_alloc = 8;
+
+  repeated string allowed_accounts = 9;
 }
 
 message CranedInfo {

--- a/protos/PublicDefs.proto
+++ b/protos/PublicDefs.proto
@@ -297,7 +297,7 @@ message PartitionInfo {
   ResourceView res_avail = 7;
   ResourceView res_alloc = 8;
 
-  repeated string allow_accounts = 9;
+  repeated string allowed_accounts = 9;
 }
 
 message CranedInfo {

--- a/protos/PublicDefs.proto
+++ b/protos/PublicDefs.proto
@@ -298,6 +298,7 @@ message PartitionInfo {
   ResourceView res_alloc = 8;
 
   repeated string allowed_accounts = 9;
+  repeated string denied_accounts = 10;
 }
 
 message CranedInfo {

--- a/src/CraneCtld/AccountManager.cpp
+++ b/src/CraneCtld/AccountManager.cpp
@@ -1063,6 +1063,8 @@ CraneExpected<void> AccountManager::CheckIfUidHasPermOnUser(
   auto user_result = GetUserInfoByUidNoLock_(uid);
   if (!user_result) return std::unexpected(user_result.error());
   const User* op_user = user_result.value();
+  result = CheckIfUserHasHigherPrivThan_(*op_user, User::None);
+  if (!result) return result;
 
   for (const auto& account_name : accounts) {
     const Account* account = GetAccountInfoNoLock_(account_name);

--- a/src/CraneCtld/AccountManager.cpp
+++ b/src/CraneCtld/AccountManager.cpp
@@ -1052,6 +1052,28 @@ CraneExpected<void> AccountManager::CheckIfUidHasPermOnUser(
   return CheckIfUserHasPermOnUserNoLock_(*op_user, user, read_only_priv);
 }
 
+CraneErrCodeExpected<void> AccountManager::CheckModifyPartitionAllowAccounts(
+    uint32_t uid, const std::string& partition_name,
+    const std::unordered_set<std::string>& allow_accounts) {
+  CraneErrCodeExpected<void> result{};
+
+  util::read_lock_guard user_guard(m_rw_user_mutex_);
+  util::read_lock_guard account_guard(m_rw_account_mutex_);
+
+  auto user_result = GetUserInfoByUidNoLock_(uid);
+  if (!user_result) return std::unexpected(user_result.error());
+  const User* op_user = user_result.value();
+
+  for (const auto& account_name : allow_accounts) {
+    const Account* account = GetAccountInfoNoLock_(account_name);
+    result =
+        CheckPartitionIsAllowedNoLock_(account, partition_name, false, false);
+    if (!result) return std::unexpected(result.error());
+  }
+
+  return result;
+}
+
 CraneExpected<void> AccountManager::CheckAddUserAllowedPartitionNoLock_(
     const User* user, const Account* account, const std::string& partition) {
   auto result = CheckPartitionIsAllowedNoLock_(account, partition, false, true);

--- a/src/CraneCtld/AccountManager.cpp
+++ b/src/CraneCtld/AccountManager.cpp
@@ -1052,9 +1052,9 @@ CraneExpected<void> AccountManager::CheckIfUidHasPermOnUser(
   return CheckIfUserHasPermOnUserNoLock_(*op_user, user, read_only_priv);
 }
 
-CraneErrCodeExpected<void> AccountManager::CheckModifyPartitionAllowAccounts(
+CraneErrCodeExpected<void> AccountManager::CheckModifyPartitionAllowedAccounts(
     uint32_t uid, const std::string& partition_name,
-    const std::unordered_set<std::string>& allow_accounts) {
+    const std::unordered_set<std::string>& allowed_accounts) {
   CraneErrCodeExpected<void> result{};
 
   util::read_lock_guard user_guard(m_rw_user_mutex_);
@@ -1064,7 +1064,7 @@ CraneErrCodeExpected<void> AccountManager::CheckModifyPartitionAllowAccounts(
   if (!user_result) return std::unexpected(user_result.error());
   const User* op_user = user_result.value();
 
-  for (const auto& account_name : allow_accounts) {
+  for (const auto& account_name : allowed_accounts) {
     const Account* account = GetAccountInfoNoLock_(account_name);
     result =
         CheckPartitionIsAllowedNoLock_(account, partition_name, false, false);

--- a/src/CraneCtld/AccountManager.cpp
+++ b/src/CraneCtld/AccountManager.cpp
@@ -1052,7 +1052,7 @@ CraneExpected<void> AccountManager::CheckIfUidHasPermOnUser(
   return CheckIfUserHasPermOnUserNoLock_(*op_user, user, read_only_priv);
 }
 
-CraneExpected<void> AccountManager::CheckModifyPartitionAllowedOrDeniedAccounts(
+CraneExpected<void> AccountManager::CheckModifyPartitionAcl(
     uint32_t uid, const std::string& partition_name,
     const std::unordered_set<std::string>& accounts) {
   CraneExpected<void> result{};

--- a/src/CraneCtld/AccountManager.cpp
+++ b/src/CraneCtld/AccountManager.cpp
@@ -1052,9 +1052,9 @@ CraneExpected<void> AccountManager::CheckIfUidHasPermOnUser(
   return CheckIfUserHasPermOnUserNoLock_(*op_user, user, read_only_priv);
 }
 
-CraneErrCodeExpected<void> AccountManager::CheckModifyPartitionAllowedAccounts(
-    uint32_t uid, const std::string& partition_name,
-    const std::unordered_set<std::string>& allowed_accounts) {
+  CraneErrCodeExpected<void> AccountManager::CheckModifyPartitionAllowedOrDeniedAccounts(
+        uint32_t uid, const std::string& partition_name,
+        const std::unordered_set<std::string>& accounts) {
   CraneErrCodeExpected<void> result{};
 
   util::read_lock_guard user_guard(m_rw_user_mutex_);
@@ -1064,7 +1064,7 @@ CraneErrCodeExpected<void> AccountManager::CheckModifyPartitionAllowedAccounts(
   if (!user_result) return std::unexpected(user_result.error());
   const User* op_user = user_result.value();
 
-  for (const auto& account_name : allowed_accounts) {
+  for (const auto& account_name : accounts) {
     const Account* account = GetAccountInfoNoLock_(account_name);
     result =
         CheckPartitionIsAllowedNoLock_(account, partition_name, false, false);

--- a/src/CraneCtld/AccountManager.cpp
+++ b/src/CraneCtld/AccountManager.cpp
@@ -1052,10 +1052,10 @@ CraneExpected<void> AccountManager::CheckIfUidHasPermOnUser(
   return CheckIfUserHasPermOnUserNoLock_(*op_user, user, read_only_priv);
 }
 
-  CraneErrCodeExpected<void> AccountManager::CheckModifyPartitionAllowedOrDeniedAccounts(
-        uint32_t uid, const std::string& partition_name,
-        const std::unordered_set<std::string>& accounts) {
-  CraneErrCodeExpected<void> result{};
+CraneExpected<void> AccountManager::CheckModifyPartitionAllowedOrDeniedAccounts(
+    uint32_t uid, const std::string& partition_name,
+    const std::unordered_set<std::string>& accounts) {
+  CraneExpected<void> result{};
 
   util::read_lock_guard user_guard(m_rw_user_mutex_);
   util::read_lock_guard account_guard(m_rw_account_mutex_);

--- a/src/CraneCtld/AccountManager.h
+++ b/src/CraneCtld/AccountManager.h
@@ -40,7 +40,6 @@ class AccountManager {
   using QosMapMutexSharedPtr = util::ScopeConstSharedPtr<
       std::unordered_map<std::string, std::unique_ptr<Qos>>, util::rw_mutex>;
 
-
   AccountManager();
 
   ~AccountManager() = default;
@@ -128,18 +127,22 @@ class AccountManager {
                                       const std::string& account,
                                       const std::string& partition);
 
-  CraneExpected<void> CheckIfUserOfAccountIsEnabled(
-      const std::string& user, const std::string& account);
+  CraneExpected<void> CheckIfUserOfAccountIsEnabled(const std::string& user,
+                                                    const std::string& account);
 
   CraneExpected<void> CheckAndApplyQosLimitOnTask(const std::string& user,
-                                       const std::string& account,
-                                       TaskInCtld* task);
+                                                  const std::string& account,
+                                                  TaskInCtld* task);
 
   CraneExpected<std::string> CheckUidIsAdmin(uint32_t uid);
 
   CraneExpected<void> CheckIfUidHasPermOnUser(uint32_t uid,
                                               const std::string& username,
                                               bool read_only_priv);
+
+  CraneErrCodeExpected<void> CheckModifyPartitionAllowAccounts(
+      uint32_t uid, const std::string& partition_name,
+      const std::unordered_set<std::string>& allow_accounts);
 
  private:
   void InitDataMap_();

--- a/src/CraneCtld/AccountManager.h
+++ b/src/CraneCtld/AccountManager.h
@@ -140,7 +140,7 @@ class AccountManager {
                                               const std::string& username,
                                               bool read_only_priv);
 
-  CraneErrCodeExpected<void> CheckModifyPartitionAllowedOrDeniedAccounts(
+  CraneExpected<void> CheckModifyPartitionAllowedOrDeniedAccounts(
       uint32_t uid, const std::string& partition_name,
       const std::unordered_set<std::string>& accounts);
 

--- a/src/CraneCtld/AccountManager.h
+++ b/src/CraneCtld/AccountManager.h
@@ -140,7 +140,7 @@ class AccountManager {
                                               const std::string& username,
                                               bool read_only_priv);
 
-  CraneExpected<void> CheckModifyPartitionAllowedOrDeniedAccounts(
+  CraneExpected<void> CheckModifyPartitionAcl(
       uint32_t uid, const std::string& partition_name,
       const std::unordered_set<std::string>& accounts);
 

--- a/src/CraneCtld/AccountManager.h
+++ b/src/CraneCtld/AccountManager.h
@@ -140,9 +140,9 @@ class AccountManager {
                                               const std::string& username,
                                               bool read_only_priv);
 
-  CraneErrCodeExpected<void> CheckModifyPartitionAllowAccounts(
+  CraneErrCodeExpected<void> CheckModifyPartitionAllowedAccounts(
       uint32_t uid, const std::string& partition_name,
-      const std::unordered_set<std::string>& allow_accounts);
+      const std::unordered_set<std::string>& allowed_accounts);
 
  private:
   void InitDataMap_();

--- a/src/CraneCtld/AccountManager.h
+++ b/src/CraneCtld/AccountManager.h
@@ -140,9 +140,9 @@ class AccountManager {
                                               const std::string& username,
                                               bool read_only_priv);
 
-  CraneErrCodeExpected<void> CheckModifyPartitionAllowedAccounts(
+  CraneErrCodeExpected<void> CheckModifyPartitionAllowedOrDeniedAccounts(
       uint32_t uid, const std::string& partition_name,
-      const std::unordered_set<std::string>& allowed_accounts);
+      const std::unordered_set<std::string>& accounts);
 
  private:
   void InitDataMap_();

--- a/src/CraneCtld/CraneCtld.cpp
+++ b/src/CraneCtld/CraneCtld.cpp
@@ -470,17 +470,17 @@ void ParseConfig(int argc, char** argv) {
             auto allowed_accounts_str =
                 partition["AllowedAccounts"].as<std::string>();
             std::vector<std::string> allowed_accounts =
-                absl::StrSplit(absl::StripAsciiWhitespace(allowed_accounts_str).data(), ",");
+                absl::StrSplit(allowed_accounts_str.data(), ",");
             for (const auto& account_name : allowed_accounts) {
-              part.allowed_accounts.insert(account_name);
+              part.allowed_accounts.insert(absl::StripAsciiWhitespace(account_name).data());
             }
           }
 
           if (partition["DeniedAccounts"] && !partition["DeniedAccounts"].IsNull()) {
             auto denied_accounts_str = partition["DeniedAccounts"].as<std::string>();
-            std::vector<std::string> denied_accounts = absl::StrSplit(absl::StripAsciiWhitespace(denied_accounts_str).data(), ",");
+            std::vector<std::string> denied_accounts = absl::StrSplit(denied_accounts_str, ",");
             for (const auto& account_name : denied_accounts) {
-              part.denied_accounts.insert(account_name);
+              part.denied_accounts.insert(absl::StripAsciiWhitespace(account_name).data());
             }
           }
 

--- a/src/CraneCtld/CraneCtld.cpp
+++ b/src/CraneCtld/CraneCtld.cpp
@@ -482,6 +482,10 @@ void ParseConfig(int argc, char** argv) {
             for (const auto& account_name : denied_accounts) {
               part.denied_accounts.insert(absl::StripAsciiWhitespace(account_name).data());
             }
+
+            if (partition["AllowedAccounts"] &&
+              !partition["AllowedAccounts"].IsNull())
+              CRANE_WARN("Hint: When using AllowedAccounts, DeniedAccounts will not take effect.");
           }
 
           if (partition["DefaultMemPerCpu"] &&

--- a/src/CraneCtld/CraneCtld.cpp
+++ b/src/CraneCtld/CraneCtld.cpp
@@ -465,6 +465,17 @@ void ParseConfig(int argc, char** argv) {
             }
           }
 
+          if (partition["AllowAccounts"] &&
+              !partition["AllowAccounts"].IsNull()) {
+            std::string allow_accounts_str =
+                partition["AllowAccounts"].as<std::string>();
+            std::vector<std::string> allow_accounts =
+                absl::StrSplit(allow_accounts_str, ",");
+            for (const auto& account_name : allow_accounts) {
+              part.allow_accounts.insert(account_name);
+            }
+          }
+
           if (partition["DefaultMemPerCpu"] &&
               !partition["DefaultMemPerCpu"].IsNull()) {
             part.default_mem_per_cpu =

--- a/src/CraneCtld/CraneCtld.cpp
+++ b/src/CraneCtld/CraneCtld.cpp
@@ -465,14 +465,14 @@ void ParseConfig(int argc, char** argv) {
             }
           }
 
-          if (partition["AllowAccounts"] &&
-              !partition["AllowAccounts"].IsNull()) {
-            std::string allow_accounts_str =
-                partition["AllowAccounts"].as<std::string>();
-            std::vector<std::string> allow_accounts =
-                absl::StrSplit(allow_accounts_str, ",");
-            for (const auto& account_name : allow_accounts) {
-              part.allow_accounts.insert(account_name);
+          if (partition["AllowedAccounts"] &&
+              !partition["AllowedAccounts"].IsNull()) {
+            std::string allowed_accounts_str =
+                partition["AllowedAccounts"].as<std::string>();
+            std::vector<std::string> allowed_accounts =
+                absl::StrSplit(allowed_accounts_str, ",");
+            for (const auto& account_name : allowed_accounts) {
+              part.allowed_accounts.insert(account_name);
             }
           }
 

--- a/src/CraneCtld/CraneCtld.cpp
+++ b/src/CraneCtld/CraneCtld.cpp
@@ -470,9 +470,15 @@ void ParseConfig(int argc, char** argv) {
             std::string allowed_accounts_str =
                 partition["AllowedAccounts"].as<std::string>();
             std::vector<std::string> allowed_accounts =
-                absl::StrSplit(allowed_accounts_str, ",");
+                absl::StrSplit(absl::StripAsciiWhitespace(allowed_accounts_str).data(), ",");
             for (const auto& account_name : allowed_accounts) {
               part.allowed_accounts.insert(account_name);
+            }
+          } else if (partition["DeniedAccounts"] && !partition["DeniedAccounts"].IsNull()) {
+            std::string denied_accounts_str = partition["DeniedAccounts"].as<std::string>();
+            std::vector<std::string> denied_accounts = absl::StrSplit(absl::StripAsciiWhitespace(denied_accounts_str).data(), ",");
+            for (const auto& account_name : denied_accounts) {
+              part.denied_accounts.insert(account_name);
             }
           }
 

--- a/src/CraneCtld/CraneCtld.cpp
+++ b/src/CraneCtld/CraneCtld.cpp
@@ -467,15 +467,17 @@ void ParseConfig(int argc, char** argv) {
 
           if (partition["AllowedAccounts"] &&
               !partition["AllowedAccounts"].IsNull()) {
-            std::string allowed_accounts_str =
+            auto allowed_accounts_str =
                 partition["AllowedAccounts"].as<std::string>();
             std::vector<std::string> allowed_accounts =
                 absl::StrSplit(absl::StripAsciiWhitespace(allowed_accounts_str).data(), ",");
             for (const auto& account_name : allowed_accounts) {
               part.allowed_accounts.insert(account_name);
             }
-          } else if (partition["DeniedAccounts"] && !partition["DeniedAccounts"].IsNull()) {
-            std::string denied_accounts_str = partition["DeniedAccounts"].as<std::string>();
+          }
+
+          if (partition["DeniedAccounts"] && !partition["DeniedAccounts"].IsNull()) {
+            auto denied_accounts_str = partition["DeniedAccounts"].as<std::string>();
             std::vector<std::string> denied_accounts = absl::StrSplit(absl::StripAsciiWhitespace(denied_accounts_str).data(), ",");
             for (const auto& account_name : denied_accounts) {
               part.denied_accounts.insert(account_name);

--- a/src/CraneCtld/CranedMetaContainer.cpp
+++ b/src/CraneCtld/CranedMetaContainer.cpp
@@ -355,8 +355,10 @@ CranedMetaContainer::QueryAllPartitionInfo() {
          part_meta->partition_global_meta.allowed_accounts) {
       allowed_accounts->Add()->assign(account_name);
     }
-    // auto* denied_accounts = part_info->mutable_denied_accounts();
-
+    auto* denied_accounts = part_info->mutable_denied_accounts();
+    for (const auto& account_name : part_meta->partition_global_meta.denied_accounts) {
+      denied_accounts->Add()->assign(account_name);
+    }
     *part_info->mutable_res_total() = static_cast<crane::grpc::ResourceView>(
         part_meta->partition_global_meta.res_total);
     *part_info->mutable_res_avail() = static_cast<crane::grpc::ResourceView>(
@@ -393,7 +395,10 @@ crane::grpc::QueryPartitionInfoReply CranedMetaContainer::QueryPartitionInfo(
        part_meta->partition_global_meta.allowed_accounts) {
     allowed_accounts->Add()->assign(account_name);
   }
-
+  auto* denied_accounts = part_info->mutable_denied_accounts();
+  for (const auto& account_name : part_meta->partition_global_meta.denied_accounts) {
+    denied_accounts->Add()->assign(account_name);
+  }
   if (part_meta->partition_global_meta.alive_craned_cnt > 0)
     part_info->set_state(crane::grpc::PartitionState::PARTITION_UP);
   else
@@ -588,17 +593,28 @@ crane::grpc::ModifyCranedStateReply CranedMetaContainer::ChangeNodeState(
   return reply;
 }
 
-CraneErrCodeExpected<void> CranedMetaContainer::ModifyPartitionAllowedAccounts(
-    const std::string& partition_name,
-    const std::unordered_set<std::string>& allowed_accounts) {
+  CraneErrCodeExpected<void> CranedMetaContainer::ModifyPartitionAllowedOrDeniedAccounts(
+        const std::string& partition_name,
+        bool is_modify_allowed,
+        const std::unordered_set<std::string>& accounts) {
   CraneErrCodeExpected<void> result{};
 
-  if (!partition_metas_map_.Contains(partition_name))
+  auto part_meta_map = partition_metas_map_.GetMapSharedPtr();
+  if (!part_meta_map->contains(partition_name))
     return std::unexpected(CraneErrCode::ERR_INVALID_PARTITION);
 
-  auto part_meta = partition_metas_map_.GetValueExclusivePtr(partition_name);
+  auto part_meta = part_meta_map->at(partition_name).GetExclusivePtr();
+  auto& allowed_accounts = part_meta->partition_global_meta.allowed_accounts;
+  auto& denied_accounts = part_meta->partition_global_meta.denied_accounts;
 
-  part_meta->partition_global_meta.allowed_accounts = allowed_accounts;
+  if (is_modify_allowed) {
+    allowed_accounts = accounts;
+    denied_accounts.clear();
+  } else if (!allowed_accounts.empty()) {
+    // allowed_accounts在使用，无法修改denied_accounts
+  } else {
+    denied_accounts = accounts;
+  }
 
   return result;
 }
@@ -610,13 +626,13 @@ bool CranedMetaContainer::CheckIfAccountIsAllowedInPartition(
   if (!part_metas_map->contains(partition_name)) return false;
 
   auto part_meta = part_metas_map->at(partition_name).GetExclusivePtr();
-  auto allowed_accounts = part_meta->partition_global_meta.allowed_accounts;
+  const auto& allowed_accounts = part_meta->partition_global_meta.allowed_accounts;
   if (!allowed_accounts.empty()) {
     if (!allowed_accounts.contains(account_name))
       return false;
   } else {
-    auto denied_accounts = part_meta->partition_global_meta.denied_accounts;
-    if (!denied_accounts.empty() && denied_accounts.contains(account_name))
+    const auto& denied_accounts = part_meta->partition_global_meta.denied_accounts;
+    if (denied_accounts.contains(account_name))
       return false;
   }
 

--- a/src/CraneCtld/CranedMetaContainer.cpp
+++ b/src/CraneCtld/CranedMetaContainer.cpp
@@ -648,7 +648,7 @@ CraneExpected<void> CranedMetaContainer::CheckIfAccountIsAllowedInPartition(
           "The account {} is not in the AllowedAccounts of the partition {}"
           "specified for the task, submission of the task is prohibited.",
           account_name, partition_name);
-      return std::unexpected(CraneErrCode::ERR_ALLOWEDLIST_MISSING);
+      return std::unexpected(CraneErrCode::ERR_NOT_IN_ALLOWED_LIST);
     }
   } else if (!denied_accounts.empty()) {
     if (denied_accounts.contains(account_name)) {
@@ -656,7 +656,7 @@ CraneExpected<void> CranedMetaContainer::CheckIfAccountIsAllowedInPartition(
           "The account {} is in the DeniedAccounts of the partition {}"
           "specified for the task, submission of the task is prohibited.",
           account_name, partition_name);
-      return std::unexpected(CraneErrCode::ERR_DENYLIST_HIT);
+      return std::unexpected(CraneErrCode::ERR_IN_DENIED_LIST);
     }
   }
 

--- a/src/CraneCtld/CranedMetaContainer.cpp
+++ b/src/CraneCtld/CranedMetaContainer.cpp
@@ -284,9 +284,11 @@ void CranedMetaContainer::InitFromConfig(const Config& config) {
     part_meta.partition_global_meta.res_total_inc_dead = part_res;
     part_meta.partition_global_meta.node_cnt = part_meta.craned_ids.size();
     part_meta.partition_global_meta.nodelist_str = partition.nodelist_str;
+    part_meta.partition_global_meta.allow_accounts = partition.allow_accounts;
 
     CRANE_DEBUG(
-        "partition [{}]'s Global resource now: (cpu: {}, mem: {}, gres: {}). "
+        "partition [{}]'s Global resource now: (cpu: {}, mem: {}, "
+        "gres: {}). "
         "It has {} craneds.",
         part_name,
         part_meta.partition_global_meta.res_total_inc_dead.CpuCount(),
@@ -347,6 +349,11 @@ CranedMetaContainer::QueryAllPartitionInfo() {
     part_info->set_total_nodes(part_meta->partition_global_meta.node_cnt);
     part_info->set_alive_nodes(
         part_meta->partition_global_meta.alive_craned_cnt);
+    auto* allow_accounts = part_info->mutable_allow_accounts();
+    for (const auto& account_name :
+         part_meta->partition_global_meta.allow_accounts) {
+      allow_accounts->Add()->assign(account_name);
+    }
 
     *part_info->mutable_res_total() = static_cast<crane::grpc::ResourceView>(
         part_meta->partition_global_meta.res_total);
@@ -379,6 +386,11 @@ crane::grpc::QueryPartitionInfoReply CranedMetaContainer::QueryPartitionInfo(
   part_info->set_name(part_meta->partition_global_meta.name);
   part_info->set_total_nodes(part_meta->partition_global_meta.node_cnt);
   part_info->set_alive_nodes(part_meta->partition_global_meta.alive_craned_cnt);
+  auto* allow_accounts = part_info->mutable_allow_accounts();
+  for (const auto& account_name :
+       part_meta->partition_global_meta.allow_accounts) {
+    allow_accounts->Add()->assign(account_name);
+  }
 
   if (part_meta->partition_global_meta.alive_craned_cnt > 0)
     part_info->set_state(crane::grpc::PartitionState::PARTITION_UP);

--- a/src/CraneCtld/CranedMetaContainer.cpp
+++ b/src/CraneCtld/CranedMetaContainer.cpp
@@ -586,6 +586,21 @@ crane::grpc::ModifyCranedStateReply CranedMetaContainer::ChangeNodeState(
   return reply;
 }
 
+CraneErrCodeExpected<void> CranedMetaContainer::ModifyPartitionAllowAccounts(
+    const std::string& partition_name,
+    const std::unordered_set<std::string>& allow_accounts) {
+  CraneErrCodeExpected<void> result{};
+
+  if (!partition_metas_map_.Contains(partition_name))
+    return std::unexpected(CraneErrCode::ERR_INVALID_PARTITION);
+
+  auto part_meta = partition_metas_map_.GetValueExclusivePtr(partition_name);
+
+  part_meta->partition_global_meta.allow_accounts = allow_accounts;
+
+  return result;
+}
+
 void CranedMetaContainer::AddDedicatedResource(
     const CranedId& node_id, const DedicatedResourceInNode& resource) {
   if (!craned_meta_map_.Contains(node_id)) {

--- a/src/CraneCtld/CranedMetaContainer.cpp
+++ b/src/CraneCtld/CranedMetaContainer.cpp
@@ -601,6 +601,18 @@ CraneErrCodeExpected<void> CranedMetaContainer::ModifyPartitionAllowAccounts(
   return result;
 }
 
+bool CranedMetaContainer::CheckIfAccountIsAllowedInPartition(
+    const std::string& partition_name, const std::string& account_name) {
+  if (!partition_metas_map_.Contains(partition_name)) return false;
+
+  auto part_meta = partition_metas_map_.GetValueExclusivePtr(partition_name);
+
+  if (!part_meta->partition_global_meta.allow_accounts.contains(account_name))
+    return false;
+
+  return true;
+}
+
 void CranedMetaContainer::AddDedicatedResource(
     const CranedId& node_id, const DedicatedResourceInNode& resource) {
   if (!craned_meta_map_.Contains(node_id)) {

--- a/src/CraneCtld/CranedMetaContainer.cpp
+++ b/src/CraneCtld/CranedMetaContainer.cpp
@@ -610,9 +610,8 @@ crane::grpc::ModifyCranedStateReply CranedMetaContainer::ChangeNodeState(
   if (is_modify_allowed) {
     allowed_accounts = accounts;
     denied_accounts.clear();
-  } else if (!allowed_accounts.empty()) {
-    // allowed_accounts在使用，无法修改denied_accounts
-  } else {
+  } else if (allowed_accounts.empty()) {
+    // When allowed_accounts is in use, denied_accounts cannot be modified.
     denied_accounts = accounts;
   }
 

--- a/src/CraneCtld/CranedMetaContainer.cpp
+++ b/src/CraneCtld/CranedMetaContainer.cpp
@@ -609,33 +609,35 @@ crane::grpc::ModifyCranedStateReply CranedMetaContainer::ChangeNodeState(
 
   if (is_modify_allowed) {
     allowed_accounts = accounts;
-    denied_accounts.clear();
-  } else if (allowed_accounts.empty()) {
-    // When allowed_accounts is in use, denied_accounts cannot be modified.
+  } else {
     denied_accounts = accounts;
   }
 
   return result;
 }
 
-bool CranedMetaContainer::CheckIfAccountIsAllowedInPartition(
+std::expected<void, std::string> CranedMetaContainer::CheckIfAccountIsAllowedInPartition(
     const std::string& partition_name, const std::string& account_name) {
   auto part_metas_map = partition_metas_map_.GetMapSharedPtr();
 
-  if (!part_metas_map->contains(partition_name)) return false;
+  if (!part_metas_map->contains(partition_name)) return std::unexpected("Partition does not exist.");
 
   auto part_meta = part_metas_map->at(partition_name).GetExclusivePtr();
   const auto& allowed_accounts = part_meta->partition_global_meta.allowed_accounts;
   if (!allowed_accounts.empty()) {
     if (!allowed_accounts.contains(account_name))
-      return false;
+      return std::unexpected(
+        "The account is not in the AllowedAccounts of the partition "
+        "specified for the task, submission of the task is prohibited.");
   } else {
     const auto& denied_accounts = part_meta->partition_global_meta.denied_accounts;
     if (denied_accounts.contains(account_name))
-      return false;
+      return std::unexpected(
+        "The account is in the DeniedAccounts of the partition "
+        "specified for the task, submission of the task is prohibited.");
   }
 
-  return true;
+  return {};
 }
 
 void CranedMetaContainer::AddDedicatedResource(

--- a/src/CraneCtld/CranedMetaContainer.cpp
+++ b/src/CraneCtld/CranedMetaContainer.cpp
@@ -284,7 +284,7 @@ void CranedMetaContainer::InitFromConfig(const Config& config) {
     part_meta.partition_global_meta.res_total_inc_dead = part_res;
     part_meta.partition_global_meta.node_cnt = part_meta.craned_ids.size();
     part_meta.partition_global_meta.nodelist_str = partition.nodelist_str;
-    part_meta.partition_global_meta.allow_accounts = partition.allow_accounts;
+    part_meta.partition_global_meta.allowed_accounts = partition.allowed_accounts;
 
     CRANE_DEBUG(
         "partition [{}]'s Global resource now: (cpu: {}, mem: {}, "
@@ -349,10 +349,10 @@ CranedMetaContainer::QueryAllPartitionInfo() {
     part_info->set_total_nodes(part_meta->partition_global_meta.node_cnt);
     part_info->set_alive_nodes(
         part_meta->partition_global_meta.alive_craned_cnt);
-    auto* allow_accounts = part_info->mutable_allow_accounts();
+    auto* allowed_accounts = part_info->mutable_allowed_accounts();
     for (const auto& account_name :
-         part_meta->partition_global_meta.allow_accounts) {
-      allow_accounts->Add()->assign(account_name);
+         part_meta->partition_global_meta.allowed_accounts) {
+      allowed_accounts->Add()->assign(account_name);
     }
 
     *part_info->mutable_res_total() = static_cast<crane::grpc::ResourceView>(
@@ -386,10 +386,10 @@ crane::grpc::QueryPartitionInfoReply CranedMetaContainer::QueryPartitionInfo(
   part_info->set_name(part_meta->partition_global_meta.name);
   part_info->set_total_nodes(part_meta->partition_global_meta.node_cnt);
   part_info->set_alive_nodes(part_meta->partition_global_meta.alive_craned_cnt);
-  auto* allow_accounts = part_info->mutable_allow_accounts();
+  auto* allowed_accounts = part_info->mutable_allowed_accounts();
   for (const auto& account_name :
-       part_meta->partition_global_meta.allow_accounts) {
-    allow_accounts->Add()->assign(account_name);
+       part_meta->partition_global_meta.allowed_accounts) {
+    allowed_accounts->Add()->assign(account_name);
   }
 
   if (part_meta->partition_global_meta.alive_craned_cnt > 0)
@@ -586,9 +586,9 @@ crane::grpc::ModifyCranedStateReply CranedMetaContainer::ChangeNodeState(
   return reply;
 }
 
-CraneErrCodeExpected<void> CranedMetaContainer::ModifyPartitionAllowAccounts(
+CraneErrCodeExpected<void> CranedMetaContainer::ModifyPartitionAllowedAccounts(
     const std::string& partition_name,
-    const std::unordered_set<std::string>& allow_accounts) {
+    const std::unordered_set<std::string>& allowed_accounts) {
   CraneErrCodeExpected<void> result{};
 
   if (!partition_metas_map_.Contains(partition_name))
@@ -596,7 +596,7 @@ CraneErrCodeExpected<void> CranedMetaContainer::ModifyPartitionAllowAccounts(
 
   auto part_meta = partition_metas_map_.GetValueExclusivePtr(partition_name);
 
-  part_meta->partition_global_meta.allow_accounts = allow_accounts;
+  part_meta->partition_global_meta.allowed_accounts = allowed_accounts;
 
   return result;
 }
@@ -607,7 +607,7 @@ bool CranedMetaContainer::CheckIfAccountIsAllowedInPartition(
 
   auto part_meta = partition_metas_map_.GetValueExclusivePtr(partition_name);
 
-  if (!part_meta->partition_global_meta.allow_accounts.contains(account_name))
+  if (!part_meta->partition_global_meta.allowed_accounts.contains(account_name))
     return false;
 
   return true;

--- a/src/CraneCtld/CranedMetaContainer.cpp
+++ b/src/CraneCtld/CranedMetaContainer.cpp
@@ -285,6 +285,7 @@ void CranedMetaContainer::InitFromConfig(const Config& config) {
     part_meta.partition_global_meta.node_cnt = part_meta.craned_ids.size();
     part_meta.partition_global_meta.nodelist_str = partition.nodelist_str;
     part_meta.partition_global_meta.allowed_accounts = partition.allowed_accounts;
+    part_meta.partition_global_meta.denied_accounts = partition.denied_accounts;
 
     CRANE_DEBUG(
         "partition [{}]'s Global resource now: (cpu: {}, mem: {}, "
@@ -354,6 +355,7 @@ CranedMetaContainer::QueryAllPartitionInfo() {
          part_meta->partition_global_meta.allowed_accounts) {
       allowed_accounts->Add()->assign(account_name);
     }
+    // auto* denied_accounts = part_info->mutable_denied_accounts();
 
     *part_info->mutable_res_total() = static_cast<crane::grpc::ResourceView>(
         part_meta->partition_global_meta.res_total);
@@ -603,12 +605,20 @@ CraneErrCodeExpected<void> CranedMetaContainer::ModifyPartitionAllowedAccounts(
 
 bool CranedMetaContainer::CheckIfAccountIsAllowedInPartition(
     const std::string& partition_name, const std::string& account_name) {
-  if (!partition_metas_map_.Contains(partition_name)) return false;
+  auto part_metas_map = partition_metas_map_.GetMapSharedPtr();
 
-  auto part_meta = partition_metas_map_.GetValueExclusivePtr(partition_name);
+  if (!part_metas_map->contains(partition_name)) return false;
 
-  if (!part_meta->partition_global_meta.allowed_accounts.contains(account_name))
-    return false;
+  auto part_meta = part_metas_map->at(partition_name).GetExclusivePtr();
+  auto allowed_accounts = part_meta->partition_global_meta.allowed_accounts;
+  if (!allowed_accounts.empty()) {
+    if (!allowed_accounts.contains(account_name))
+      return false;
+  } else {
+    auto denied_accounts = part_meta->partition_global_meta.denied_accounts;
+    if (!denied_accounts.empty() && denied_accounts.contains(account_name))
+      return false;
+  }
 
   return true;
 }

--- a/src/CraneCtld/CranedMetaContainer.h
+++ b/src/CraneCtld/CranedMetaContainer.h
@@ -90,9 +90,10 @@ class CranedMetaContainer final {
   crane::grpc::ModifyCranedStateReply ChangeNodeState(
       const crane::grpc::ModifyCranedStateRequest& request);
 
-  CraneErrCodeExpected<void> ModifyPartitionAllowedAccounts(
+  CraneErrCodeExpected<void> ModifyPartitionAllowedOrDeniedAccounts(
       const std::string& partition_name,
-      const std::unordered_set<std::string>& allowed_accounts);
+      bool is_modify_allowed,
+      const std::unordered_set<std::string>& accounts);
 
   bool CheckIfAccountIsAllowedInPartition(const std::string& partition_name,
                                           const std::string& account_name);

--- a/src/CraneCtld/CranedMetaContainer.h
+++ b/src/CraneCtld/CranedMetaContainer.h
@@ -90,9 +90,9 @@ class CranedMetaContainer final {
   crane::grpc::ModifyCranedStateReply ChangeNodeState(
       const crane::grpc::ModifyCranedStateRequest& request);
 
-  CraneErrCodeExpected<void> ModifyPartitionAllowAccounts(
+  CraneErrCodeExpected<void> ModifyPartitionAllowedAccounts(
       const std::string& partition_name,
-      const std::unordered_set<std::string>& allow_accounts);
+      const std::unordered_set<std::string>& allowed_accounts);
 
   bool CheckIfAccountIsAllowedInPartition(const std::string& partition_name,
                                           const std::string& account_name);

--- a/src/CraneCtld/CranedMetaContainer.h
+++ b/src/CraneCtld/CranedMetaContainer.h
@@ -94,6 +94,9 @@ class CranedMetaContainer final {
       const std::string& partition_name,
       const std::unordered_set<std::string>& allow_accounts);
 
+  bool CheckIfAccountIsAllowedInPartition(const std::string& partition_name,
+                                          const std::string& account_name);
+
   void CranedUp(const CranedId& craned_id);
 
   void CranedDown(const CranedId& craned_id);

--- a/src/CraneCtld/CranedMetaContainer.h
+++ b/src/CraneCtld/CranedMetaContainer.h
@@ -95,7 +95,7 @@ class CranedMetaContainer final {
       bool is_modify_allowed,
       const std::unordered_set<std::string>& accounts);
 
-  bool CheckIfAccountIsAllowedInPartition(const std::string& partition_name,
+  std::expected<void, std::string> CheckIfAccountIsAllowedInPartition(const std::string& partition_name,
                                           const std::string& account_name);
 
   void CranedUp(const CranedId& craned_id);

--- a/src/CraneCtld/CranedMetaContainer.h
+++ b/src/CraneCtld/CranedMetaContainer.h
@@ -90,6 +90,10 @@ class CranedMetaContainer final {
   crane::grpc::ModifyCranedStateReply ChangeNodeState(
       const crane::grpc::ModifyCranedStateRequest& request);
 
+  CraneErrCodeExpected<void> ModifyPartitionAllowAccounts(
+      const std::string& partition_name,
+      const std::unordered_set<std::string>& allow_accounts);
+
   void CranedUp(const CranedId& craned_id);
 
   void CranedDown(const CranedId& craned_id);

--- a/src/CraneCtld/CranedMetaContainer.h
+++ b/src/CraneCtld/CranedMetaContainer.h
@@ -90,9 +90,9 @@ class CranedMetaContainer final {
   crane::grpc::ModifyCranedStateReply ChangeNodeState(
       const crane::grpc::ModifyCranedStateRequest& request);
 
-  CraneExpected<void> ModifyPartitionAllowedOrDeniedAccounts(
-      const std::string& partition_name, bool is_modify_allowed,
-      const std::unordered_set<std::string>& accounts);
+  CraneExpected<void> ModifyPartitionAcl(
+      const std::string& partition_name, bool is_allowed_list,
+      std::unordered_set<std::string>&& accounts);
 
   CraneExpected<void> CheckIfAccountIsAllowedInPartition(
       const std::string& partition_name, const std::string& account_name);

--- a/src/CraneCtld/CranedMetaContainer.h
+++ b/src/CraneCtld/CranedMetaContainer.h
@@ -90,13 +90,12 @@ class CranedMetaContainer final {
   crane::grpc::ModifyCranedStateReply ChangeNodeState(
       const crane::grpc::ModifyCranedStateRequest& request);
 
-  CraneErrCodeExpected<void> ModifyPartitionAllowedOrDeniedAccounts(
-      const std::string& partition_name,
-      bool is_modify_allowed,
+  CraneExpected<void> ModifyPartitionAllowedOrDeniedAccounts(
+      const std::string& partition_name, bool is_modify_allowed,
       const std::unordered_set<std::string>& accounts);
 
-  std::expected<void, std::string> CheckIfAccountIsAllowedInPartition(const std::string& partition_name,
-                                          const std::string& account_name);
+  CraneExpected<void> CheckIfAccountIsAllowedInPartition(
+      const std::string& partition_name, const std::string& account_name);
 
   void CranedUp(const CranedId& craned_id);
 

--- a/src/CraneCtld/CtldGrpcServer.cpp
+++ b/src/CraneCtld/CtldGrpcServer.cpp
@@ -1026,12 +1026,10 @@ CraneExpected<std::future<task_id_t>> CtldServer::SubmitTaskToScheduler(
     return std::unexpected(enable_res.error());
   }
 
-  if (!g_meta_container->CheckIfAccountIsAllowedInPartition(task->partition_id,
-                                                            task->account))
-    return std::unexpected(
-        "The account is not in the AllowedAccounts of the partition "
-        "specified "
-        "for the task, submission of the task is prohibited.");
+  auto result = g_meta_container->CheckIfAccountIsAllowedInPartition(task->partition_id,
+                                                            task->account);
+  if (!result)
+    return std::unexpected(result.error());
 
   auto result = g_task_scheduler->AcquireTaskAttributes(task.get());
 

--- a/src/CraneCtld/CtldGrpcServer.cpp
+++ b/src/CraneCtld/CtldGrpcServer.cpp
@@ -254,32 +254,33 @@ grpc::Status CraneCtldServiceImpl::ModifyNode(
   return grpc::Status::OK;
 }
 
-grpc::Status CraneCtldServiceImpl::ModifyPartitionAllowedAccounts(
+grpc::Status CraneCtldServiceImpl::ModifyPartitionAllowedOrDeniedAccounts(
     grpc::ServerContext *context,
-    const crane::grpc::ModifyPartitionAllowedAccountsRequest *request,
-    crane::grpc::ModifyPartitionAllowedAccountsReply *response) {
+    const crane::grpc::ModifyPartitionAllowedOrDeniedAccountsRequest *request,
+    crane::grpc::ModifyPartitionAllowedOrDeniedAccountsReply *response) {
   CraneErrCodeExpected<void> result;
 
-  std::unordered_set<std::string> allowed_accounts;
-  for (const auto &account_name : request->allowed_accounts()) {
-    allowed_accounts.insert(account_name);
+  std::unordered_set<std::string> accounts;
+
+  for (const auto &account_name : request->accounts()) {
+    accounts.insert(account_name);
   }
 
-  result = g_account_manager->CheckModifyPartitionAllowedAccounts(
-      request->uid(), request->partition_name(), allowed_accounts);
+  result = g_account_manager->CheckModifyPartitionAllowedOrDeniedAccounts(
+      request->uid(), request->partition_name(), accounts);
 
   if (!result) {
     response->set_ok(false);
-    response->set_reason(result.error());
+    response->set_err_code(result.error());
     return grpc::Status::OK;
   }
 
-  result = g_meta_container->ModifyPartitionAllowedAccounts(
-      request->partition_name(), allowed_accounts);
+  result = g_meta_container->ModifyPartitionAllowedOrDeniedAccounts(
+        request->partition_name(), request->is_modify_allowed(), accounts);
 
   if (!result) {
     response->set_ok(false);
-    response->set_reason(result.error());
+    response->set_err_code(result.error());
   } else {
     response->set_ok(true);
   }

--- a/src/CraneCtld/CtldGrpcServer.cpp
+++ b/src/CraneCtld/CtldGrpcServer.cpp
@@ -1025,6 +1025,13 @@ CraneExpected<std::future<task_id_t>> CtldServer::SubmitTaskToScheduler(
     return std::unexpected(enable_res.error());
   }
 
+  if (!g_meta_container->CheckIfAccountIsAllowedInPartition(task->partition_id,
+                                                            task->account))
+    return std::unexpected(
+        "The account is not in the AllowAccounts of the partition "
+        "specified "
+        "for the task, submission of the task is prohibited.");
+
   auto result = g_task_scheduler->AcquireTaskAttributes(task.get());
 
   if (result) result = g_task_scheduler->CheckTaskValidity(task.get());

--- a/src/CraneCtld/CtldGrpcServer.cpp
+++ b/src/CraneCtld/CtldGrpcServer.cpp
@@ -254,6 +254,13 @@ grpc::Status CraneCtldServiceImpl::ModifyNode(
   return grpc::Status::OK;
 }
 
+grpc::Status CraneCtldServiceImpl::ModifyPartitionAllowedAccounts(
+    grpc::ServerContext *context,
+    const crane::grpc::ModifyPartitionAllowedAccountsRequest *request,
+    crane::grpc::ModifyPartitionAllowedAccountsReply *response) {
+  return grpc::Status::OK;
+}
+
 grpc::Status CraneCtldServiceImpl::QueryTasksInfo(
     grpc::ServerContext *context,
     const crane::grpc::QueryTasksInfoRequest *request,

--- a/src/CraneCtld/CtldGrpcServer.cpp
+++ b/src/CraneCtld/CtldGrpcServer.cpp
@@ -254,10 +254,10 @@ grpc::Status CraneCtldServiceImpl::ModifyNode(
   return grpc::Status::OK;
 }
 
-grpc::Status CraneCtldServiceImpl::ModifyPartitionAllowedAccounts(
+grpc::Status CraneCtldServiceImpl::ModifyPartitionAllowAccounts(
     grpc::ServerContext *context,
-    const crane::grpc::ModifyPartitionAllowedAccountsRequest *request,
-    crane::grpc::ModifyPartitionAllowedAccountsReply *response) {
+    const crane::grpc::ModifyPartitionAllowAccountsRequest *request,
+    crane::grpc::ModifyPartitionAllowAccountsReply *response) {
   return grpc::Status::OK;
 }
 

--- a/src/CraneCtld/CtldGrpcServer.cpp
+++ b/src/CraneCtld/CtldGrpcServer.cpp
@@ -254,10 +254,10 @@ grpc::Status CraneCtldServiceImpl::ModifyNode(
   return grpc::Status::OK;
 }
 
-grpc::Status CraneCtldServiceImpl::ModifyPartitionAllowedOrDeniedAccounts(
+grpc::Status CraneCtldServiceImpl::ModifyPartitionAcl(
     grpc::ServerContext *context,
-    const crane::grpc::ModifyPartitionAllowedOrDeniedAccountsRequest *request,
-    crane::grpc::ModifyPartitionAllowedOrDeniedAccountsReply *response) {
+    const crane::grpc::ModifyPartitionAclRequest *request,
+    crane::grpc::ModifyPartitionAclReply *response) {
   CraneExpected<void> result;
 
   std::unordered_set<std::string> accounts;
@@ -266,8 +266,8 @@ grpc::Status CraneCtldServiceImpl::ModifyPartitionAllowedOrDeniedAccounts(
     accounts.insert(account_name);
   }
 
-  result = g_account_manager->CheckModifyPartitionAllowedOrDeniedAccounts(
-      request->uid(), request->partition_name(), accounts);
+  result = g_account_manager->CheckModifyPartitionAcl(
+      request->uid(), request->partition(), accounts);
 
   if (!result) {
     response->set_ok(false);
@@ -275,8 +275,8 @@ grpc::Status CraneCtldServiceImpl::ModifyPartitionAllowedOrDeniedAccounts(
     return grpc::Status::OK;
   }
 
-  result = g_meta_container->ModifyPartitionAllowedOrDeniedAccounts(
-      request->partition_name(), request->is_modify_allowed(), accounts);
+  result = g_meta_container->ModifyPartitionAcl(
+      request->partition(), request->is_allowed_list(), std::move(accounts));
 
   if (!result) {
     response->set_ok(false);

--- a/src/CraneCtld/CtldGrpcServer.cpp
+++ b/src/CraneCtld/CtldGrpcServer.cpp
@@ -271,7 +271,7 @@ grpc::Status CraneCtldServiceImpl::ModifyPartitionAcl(
 
   if (!result) {
     response->set_ok(false);
-    response->set_err_code(result.error());
+    response->set_code(result.error());
     return grpc::Status::OK;
   }
 
@@ -280,7 +280,7 @@ grpc::Status CraneCtldServiceImpl::ModifyPartitionAcl(
 
   if (!result) {
     response->set_ok(false);
-    response->set_err_code(result.error());
+    response->set_code(result.error());
   } else {
     response->set_ok(true);
   }

--- a/src/CraneCtld/CtldGrpcServer.cpp
+++ b/src/CraneCtld/CtldGrpcServer.cpp
@@ -254,19 +254,19 @@ grpc::Status CraneCtldServiceImpl::ModifyNode(
   return grpc::Status::OK;
 }
 
-grpc::Status CraneCtldServiceImpl::ModifyPartitionAllowAccounts(
+grpc::Status CraneCtldServiceImpl::ModifyPartitionAllowedAccounts(
     grpc::ServerContext *context,
-    const crane::grpc::ModifyPartitionAllowAccountsRequest *request,
-    crane::grpc::ModifyPartitionAllowAccountsReply *response) {
+    const crane::grpc::ModifyPartitionAllowedAccountsRequest *request,
+    crane::grpc::ModifyPartitionAllowedAccountsReply *response) {
   CraneErrCodeExpected<void> result;
 
-  std::unordered_set<std::string> allow_accounts;
-  for (const auto &account_name : request->allow_accounts()) {
-    allow_accounts.insert(account_name);
+  std::unordered_set<std::string> allowed_accounts;
+  for (const auto &account_name : request->allowed_accounts()) {
+    allowed_accounts.insert(account_name);
   }
 
-  result = g_account_manager->CheckModifyPartitionAllowAccounts(
-      request->uid(), request->partition_name(), allow_accounts);
+  result = g_account_manager->CheckModifyPartitionAllowedAccounts(
+      request->uid(), request->partition_name(), allowed_accounts);
 
   if (!result) {
     response->set_ok(false);
@@ -274,8 +274,8 @@ grpc::Status CraneCtldServiceImpl::ModifyPartitionAllowAccounts(
     return grpc::Status::OK;
   }
 
-  result = g_meta_container->ModifyPartitionAllowAccounts(
-      request->partition_name(), allow_accounts);
+  result = g_meta_container->ModifyPartitionAllowedAccounts(
+      request->partition_name(), allowed_accounts);
 
   if (!result) {
     response->set_ok(false);
@@ -1028,7 +1028,7 @@ CraneExpected<std::future<task_id_t>> CtldServer::SubmitTaskToScheduler(
   if (!g_meta_container->CheckIfAccountIsAllowedInPartition(task->partition_id,
                                                             task->account))
     return std::unexpected(
-        "The account is not in the AllowAccounts of the partition "
+        "The account is not in the AllowedAccounts of the partition "
         "specified "
         "for the task, submission of the task is prohibited.");
 

--- a/src/CraneCtld/CtldGrpcServer.cpp
+++ b/src/CraneCtld/CtldGrpcServer.cpp
@@ -258,7 +258,7 @@ grpc::Status CraneCtldServiceImpl::ModifyPartitionAllowedOrDeniedAccounts(
     grpc::ServerContext *context,
     const crane::grpc::ModifyPartitionAllowedOrDeniedAccountsRequest *request,
     crane::grpc::ModifyPartitionAllowedOrDeniedAccountsReply *response) {
-  CraneErrCodeExpected<void> result;
+  CraneExpected<void> result;
 
   std::unordered_set<std::string> accounts;
 
@@ -276,7 +276,7 @@ grpc::Status CraneCtldServiceImpl::ModifyPartitionAllowedOrDeniedAccounts(
   }
 
   result = g_meta_container->ModifyPartitionAllowedOrDeniedAccounts(
-        request->partition_name(), request->is_modify_allowed(), accounts);
+      request->partition_name(), request->is_modify_allowed(), accounts);
 
   if (!result) {
     response->set_ok(false);
@@ -1026,12 +1026,11 @@ CraneExpected<std::future<task_id_t>> CtldServer::SubmitTaskToScheduler(
     return std::unexpected(enable_res.error());
   }
 
-  auto result = g_meta_container->CheckIfAccountIsAllowedInPartition(task->partition_id,
-                                                            task->account);
-  if (!result)
-    return std::unexpected(result.error());
+  auto result = g_meta_container->CheckIfAccountIsAllowedInPartition(
+      task->partition_id, task->account);
+  if (!result) return std::unexpected(result.error());
 
-  auto result = g_task_scheduler->AcquireTaskAttributes(task.get());
+  result = g_task_scheduler->AcquireTaskAttributes(task.get());
 
   if (result) result = g_task_scheduler->CheckTaskValidity(task.get());
 

--- a/src/CraneCtld/CtldGrpcServer.h
+++ b/src/CraneCtld/CtldGrpcServer.h
@@ -227,10 +227,10 @@ class CraneCtldServiceImpl final : public crane::grpc::CraneCtld::Service {
       const crane::grpc::ModifyCranedStateRequest *request,
       crane::grpc::ModifyCranedStateReply *response) override;
 
-  grpc::Status ModifyPartitionAllowedAccounts(
+  grpc::Status ModifyPartitionAllowAccounts(
       grpc::ServerContext *context,
-      const crane::grpc::ModifyPartitionAllowedAccountsRequest *request,
-      crane::grpc::ModifyPartitionAllowedAccountsReply *response) override;
+      const crane::grpc::ModifyPartitionAllowAccountsRequest *request,
+      crane::grpc::ModifyPartitionAllowAccountsReply *response) override;
 
   grpc::Status AddAccount(grpc::ServerContext *context,
                           const crane::grpc::AddAccountRequest *request,

--- a/src/CraneCtld/CtldGrpcServer.h
+++ b/src/CraneCtld/CtldGrpcServer.h
@@ -227,10 +227,10 @@ class CraneCtldServiceImpl final : public crane::grpc::CraneCtld::Service {
       const crane::grpc::ModifyCranedStateRequest *request,
       crane::grpc::ModifyCranedStateReply *response) override;
 
-  grpc::Status ModifyPartitionAllowAccounts(
+  grpc::Status ModifyPartitionAllowedAccounts(
       grpc::ServerContext *context,
-      const crane::grpc::ModifyPartitionAllowAccountsRequest *request,
-      crane::grpc::ModifyPartitionAllowAccountsReply *response) override;
+      const crane::grpc::ModifyPartitionAllowedAccountsRequest *request,
+      crane::grpc::ModifyPartitionAllowedAccountsReply *response) override;
 
   grpc::Status AddAccount(grpc::ServerContext *context,
                           const crane::grpc::AddAccountRequest *request,

--- a/src/CraneCtld/CtldGrpcServer.h
+++ b/src/CraneCtld/CtldGrpcServer.h
@@ -227,10 +227,10 @@ class CraneCtldServiceImpl final : public crane::grpc::CraneCtld::Service {
       const crane::grpc::ModifyCranedStateRequest *request,
       crane::grpc::ModifyCranedStateReply *response) override;
 
-  grpc::Status ModifyPartitionAllowedAccounts(
+  grpc::Status ModifyPartitionAllowedOrDeniedAccounts(
       grpc::ServerContext *context,
-      const crane::grpc::ModifyPartitionAllowedAccountsRequest *request,
-      crane::grpc::ModifyPartitionAllowedAccountsReply *response) override;
+      const crane::grpc::ModifyPartitionAllowedOrDeniedAccountsRequest *request,
+      crane::grpc::ModifyPartitionAllowedOrDeniedAccountsReply *response) override;
 
   grpc::Status AddAccount(grpc::ServerContext *context,
                           const crane::grpc::AddAccountRequest *request,

--- a/src/CraneCtld/CtldGrpcServer.h
+++ b/src/CraneCtld/CtldGrpcServer.h
@@ -227,6 +227,11 @@ class CraneCtldServiceImpl final : public crane::grpc::CraneCtld::Service {
       const crane::grpc::ModifyCranedStateRequest *request,
       crane::grpc::ModifyCranedStateReply *response) override;
 
+  grpc::Status ModifyPartitionAllowedAccounts(
+      grpc::ServerContext *context,
+      const crane::grpc::ModifyPartitionAllowedAccountsRequest *request,
+      crane::grpc::ModifyPartitionAllowedAccountsReply *response) override;
+
   grpc::Status AddAccount(grpc::ServerContext *context,
                           const crane::grpc::AddAccountRequest *request,
                           crane::grpc::AddAccountReply *response) override;

--- a/src/CraneCtld/CtldGrpcServer.h
+++ b/src/CraneCtld/CtldGrpcServer.h
@@ -227,10 +227,10 @@ class CraneCtldServiceImpl final : public crane::grpc::CraneCtld::Service {
       const crane::grpc::ModifyCranedStateRequest *request,
       crane::grpc::ModifyCranedStateReply *response) override;
 
-  grpc::Status ModifyPartitionAllowedOrDeniedAccounts(
+  grpc::Status ModifyPartitionAcl(
       grpc::ServerContext *context,
-      const crane::grpc::ModifyPartitionAllowedOrDeniedAccountsRequest *request,
-      crane::grpc::ModifyPartitionAllowedOrDeniedAccountsReply *response) override;
+      const crane::grpc::ModifyPartitionAclRequest *request,
+      crane::grpc::ModifyPartitionAclReply *response) override;
 
   grpc::Status AddAccount(grpc::ServerContext *context,
                           const crane::grpc::AddAccountRequest *request,

--- a/src/CraneCtld/CtldPublicDefs.h
+++ b/src/CraneCtld/CtldPublicDefs.h
@@ -80,7 +80,7 @@ struct Config {
     // optional, 0 indicates no limit
     uint64_t max_mem_per_cpu;
     std::unordered_set<std::string> nodes;
-    std::unordered_set<std::string> AllowAccounts;
+    std::unordered_set<std::string> allow_accounts;
   };
 
   struct CraneCtldListenConf {

--- a/src/CraneCtld/CtldPublicDefs.h
+++ b/src/CraneCtld/CtldPublicDefs.h
@@ -215,6 +215,9 @@ struct PartitionGlobalMeta {
 
   std::string name;
   std::string nodelist_str;
+
+  std::unordered_set<std::string> allow_accounts;
+
   uint32_t node_cnt;
   uint32_t alive_craned_cnt;
 };

--- a/src/CraneCtld/CtldPublicDefs.h
+++ b/src/CraneCtld/CtldPublicDefs.h
@@ -80,7 +80,7 @@ struct Config {
     // optional, 0 indicates no limit
     uint64_t max_mem_per_cpu;
     std::unordered_set<std::string> nodes;
-    std::unordered_set<std::string> allow_accounts;
+    std::unordered_set<std::string> allowed_accounts;
   };
 
   struct CraneCtldListenConf {
@@ -216,7 +216,7 @@ struct PartitionGlobalMeta {
   std::string name;
   std::string nodelist_str;
 
-  std::unordered_set<std::string> allow_accounts;
+  std::unordered_set<std::string> allowed_accounts;
 
   uint32_t node_cnt;
   uint32_t alive_craned_cnt;

--- a/src/CraneCtld/CtldPublicDefs.h
+++ b/src/CraneCtld/CtldPublicDefs.h
@@ -81,6 +81,7 @@ struct Config {
     uint64_t max_mem_per_cpu;
     std::unordered_set<std::string> nodes;
     std::unordered_set<std::string> allowed_accounts;
+    std::unordered_set<std::string> denied_accounts;
   };
 
   struct CraneCtldListenConf {
@@ -217,6 +218,7 @@ struct PartitionGlobalMeta {
   std::string nodelist_str;
 
   std::unordered_set<std::string> allowed_accounts;
+  std::unordered_set<std::string> denied_accounts;
 
   uint32_t node_cnt;
   uint32_t alive_craned_cnt;

--- a/src/Craned/CranedPublicDefs.h
+++ b/src/Craned/CranedPublicDefs.h
@@ -45,7 +45,7 @@ struct TaskInfoOfUid {
 
 struct Partition {
   std::unordered_set<std::string> nodes;
-  std::unordered_set<std::string> AllowAccounts;
+  std::unordered_set<std::string> AllowedAccounts;
 };
 
 struct Config {

--- a/src/Utilities/PublicHeader/include/crane/PublicHeader.h
+++ b/src/Utilities/PublicHeader/include/crane/PublicHeader.h
@@ -35,8 +35,13 @@ using task_id_t = uint32_t;
 
 using CraneErrCode = crane::grpc::ErrCode;
 
+using CraneErrCode = crane::grpc::ErrCode;
+
 template <typename T>
 using CraneExpected = std::expected<T, CraneErrCode>;
+
+template <typename T>
+using CraneErrCodeExpected = std::expected<T, CraneErrCode>;
 
 inline const char* kCtldDefaultPort = "10011";
 inline const char* kCranedDefaultPort = "10010";

--- a/src/Utilities/PublicHeader/include/crane/PublicHeader.h
+++ b/src/Utilities/PublicHeader/include/crane/PublicHeader.h
@@ -35,13 +35,8 @@ using task_id_t = uint32_t;
 
 using CraneErrCode = crane::grpc::ErrCode;
 
-using CraneErrCode = crane::grpc::ErrCode;
-
 template <typename T>
 using CraneExpected = std::expected<T, CraneErrCode>;
-
-template <typename T>
-using CraneErrCodeExpected = std::expected<T, CraneErrCode>;
 
 inline const char* kCtldDefaultPort = "10011";
 inline const char* kCranedDefaultPort = "10010";


### PR DESCRIPTION
1. config文件partition添加AllowAccounts设置，AllowAccounts=，ctld启动时读取配置。
2. 命令行修改partition的AllowAccounts，无需持久化，持久化只能在config文件进行定义。
3. ccontrol show partition 添加AllowAccounts条目展示。
4. 提交任务时判断account是否在partition的AllowAccounts中