### PR TITLE
feat: Add the functionality to modify the default user account.

### DIFF
--- a/protos/PublicDefs.proto
+++ b/protos/PublicDefs.proto
@@ -400,15 +400,15 @@ enum ModifyField {
   Qos = 1;
   DefaultQos = 2;
   // account and qos
-  Description = 3;
+  Description = 10;
   // user
-  AdminLevel = 4;
-  DefaultAccount = 5;
+  AdminLevel = 20;
+  DefaultAccount = 21;
   // qos
-  Priority = 6;
-  MaxJobsPerUser = 7;
-  MaxCpusPerUser = 8;
-  MaxTimeLimitPerTask = 9;
+  Priority = 30;
+  MaxJobsPerUser = 31;
+  MaxCpusPerUser = 32;
+  MaxTimeLimitPerTask = 33;
 }
 
 message AccountInfo {

--- a/protos/PublicDefs.proto
+++ b/protos/PublicDefs.proto
@@ -403,11 +403,12 @@ enum ModifyField {
   Description = 3;
   // user
   AdminLevel = 4;
+  DefaultAccount = 5;
   // qos
-  Priority = 5;
-  MaxJobsPerUser = 6;
-  MaxCpusPerUser = 7;
-  MaxTimeLimitPerTask = 8;
+  Priority = 6;
+  MaxJobsPerUser = 7;
+  MaxCpusPerUser = 8;
+  MaxTimeLimitPerTask = 9;
 }
 
 message AccountInfo {

--- a/src/CraneCtld/AccountManager.cpp
+++ b/src/CraneCtld/AccountManager.cpp
@@ -508,7 +508,7 @@ AccountManager::CraneExpected<void> AccountManager::ModifyAdminLevel(
 }
 
 AccountManager::CraneExpected<void> AccountManager::ModifyUserDefaultAccount(
-uint32_t uid, const std::string& user,const std::string& def_account) {
+    uint32_t uid, const std::string& user, const std::string& def_account) {
   util::write_lock_guard user_guard(m_rw_user_mutex_);
   CraneExpected<void> result{};
 
@@ -996,7 +996,8 @@ std::expected<void, std::string> AccountManager::CheckAndApplyQosLimitOnTask(
 
   if (!g_account_meta_container->CheckAndMallocQosResourceFromUser(
           user_share_ptr->name, *task, *qos_share_ptr))
-    return std::unexpected("The requested QoS resources have reached the user's limit.");
+    return std::unexpected(
+        "The requested QoS resources have reached the user's limit.");
 
   return {};
 }
@@ -1946,19 +1947,19 @@ AccountManager::CraneExpected<void> AccountManager::SetUserAdminLevel_(
 }
 
 AccountManager::CraneExpected<void> AccountManager::SetUserDefaultAccount_(
-    const std::string& name, const std::string& new_account) {
+    const std::string& user, const std::string& def_account) {
   // Update to database
   mongocxx::client_session::with_transaction_cb callback =
       [&](mongocxx::client_session* session) {
         g_db_client->UpdateEntityOne(MongodbClient::EntityType::USER, "$set",
-                                     name, "default_account", new_account);
+                                     user, "default_account", def_account);
       };
 
   if (!g_db_client->CommitTransaction(callback)) {
     return std::unexpected(CraneErrCode::ERR_UPDATE_DATABASE);
   }
 
-  m_user_map_[name]->default_account = new_account;
+  m_user_map_[user]->default_account = def_account;
 
   return {};
 }

--- a/src/CraneCtld/AccountManager.cpp
+++ b/src/CraneCtld/AccountManager.cpp
@@ -508,7 +508,7 @@ AccountManager::CraneExpected<void> AccountManager::ModifyAdminLevel(
 }
 
 AccountManager::CraneExpected<void> AccountManager::ModifyUserDefaultAccount(
-    uint32_t uid, const std::string& name, const std::string& value) {
+uint32_t uid, const std::string& user,const std::string& def_account) {
   util::write_lock_guard user_guard(m_rw_user_mutex_);
   CraneExpected<void> result{};
 
@@ -516,18 +516,18 @@ AccountManager::CraneExpected<void> AccountManager::ModifyUserDefaultAccount(
   if (!user_result) return std::unexpected(user_result.error());
   const User* op_user = user_result.value();
 
-  const User* user = GetExistedUserInfoNoLock_(name);
-  if (!user) return std::unexpected(CraneErrCode::ERR_INVALID_USER);
+  const User* user_ptr = GetExistedUserInfoNoLock_(user);
+  if (!user_ptr) return std::unexpected(CraneErrCode::ERR_INVALID_USER);
 
-  result = CheckIfUserHasHigherPrivThan_(*op_user, user->admin_level);
+  result = CheckIfUserHasHigherPrivThan_(*op_user, user_ptr->admin_level);
   if (!result) return std::unexpected(CraneErrCode::ERR_PERMISSION_USER);
 
-  if (!user->account_to_attrs_map.contains(value))
+  if (!user_ptr->account_to_attrs_map.contains(def_account))
     return std::unexpected(CraneErrCode::ERR_USER_ALLOWED_ACCOUNT);
 
-  if (user->default_account == value) return result;
+  if (user_ptr->default_account == def_account) return result;
 
-  return SetUserDefaultAccount_(name, value);
+  return SetUserDefaultAccount_(user, def_account);
 }
 
 AccountManager::CraneExpected<void> AccountManager::ModifyUserDefaultQos(

--- a/src/CraneCtld/AccountManager.cpp
+++ b/src/CraneCtld/AccountManager.cpp
@@ -507,6 +507,29 @@ AccountManager::CraneExpected<void> AccountManager::ModifyAdminLevel(
   return SetUserAdminLevel_(name, new_level);
 }
 
+AccountManager::CraneExpected<void> AccountManager::ModifyUserDefaultAccount(
+    uint32_t uid, const std::string& name, const std::string& value) {
+  util::write_lock_guard user_guard(m_rw_user_mutex_);
+  CraneExpected<void> result{};
+
+  auto user_result = GetUserInfoByUidNoLock_(uid);
+  if (!user_result) return std::unexpected(user_result.error());
+  const User* op_user = user_result.value();
+
+  const User* user = GetExistedUserInfoNoLock_(name);
+  if (!user) return std::unexpected(CraneErrCode::ERR_INVALID_USER);
+
+  result = CheckIfUserHasHigherPrivThan_(*op_user, user->admin_level);
+  if (!result) return std::unexpected(CraneErrCode::ERR_PERMISSION_USER);
+
+  if (!user->account_to_attrs_map.contains(value))
+    return std::unexpected(CraneErrCode::ERR_USER_ALLOWED_ACCOUNT);
+
+  if (user->default_account == value) return result;
+
+  return SetUserDefaultAccount_(name, value);
+}
+
 AccountManager::CraneExpected<void> AccountManager::ModifyUserDefaultQos(
     uint32_t uid, const std::string& name, const std::string& partition,
     const std::string& account, const std::string& value) {
@@ -1918,6 +1941,24 @@ AccountManager::CraneExpected<void> AccountManager::SetUserAdminLevel_(
   }
 
   m_user_map_[name]->admin_level = new_level;
+
+  return {};
+}
+
+AccountManager::CraneExpected<void> AccountManager::SetUserDefaultAccount_(
+    const std::string& name, const std::string& new_account) {
+  // Update to database
+  mongocxx::client_session::with_transaction_cb callback =
+      [&](mongocxx::client_session* session) {
+        g_db_client->UpdateEntityOne(MongodbClient::EntityType::USER, "$set",
+                                     name, "default_account", new_account);
+      };
+
+  if (!g_db_client->CommitTransaction(callback)) {
+    return std::unexpected(CraneErrCode::ERR_UPDATE_DATABASE);
+  }
+
+  m_user_map_[name]->default_account = new_account;
 
   return {};
 }

--- a/src/CraneCtld/AccountManager.h
+++ b/src/CraneCtld/AccountManager.h
@@ -89,6 +89,9 @@ class AccountManager {
    */
   CraneExpected<void> ModifyAdminLevel(uint32_t uid, const std::string& name,
                                        const std::string& value);
+  CraneExpected<void> ModifyUserDefaultAccount(uint32_t uid,
+                                               const std::string& name,
+                                               const std::string& value);
   CraneExpected<void> ModifyUserDefaultQos(uint32_t uid,
                                            const std::string& name,
                                            const std::string& partition,
@@ -263,6 +266,10 @@ class AccountManager {
 
   CraneExpected<void> SetUserAdminLevel_(const std::string& name,
                                          User::AdminLevel new_level);
+
+  CraneExpected<void> SetUserDefaultAccount_(const std::string& name,
+                                             const std::string& new_account);
+
   CraneExpected<void> SetUserDefaultQos_(const User& user,
                                          const std::string& account,
                                          const std::string& partition,

--- a/src/CraneCtld/AccountManager.h
+++ b/src/CraneCtld/AccountManager.h
@@ -267,8 +267,8 @@ class AccountManager {
   CraneExpected<void> SetUserAdminLevel_(const std::string& name,
                                          User::AdminLevel new_level);
 
-  CraneExpected<void> SetUserDefaultAccount_(const std::string& name,
-                                             const std::string& new_account);
+  CraneExpected<void> SetUserDefaultAccount_(const std::string& user,
+                                             const std::string& def_account);
 
   CraneExpected<void> SetUserDefaultQos_(const User& user,
                                          const std::string& account,

--- a/src/CraneCtld/AccountManager.h
+++ b/src/CraneCtld/AccountManager.h
@@ -90,8 +90,8 @@ class AccountManager {
   CraneExpected<void> ModifyAdminLevel(uint32_t uid, const std::string& name,
                                        const std::string& value);
   CraneExpected<void> ModifyUserDefaultAccount(uint32_t uid,
-                                               const std::string& name,
-                                               const std::string& value);
+                                               const std::string& user,
+                                               const std::string& def_account);
   CraneExpected<void> ModifyUserDefaultQos(uint32_t uid,
                                            const std::string& name,
                                            const std::string& partition,

--- a/src/CraneCtld/CtldGrpcServer.cpp
+++ b/src/CraneCtld/CtldGrpcServer.cpp
@@ -455,6 +455,10 @@ grpc::Status CraneCtldServiceImpl::ModifyUser(
           request->uid(), request->name(), request->partition(),
           request->account(), request->value());
       break;
+    case crane::grpc::ModifyField::DefaultAccount:
+      modify_res = g_account_manager->ModifyUserDefaultAccount(
+          request->uid(), request->name(), request->value());
+      break;
     default:
       std::unreachable();
     }


### PR DESCRIPTION
命令：
cacctmgr modify user -N=username  --default-account or -D=new_default_account

proto改动：
publicDefs.proto ModifyField 增加 DefaultAccount

鉴权流程：
1. uid 以及 op_user 是否有效
2. 用户权限等级比较
3. 用户是否属于new_default_account