### PR TITLE
feat: Add power-control interface

### DIFF
--- a/protos/Crane.proto
+++ b/protos/Crane.proto
@@ -443,6 +443,7 @@ message QueryClusterInfoRequest {
   repeated string filter_nodes = 2;
   repeated CranedResourceState filter_craned_resource_states = 3;
   repeated CranedControlState filter_craned_control_states = 4;
+  repeated CranedPowerState filter_craned_power_states = 5;
 }
 
 message QueryClusterInfoReply {
@@ -889,6 +890,7 @@ service CraneCtld {
   rpc CreateReservation(CreateReservationRequest) returns (CreateReservationReply);
   rpc DeleteReservation(DeleteReservationRequest) returns (DeleteReservationReply);
 
+  /* RPC called form plugin */
   rpc PowerStateChange(PowerStateChangeRequest) returns (PowerStateChangeReply);
 }
 

--- a/protos/Crane.proto
+++ b/protos/Crane.proto
@@ -825,6 +825,16 @@ message StreamTaskIOReply {
   }
 }
 
+message PowerStateChangeRequest {
+  string craned_id = 1;
+  CranedPowerState state = 2;
+  string reason = 3;
+}
+
+message PowerStateChangeReply {
+  bool ok = 1;
+}
+
 // Todo: Divide service into two parts: one for Craned and one for Crun
 //  We need to distinguish the message sender
 //  and have some kind of authentication
@@ -878,6 +888,8 @@ service CraneCtld {
   rpc QueryTasksInfo(QueryTasksInfoRequest) returns (QueryTasksInfoReply);
   rpc CreateReservation(CreateReservationRequest) returns (CreateReservationReply);
   rpc DeleteReservation(DeleteReservationRequest) returns (DeleteReservationReply);
+
+  rpc PowerStateChange(PowerStateChangeRequest) returns (PowerStateChangeReply);
 }
 
 service Craned {

--- a/protos/Plugin.proto
+++ b/protos/Plugin.proto
@@ -55,7 +55,7 @@ message EndHookReply {
 message CreateCgroupHookRequest {
   uint32 task_id = 1;
   string cgroup = 2;
-  DedicatedResourceInNode resource = 3;
+  ResourceInNode resource = 3;
 }
 
 message CreateCgroupHookReply {
@@ -71,12 +71,19 @@ message DestroyCgroupHookReply {
   bool ok = 1;
 }
 
+message CranedState {
+  oneof state_type {
+    CranedPowerState power_state = 1;
+    CranedControlState control_state = 2;
+  }
+}
+
 message CranedEventInfo {
   google.protobuf.Timestamp start_time = 1;
   string node_name = 2;
   string cluster_name = 3;
   string reason = 4;
-  CranedControlState state = 5;
+  CranedState state = 5;
   uint32 uid = 6;
 }
 
@@ -88,11 +95,40 @@ message NodeEventHookReply {
   bool ok = 1;
 }
 
+message UpdatePowerStateHookRequest {
+    string craned_id = 1;
+    CranedControlState state = 2;
+}
+
+message UpdatePowerStateHookReply {
+    bool ok = 1;
+}
+
+message GetCranedByPowerStateHookSyncRequest {
+    CranedPowerState state = 1;
+}
+
+message GetCranedByPowerStateHookSyncReply {
+    repeated string craned_ids = 1;
+}
+
+message RegisterCranedHookRequest {
+    string craned_id = 1;
+    repeated NetworkInterface network_interfaces = 2;
+}
+
+message RegisterCranedHookReply {
+    bool ok = 1;
+}
+
 service CranePluginD {
   /* ----------------------------------- Called from CraneCtld ---------------------------------------------------- */
   rpc StartHook(StartHookRequest) returns (StartHookReply);
   rpc EndHook(EndHookRequest) returns (EndHookReply);
   rpc NodeEventHook(NodeEventHookRequest) returns (NodeEventHookReply);
+  rpc UpdatePowerStateHook(UpdatePowerStateHookRequest) returns (UpdatePowerStateHookReply);
+  rpc GetCranedByPowerStateHookSync(GetCranedByPowerStateHookSyncRequest) returns (GetCranedByPowerStateHookSyncReply);
+  rpc RegisterCranedHook(RegisterCranedHookRequest) returns (RegisterCranedHookReply);
 
   /* ----------------------------------- Called from Craned ---------------------------------------------------- */
   rpc CreateCgroupHook(CreateCgroupHookRequest) returns (CreateCgroupHookReply);

--- a/protos/Plugin.proto
+++ b/protos/Plugin.proto
@@ -71,20 +71,16 @@ message DestroyCgroupHookReply {
   bool ok = 1;
 }
 
-message CranedState {
-  oneof state_type {
-    CranedPowerState power_state = 1;
-    CranedControlState control_state = 2;
-  }
-}
-
 message CranedEventInfo {
   google.protobuf.Timestamp start_time = 1;
   string node_name = 2;
   string cluster_name = 3;
   string reason = 4;
-  CranedState state = 5;
-  uint32 uid = 6;
+  oneof state_type {
+    CranedPowerState power_state = 5;
+    CranedControlState control_state = 6;
+  }
+  uint32 uid = 7;
 }
 
 message NodeEventHookRequest {
@@ -104,14 +100,6 @@ message UpdatePowerStateHookReply {
     bool ok = 1;
 }
 
-message GetCranedByPowerStateHookSyncRequest {
-    CranedPowerState state = 1;
-}
-
-message GetCranedByPowerStateHookSyncReply {
-    repeated string craned_ids = 1;
-}
-
 message RegisterCranedHookRequest {
     string craned_id = 1;
     repeated NetworkInterface network_interfaces = 2;
@@ -127,7 +115,6 @@ service CranePluginD {
   rpc EndHook(EndHookRequest) returns (EndHookReply);
   rpc NodeEventHook(NodeEventHookRequest) returns (NodeEventHookReply);
   rpc UpdatePowerStateHook(UpdatePowerStateHookRequest) returns (UpdatePowerStateHookReply);
-  rpc GetCranedByPowerStateHookSync(GetCranedByPowerStateHookSyncRequest) returns (GetCranedByPowerStateHookSyncReply);
   rpc RegisterCranedHook(RegisterCranedHookRequest) returns (RegisterCranedHookReply);
 
   /* ----------------------------------- Called from Craned ---------------------------------------------------- */

--- a/protos/PublicDefs.proto
+++ b/protos/PublicDefs.proto
@@ -83,6 +83,8 @@ enum CranedResourceState {
   CRANE_MIX = 1;
   CRANE_ALLOC = 2;
   CRANE_DOWN = 3;
+  CRANE_OFF = 4;
+  CRANE_SLEEPING = 5;
 }
 
 enum CranedPowerState {
@@ -584,5 +586,5 @@ message CranedRemoteMeta {
   google.protobuf.Timestamp system_boot_time = 5;
   repeated uint32 lost_tasks = 6;
   repeated uint32 lost_jobs = 7;
-  repeated NetworkInterface network_interfaces = 7;
+  repeated NetworkInterface network_interfaces = 8;
 }

--- a/protos/PublicDefs.proto
+++ b/protos/PublicDefs.proto
@@ -584,5 +584,5 @@ message CranedRemoteMeta {
   google.protobuf.Timestamp system_boot_time = 5;
   repeated uint32 lost_tasks = 6;
   repeated uint32 lost_jobs = 7;
-  repeated NetworkInterface network_interfaces = 6;
+  repeated NetworkInterface network_interfaces = 7;
 }

--- a/protos/PublicDefs.proto
+++ b/protos/PublicDefs.proto
@@ -83,8 +83,6 @@ enum CranedResourceState {
   CRANE_MIX = 1;
   CRANE_ALLOC = 2;
   CRANE_DOWN = 3;
-  CRANE_OFF = 4;
-  CRANE_SLEEPING = 5;
 }
 
 enum CranedPowerState {
@@ -341,10 +339,11 @@ message CranedInfo {
   string hostname = 1;
   CranedResourceState resource_state = 2;
   CranedControlState control_state = 3;
+  CranedPowerState power_state = 4;
 
-  ResourceInNode res_total = 4;
-  ResourceInNode res_avail = 5;
-  ResourceInNode res_alloc = 6;
+  ResourceInNode res_total = 5;
+  ResourceInNode res_avail = 6;
+  ResourceInNode res_alloc = 7;
 
   repeated string partition_names = 10;
   uint32 running_task_num = 11;
@@ -377,8 +376,9 @@ message TrimmedPartitionInfo {
   message TrimmedCranedInfo {
     CranedResourceState resource_state = 1;
     CranedControlState control_state = 2;
-    uint32 count = 3;
-    string craned_list_regex = 4;
+    CranedPowerState power_state = 3;
+    uint32 count = 4;
+    string craned_list_regex = 5;
   }
 
   string name = 1;

--- a/protos/PublicDefs.proto
+++ b/protos/PublicDefs.proto
@@ -85,9 +85,24 @@ enum CranedResourceState {
   CRANE_DOWN = 3;
 }
 
+enum CranedPowerState {
+  CRANE_POWER_ACTIVE = 0;
+  CRANE_POWER_IDLE = 1;
+  CRANE_POWER_SLEEPING = 2;
+  CRANE_POWER_POWEREDOFF = 3;
+  CRANE_POWER_TO_SLEEPING = 4;
+  CRANE_POWER_WAKING_UP = 5;
+  CRANE_POWER_POWERING_ON = 6;
+  CRANE_POWER_POWERING_OFF = 7;
+}
+
 enum CranedControlState {
   CRANE_NONE = 0;
   CRANE_DRAIN = 1;
+  CRANE_POWEROFF = 2;
+  CRANE_SLEEP = 3;
+  CRANE_WAKE = 4;
+  CRANE_POWERON = 5;
 }
 
 enum TaskStatus {
@@ -554,6 +569,13 @@ message SystemRelInfo {
   string version = 3;
 }
 
+message NetworkInterface {
+  string name = 1;
+  string mac_address = 2;
+  repeated string ipv4_addresses = 3;
+  repeated string ipv6_addresses = 4;
+}
+
 message CranedRemoteMeta {
   DedicatedResourceInNode dres_in_node = 1;
   SystemRelInfo sys_rel_info = 2;
@@ -562,4 +584,5 @@ message CranedRemoteMeta {
   google.protobuf.Timestamp system_boot_time = 5;
   repeated uint32 lost_tasks = 6;
   repeated uint32 lost_jobs = 7;
+  repeated NetworkInterface network_interfaces = 6;
 }

--- a/src/CraneCtld/CranedMetaContainer.cpp
+++ b/src/CraneCtld/CranedMetaContainer.cpp
@@ -31,7 +31,7 @@ void CranedMetaContainer::CranedUp(
 
   if (g_plugin_client != nullptr) {
     std::vector<crane::NetworkInterface> interfaces;
-    for (const auto& interface : remote_meta.network_interfaces) {
+    for (const auto& interface : remote_meta.network_interfaces()) {
       interfaces.emplace_back(interface);
     }
     g_plugin_client->RegisterCranedHookAsync(craned_id, interfaces);

--- a/src/CraneCtld/CranedMetaContainer.cpp
+++ b/src/CraneCtld/CranedMetaContainer.cpp
@@ -29,7 +29,7 @@ void CranedMetaContainer::CranedUp(
     const crane::grpc::CranedRemoteMeta& remote_meta) {
   CRANE_ASSERT(craned_id_part_ids_map_.contains(craned_id));
 
-  if (g_plugin_client != nullptr) {
+  if (g_config.Plugin.Enabled && g_plugin_client != nullptr) {
     std::vector<crane::NetworkInterface> interfaces;
     for (const auto& interface : remote_meta.network_interfaces()) {
       interfaces.emplace_back(interface);
@@ -626,7 +626,8 @@ crane::grpc::QueryClusterInfoReply CranedMetaContainer::QueryClusterInfo(
   };
 
   if (request.filter_craned_control_states().empty() ||
-      request.filter_craned_resource_states().empty()) {
+      request.filter_craned_resource_states().empty() ||
+      request.filter_craned_power_states().empty()) {
     reply.set_ok(true);
     return reply;
   }
@@ -640,6 +641,11 @@ crane::grpc::QueryClusterInfoReply CranedMetaContainer::QueryClusterInfo(
   bool resource_filters[resource_state_num] = {false};
   for (const auto& it : request.filter_craned_resource_states())
     resource_filters[static_cast<int>(it)] = true;
+
+  const int power_state_num = crane::grpc::CranedPowerState_ARRAYSIZE;
+  bool power_filters[power_state_num] = {false};
+  for (const auto& it : request.filter_craned_power_states())
+    power_filters[static_cast<int>(it)] = true;
 
   // Ensure that the map global read lock is held during the following filtering
   // operations and partition_meta_map_ must be locked before craned_meta_map_
@@ -678,7 +684,8 @@ crane::grpc::QueryClusterInfoReply CranedMetaContainer::QueryClusterInfo(
     }
 
     std::list<std::string> craned_name_lists[control_state_num]
-                                            [resource_state_num];
+                                            [resource_state_num]
+                                            [power_state_num];
 
     auto craned_rng =
         craned_ids |
@@ -711,35 +718,29 @@ crane::grpc::QueryClusterInfoReply CranedMetaContainer::QueryClusterInfo(
           resource_state = crane::grpc::CranedResourceState::CRANE_MIX;
         }
       } else {
-        if (craned_meta->power_state == CranedPowerState::PoweredOff ||
-            craned_meta->power_state == CranedPowerState::PoweringOff ||
-            craned_meta->power_state == CranedPowerState::PoweringOn) {
-          resource_state = crane::grpc::CranedResourceState::CRANE_OFF;
-        } else if (craned_meta->power_state == CranedPowerState::Sleeping ||
-                   craned_meta->power_state == CranedPowerState::ToSleeping ||
-                   craned_meta->power_state == CranedPowerState::WakingUp) {
-          resource_state = crane::grpc::CranedResourceState::CRANE_SLEEPING;
-        } else {
-          resource_state = crane::grpc::CranedResourceState::CRANE_DOWN;
-        }
+        resource_state = crane::grpc::CranedResourceState::CRANE_DOWN;
       }
       if (control_filters[static_cast<int>(control_state)] &&
-          resource_filters[static_cast<int>(resource_state)]) {
-        craned_name_lists[static_cast<int>(control_state)]
-                         [static_cast<int>(resource_state)]
-                             .emplace_back(craned_meta->static_meta.hostname);
+          resource_filters[static_cast<int>(resource_state)] &&
+          power_filters[static_cast<int>(craned_meta->power_state)]) {
+        craned_name_lists[static_cast<int>(control_state)][static_cast<int>(
+            resource_state)][static_cast<int>(craned_meta->power_state)]
+            .emplace_back(craned_meta->static_meta.hostname);
       }
     });
 
     auto* craned_lists = part_info->mutable_craned_lists();
     for (int i = 0; i < control_state_num; i++) {
       for (int j = 0; j < resource_state_num; j++) {
-        auto* craned_list = craned_lists->Add();
-        craned_list->set_control_state(crane::grpc::CranedControlState(i));
-        craned_list->set_resource_state(crane::grpc::CranedResourceState(j));
-        craned_list->set_count(craned_name_lists[i][j].size());
-        craned_list->set_craned_list_regex(
-            util::HostNameListToStr(craned_name_lists[i][j]));
+        for (int k = 0; k < power_state_num; k++) {
+          auto* craned_list = craned_lists->Add();
+          craned_list->set_control_state(crane::grpc::CranedControlState(i));
+          craned_list->set_resource_state(crane::grpc::CranedResourceState(j));
+          craned_list->set_power_state(crane::grpc::CranedPowerState(k));
+          craned_list->set_count(craned_name_lists[i][j][k].size());
+          craned_list->set_craned_list_regex(
+              util::HostNameListToStr(craned_name_lists[i][j][k]));
+        }
       }
     }
   });
@@ -784,8 +785,7 @@ crane::grpc::ModifyCranedStateReply CranedMetaContainer::ChangeNodeState(
         if (g_config.Plugin.Enabled && craned_meta->drain != true) {
           // Set node event info
           event.set_node_name(craned_id);
-          event.mutable_state()->set_control_state(
-              crane::grpc::CranedControlState::CRANE_DRAIN);
+          event.set_control_state(crane::grpc::CranedControlState::CRANE_DRAIN);
           event_list.emplace_back(event);
         }
 
@@ -797,8 +797,7 @@ crane::grpc::ModifyCranedStateReply CranedMetaContainer::ChangeNodeState(
         if (g_config.Plugin.Enabled && craned_meta->drain != false) {
           // Set node event info
           event.set_node_name(craned_id);
-          event.mutable_state()->set_control_state(
-              crane::grpc::CranedControlState::CRANE_NONE);
+          event.set_control_state(crane::grpc::CranedControlState::CRANE_NONE);
           event_list.emplace_back(event);
         }
 
@@ -963,6 +962,9 @@ void CranedMetaContainer::SetGrpcCranedInfoByCranedMeta_(
     craned_info->set_control_state(crane::grpc::CranedControlState::CRANE_NONE);
   }
 
+  // Set power state
+  craned_info->set_power_state(craned_meta.power_state);
+
   if (craned_meta.alive) {
     if (craned_meta.res_in_use.IsZero())
       craned_info->set_resource_state(
@@ -974,64 +976,13 @@ void CranedMetaContainer::SetGrpcCranedInfoByCranedMeta_(
       craned_info->set_resource_state(
           crane::grpc::CranedResourceState::CRANE_MIX);
   } else {
-    if (craned_meta.power_state == CranedPowerState::PoweredOff ||
-        craned_meta.power_state == CranedPowerState::PoweringOff ||
-        craned_meta.power_state == CranedPowerState::PoweringOn) {
-      craned_info->set_resource_state(
-          crane::grpc::CranedResourceState::CRANE_OFF);
-    } else if (craned_meta.power_state == CranedPowerState::Sleeping ||
-               craned_meta.power_state == CranedPowerState::ToSleeping ||
-               craned_meta.power_state == CranedPowerState::WakingUp) {
-      craned_info->set_resource_state(
-          crane::grpc::CranedResourceState::CRANE_SLEEPING);
-    } else {
-      craned_info->set_resource_state(
-          crane::grpc::CranedResourceState::CRANE_DOWN);
-    }
+    craned_info->set_resource_state(
+        crane::grpc::CranedResourceState::CRANE_DOWN);
   }
 
   craned_info->mutable_partition_names()->Assign(
       craned_meta.static_meta.partition_ids.begin(),
       craned_meta.static_meta.partition_ids.end());
-}
-
-bool CranedMetaContainer::UpdateCranedPowerState(
-    const CranedId& craned_id,
-    const crane::grpc::CranedPowerState& power_state) {
-  if (!craned_meta_map_.Contains(craned_id)) {
-    return false;
-  }
-
-  auto craned_meta = craned_meta_map_[craned_id];
-  switch (power_state) {
-  case crane::grpc::CranedPowerState::CRANE_POWER_ACTIVE:
-    craned_meta->power_state = CranedPowerState::Active;
-    break;
-  case crane::grpc::CranedPowerState::CRANE_POWER_IDLE:
-    craned_meta->power_state = CranedPowerState::Idle;
-    break;
-  case crane::grpc::CranedPowerState::CRANE_POWER_SLEEPING:
-    craned_meta->power_state = CranedPowerState::Sleeping;
-    break;
-  case crane::grpc::CranedPowerState::CRANE_POWER_POWEREDOFF:
-    craned_meta->power_state = CranedPowerState::PoweredOff;
-    break;
-  case crane::grpc::CranedPowerState::CRANE_POWER_TO_SLEEPING:
-    craned_meta->power_state = CranedPowerState::ToSleeping;
-    break;
-  case crane::grpc::CranedPowerState::CRANE_POWER_WAKING_UP:
-    craned_meta->power_state = CranedPowerState::WakingUp;
-    break;
-  case crane::grpc::CranedPowerState::CRANE_POWER_POWERING_ON:
-    craned_meta->power_state = CranedPowerState::PoweringOn;
-    break;
-  case crane::grpc::CranedPowerState::CRANE_POWER_POWERING_OFF:
-    craned_meta->power_state = CranedPowerState::PoweringOff;
-    break;
-  default:
-    return false;
-  }
-  return true;
 }
 
 }  // namespace Ctld

--- a/src/CraneCtld/CranedMetaContainer.h
+++ b/src/CraneCtld/CranedMetaContainer.h
@@ -103,6 +103,9 @@ class CranedMetaContainer final {
 
   bool CheckCranedOnline(const CranedId& craned_id);
 
+  bool UpdateCranedPowerState(const CranedId& craned_id,
+                              const crane::grpc::CranedPowerState& power_state);
+
   int GetOnlineCranedCount();
 
   PartitionMetaPtr GetPartitionMetasPtr(const PartitionId& partition_id);

--- a/src/CraneCtld/CranedMetaContainer.h
+++ b/src/CraneCtld/CranedMetaContainer.h
@@ -103,9 +103,6 @@ class CranedMetaContainer final {
 
   bool CheckCranedOnline(const CranedId& craned_id);
 
-  bool UpdateCranedPowerState(const CranedId& craned_id,
-                              const crane::grpc::CranedPowerState& power_state);
-
   int GetOnlineCranedCount();
 
   PartitionMetaPtr GetPartitionMetasPtr(const PartitionId& partition_id);

--- a/src/CraneCtld/CtldGrpcServer.cpp
+++ b/src/CraneCtld/CtldGrpcServer.cpp
@@ -403,18 +403,18 @@ grpc::Status CraneCtldServiceImpl::ModifyNode(
 
       const auto requested_state = request->new_state();
       const auto current_state = craned_meta->power_state;
-      if ((requested_state == crane::grpc::CRANE_POWEROFF ||
-           requested_state == crane::grpc::CRANE_SLEEP) &&
-          current_state == crane::grpc::CRANE_POWER_ACTIVE) {
+      if ((requested_state == crane::grpc::CranedControlState::CRANE_POWEROFF ||
+           requested_state == crane::grpc::CranedControlState::CRANE_SLEEP) &&
+          current_state == crane::grpc::CranedPowerState::CRANE_POWER_ACTIVE) {
         response->add_not_modified_nodes(crane_id);
         response->add_not_modified_reasons(
             "Node is running, can't sleep or poweroff");
         continue;
       }
-      if ((requested_state == crane::grpc::CRANE_WAKE ||
-           requested_state == crane::grpc::CRANE_POWERON) &&
-          (current_state == crane::grpc::CRANE_POWER_IDLE ||
-           current_state == crane::grpc::CRANE_POWER_ACTIVE)) {
+      if ((requested_state == crane::grpc::CranedControlState::CRANE_WAKE ||
+           requested_state == crane::grpc::CranedControlState::CRANE_POWERON) &&
+          (current_state == crane::grpc::CranedPowerState::CRANE_POWER_IDLE ||
+           current_state == crane::grpc::CranedPowerState::CRANE_POWER_ACTIVE)) {
         response->add_not_modified_nodes(crane_id);
         response->add_not_modified_reasons(
             "Node is idle or running, don't need to wake up or poweron");

--- a/src/CraneCtld/CtldGrpcServer.h
+++ b/src/CraneCtld/CtldGrpcServer.h
@@ -314,6 +314,11 @@ class CraneCtldServiceImpl final : public crane::grpc::CraneCtld::Service {
       const crane::grpc::DeleteReservationRequest *request,
       crane::grpc::DeleteReservationReply *response) override;
 
+  grpc::Status PowerStateChange(
+      grpc::ServerContext *context,
+      const crane::grpc::PowerStateChangeRequest *request,
+      crane::grpc::PowerStateChangeReply *response) override;
+
  private:
   CtldServer *m_ctld_server_;
 };

--- a/src/CraneCtld/CtldPublicDefs.h
+++ b/src/CraneCtld/CtldPublicDefs.h
@@ -200,6 +200,8 @@ struct CranedRemoteMeta {
   absl::Time craned_start_time;
   absl::Time system_boot_time;
 
+  std::vector<crane::grpc::NetworkInterface> network_interfaces;
+
   CranedRemoteMeta() = default;
 
   explicit CranedRemoteMeta(const crane::grpc::CranedRemoteMeta& grpc_meta)

--- a/src/CraneCtld/CtldPublicDefs.h
+++ b/src/CraneCtld/CtldPublicDefs.h
@@ -213,6 +213,11 @@ struct CranedRemoteMeta {
         absl::FromUnixSeconds(grpc_meta.craned_start_time().seconds());
     this->system_boot_time =
         absl::FromUnixSeconds(grpc_meta.system_boot_time().seconds());
+    
+    this->network_interfaces.clear();
+    for (const auto& interface : grpc_meta.network_interfaces()) {
+      this->network_interfaces.emplace_back(interface);
+    }
   }
 };
 

--- a/src/CraneCtld/CtldPublicDefs.h
+++ b/src/CraneCtld/CtldPublicDefs.h
@@ -230,7 +230,7 @@ struct CranedMeta {
   CranedRemoteMeta remote_meta;
 
   bool alive{false};
-  crane::grpc::CranedPowerState power_state{crane::grpc::CRANE_IDLE};
+  crane::grpc::CranedPowerState power_state{crane::grpc::CranedPowerState::CRANE_POWER_IDLE};
 
   // total = avail + in-use
   ResourceInNode res_total;  // A copy of res in CranedStaticMeta,

--- a/src/CraneCtld/CtldPublicDefs.h
+++ b/src/CraneCtld/CtldPublicDefs.h
@@ -213,12 +213,26 @@ struct CranedRemoteMeta {
         absl::FromUnixSeconds(grpc_meta.craned_start_time().seconds());
     this->system_boot_time =
         absl::FromUnixSeconds(grpc_meta.system_boot_time().seconds());
-    
+
     this->network_interfaces.clear();
     for (const auto& interface : grpc_meta.network_interfaces()) {
       this->network_interfaces.emplace_back(interface);
     }
   }
+};
+
+/**
+ * The power state of a Craned node.
+ */
+enum class CranedPowerState {
+  Active,
+  Idle,
+  Sleeping,
+  PoweredOff,
+  ToSleeping,
+  WakingUp,
+  PoweringOn,
+  PoweringOff
 };
 
 /**
@@ -230,6 +244,7 @@ struct CranedMeta {
   CranedRemoteMeta remote_meta;
 
   bool alive{false};
+  CranedPowerState power_state{CranedPowerState::Idle};
 
   // total = avail + in-use
   ResourceInNode res_total;  // A copy of res in CranedStaticMeta,

--- a/src/CraneCtld/CtldPublicDefs.h
+++ b/src/CraneCtld/CtldPublicDefs.h
@@ -222,20 +222,6 @@ struct CranedRemoteMeta {
 };
 
 /**
- * The power state of a Craned node.
- */
-enum class CranedPowerState {
-  Active,
-  Idle,
-  Sleeping,
-  PoweredOff,
-  ToSleeping,
-  WakingUp,
-  PoweringOn,
-  PoweringOff
-};
-
-/**
  * Represent the runtime status on a Craned node.
  * A Node is uniquely identified by (partition id, node index).
  */
@@ -244,7 +230,7 @@ struct CranedMeta {
   CranedRemoteMeta remote_meta;
 
   bool alive{false};
-  CranedPowerState power_state{CranedPowerState::Idle};
+  crane::grpc::CranedPowerState power_state{crane::grpc::CRANE_IDLE};
 
   // total = avail + in-use
   ResourceInNode res_total;  // A copy of res in CranedStaticMeta,

--- a/src/Craned/CgroupManager.cpp
+++ b/src/Craned/CgroupManager.cpp
@@ -556,7 +556,7 @@ std::unique_ptr<CgroupInterface> CgroupManager::AllocateAndGetJobCgroup(
   if (g_config.Plugin.Enabled) {
     g_plugin_client->CreateCgroupHookAsync(job.job_id,
                                            cg_unique_ptr->CgroupPathStr(),
-                                           res.dedicated_res_in_node());
+                                           res);
   }
 
   CRANE_TRACE(

--- a/src/Craned/Craned.cpp
+++ b/src/Craned/Craned.cpp
@@ -534,6 +534,7 @@ void ParseConfig(int argc, char** argv) {
 
   g_config.CranedMeta.CranedStartTime = absl::Now();
   g_config.CranedMeta.SystemBootTime = util::os::GetSystemBootTime();
+  g_config.CranedMeta.NetworkInterfaces = crane::GetNetworkInterfaces();
 }
 
 void CreateRequiredDirectories() {

--- a/src/Craned/CranedPublicDefs.h
+++ b/src/Craned/CranedPublicDefs.h
@@ -21,6 +21,7 @@
 #include "CranedPreCompiledHeader.h"
 // Precompiled header comes first
 
+#include "crane/Network.h"
 #include "crane/OS.h"
 
 namespace Craned {
@@ -89,6 +90,7 @@ struct Config {
     SystemRelInfo SysInfo;
     absl::Time CranedStartTime;
     absl::Time SystemBootTime;
+    std::vector<crane::NetworkInterface> NetworkInterfaces;
   };
 
   CranedMeta CranedMeta;

--- a/src/Craned/CtldClient.cpp
+++ b/src/Craned/CtldClient.cpp
@@ -405,6 +405,10 @@ bool CtldClient::CranedRegister_(RegToken const& token,
   grpc_meta->mutable_lost_jobs()->Assign(lost_jobs.begin(), lost_jobs.end());
   grpc_meta->mutable_lost_tasks()->Assign(lost_tasks.begin(), lost_tasks.end());
 
+  for (const auto& interface : g_config.CranedMeta.NetworkInterfaces) {
+    *grpc_meta->add_network_interfaces() = interface;
+  }
+
   grpc::ClientContext context;
   context.set_deadline(std::chrono::system_clock::now() +
                        std::chrono::seconds(1));

--- a/src/Utilities/PluginClient/PluginClient.cpp
+++ b/src/Utilities/PluginClient/PluginClient.cpp
@@ -322,25 +322,4 @@ void PluginClient::RegisterCranedHookAsync(
   m_event_queue_.enqueue(std::move(e));
 }
 
-std::optional<crane::grpc::plugin::GetCranedByPowerStateHookSyncReply>
-PluginClient::GetCranedByPowerStateHookSync(
-    crane::grpc::CranedPowerState state) {
-  grpc::ClientContext context;
-  crane::grpc::plugin::GetCranedByPowerStateHookSyncRequest request;
-  crane::grpc::plugin::GetCranedByPowerStateHookSyncReply reply;
-
-  request.set_state(state);
-
-  auto status =
-      m_stub_->GetCranedByPowerStateHookSync(&context, request, &reply);
-  if (!status.ok()) {
-    CRANE_ERROR("[Plugin] Failed to get craned list: {}; {} (code: {})",
-                context.debug_error_string(), status.error_message(),
-                int(status.error_code()));
-    return std::nullopt;
-  }
-
-  return reply;
-}
-
 }  // namespace plugin

--- a/src/Utilities/PluginClient/PluginClient.cpp
+++ b/src/Utilities/PluginClient/PluginClient.cpp
@@ -29,6 +29,7 @@
 #include <cstddef>
 #include <iterator>
 #include <memory>
+#include <optional>
 #include <string>
 #include <thread>
 #include <vector>
@@ -195,6 +196,34 @@ grpc::Status PluginClient::NodeEventHook_(grpc::ClientContext* context,
   return m_stub_->NodeEventHook(context, *request, &reply);
 }
 
+grpc::Status PluginClient::SendUpdatePowerStateHook_(
+    grpc::ClientContext* context, google::protobuf::Message* msg) {
+  using crane::grpc::plugin::UpdatePowerStateHookReply;
+  using crane::grpc::plugin::UpdatePowerStateHookRequest;
+
+  auto* request = dynamic_cast<UpdatePowerStateHookRequest*>(msg);
+  CRANE_ASSERT(request != nullptr);
+
+  UpdatePowerStateHookReply reply;
+
+  CRANE_TRACE("[Plugin] Sending UpdatePowerStateHook.");
+  return m_stub_->UpdatePowerStateHook(context, *request, &reply);
+}
+
+grpc::Status PluginClient::SendRegisterCranedHook_(
+    grpc::ClientContext* context, google::protobuf::Message* msg) {
+  using crane::grpc::plugin::RegisterCranedHookReply;
+  using crane::grpc::plugin::RegisterCranedHookRequest;
+
+  auto* request = dynamic_cast<RegisterCranedHookRequest*>(msg);
+  CRANE_ASSERT(request != nullptr);
+
+  RegisterCranedHookReply reply;
+
+  CRANE_TRACE("[Plugin] Sending RegisterCranedHook.");
+  return m_stub_->RegisterCranedHook(context, *request, &reply);
+}
+
 void PluginClient::StartHookAsync(std::vector<crane::grpc::TaskInfo> tasks) {
   auto request = std::make_unique<crane::grpc::plugin::StartHookRequest>();
   auto* task_list = request->mutable_task_info_list();
@@ -227,7 +256,7 @@ void PluginClient::EndHookAsync(std::vector<crane::grpc::TaskInfo> tasks) {
 
 void PluginClient::CreateCgroupHookAsync(
     task_id_t task_id, const std::string& cgroup,
-    const crane::grpc::DedicatedResourceInNode& resource) {
+    const crane::grpc::ResourceInNode& resource) {
   auto request =
       std::make_unique<crane::grpc::plugin::CreateCgroupHookRequest>();
   request->set_task_id(task_id);
@@ -263,6 +292,55 @@ void PluginClient::NodeEventHookAsync(
   HookEvent e{HookType::INSERT_EVENT,
               std::unique_ptr<google::protobuf::Message>(std::move(request))};
   m_event_queue_.enqueue(std::move(e));
+}
+
+void PluginClient::UpdatePowerStateHookAsync(
+    const std::string& craned_id, crane::grpc::CranedControlState state) {
+  auto request =
+      std::make_unique<crane::grpc::plugin::UpdatePowerStateHookRequest>();
+  request->set_craned_id(craned_id);
+  request->set_state(state);
+
+  HookEvent e{HookType::UPDATE_POWER_STATE,
+              std::unique_ptr<google::protobuf::Message>(std::move(request))};
+  m_event_queue_.enqueue(std::move(e));
+}
+
+void PluginClient::RegisterCranedHookAsync(
+    const std::string& craned_id,
+    const std::vector<crane::NetworkInterface>& interfaces) {
+  auto request =
+      std::make_unique<crane::grpc::plugin::RegisterCranedHookRequest>();
+  request->set_craned_id(craned_id);
+
+  for (const auto& interface : interfaces) {
+    request->mutable_network_interfaces()->Add()->CopyFrom(interface);
+  }
+
+  HookEvent e{HookType::REGISTER_CRANED,
+              std::unique_ptr<google::protobuf::Message>(std::move(request))};
+  m_event_queue_.enqueue(std::move(e));
+}
+
+std::optional<crane::grpc::plugin::GetCranedByPowerStateHookSyncReply>
+PluginClient::GetCranedByPowerStateHookSync(
+    crane::grpc::CranedPowerState state) {
+  grpc::ClientContext context;
+  crane::grpc::plugin::GetCranedByPowerStateHookSyncRequest request;
+  crane::grpc::plugin::GetCranedByPowerStateHookSyncReply reply;
+
+  request.set_state(state);
+
+  auto status =
+      m_stub_->GetCranedByPowerStateHookSync(&context, request, &reply);
+  if (!status.ok()) {
+    CRANE_ERROR("[Plugin] Failed to get craned list: {}; {} (code: {})",
+                context.debug_error_string(), status.error_message(),
+                int(status.error_code()));
+    return std::nullopt;
+  }
+
+  return reply;
 }
 
 }  // namespace plugin

--- a/src/Utilities/PluginClient/include/crane/PluginClient.h
+++ b/src/Utilities/PluginClient/include/crane/PluginClient.h
@@ -85,9 +85,6 @@ class PluginClient {
       const std::string& craned_id,
       const std::vector<crane::NetworkInterface>& interfaces);
 
-  std::optional<crane::grpc::plugin::GetCranedByPowerStateHookSyncReply>
-  GetCranedByPowerStateHookSync(crane::grpc::CranedPowerState state);
-
  private:
   // HookDispatchFunc is a function pointer type that handles different
   // event.

--- a/src/Utilities/PublicHeader/Network.cpp
+++ b/src/Utilities/PublicHeader/Network.cpp
@@ -18,6 +18,15 @@
 
 #include "crane/Network.h"
 
+#include <arpa/inet.h>
+#include <ifaddrs.h>
+#include <linux/if_packet.h>
+#include <net/if.h>
+#include <netinet/in.h>
+#include <sys/ioctl.h>
+#include <sys/socket.h>
+#include <ranges>
+
 #include "crane/Logger.h"
 
 namespace crane {
@@ -342,6 +351,128 @@ bool FindTcpInodeByPort(const std::string& tcp_path, int port, ino_t* inode) {
     CRANE_ERROR("Can't open file: {}", tcp_path);
   }
   return false;
+}
+
+std::vector<NetworkInterface> GetNetworkInterfaces() {
+  std::unordered_map<std::string, NetworkInterface> interface_map;
+  constexpr int kMaxRetries = 10;
+  constexpr int kRetryIntervalMs = 3000;  // Retry every 3 seconds
+  
+  for (int retry = 0; retry < kMaxRetries; ++retry) {
+    interface_map.clear();
+    bool has_valid_ip = false;
+    
+    struct ifaddrs *ifaddr, *ifa;
+    if (getifaddrs(&ifaddr) == -1) {
+      CRANE_ERROR("getifaddrs failed: {}", strerror(errno));
+      if (retry < kMaxRetries - 1) {
+        CRANE_WARN("Retrying to get network interfaces ({}/{})", retry + 1, kMaxRetries);
+        std::this_thread::sleep_for(std::chrono::milliseconds(kRetryIntervalMs));
+        continue;
+      }
+      return {};
+    }
+
+    for (ifa = ifaddr; ifa != nullptr; ifa = ifa->ifa_next) {
+      if (ifa->ifa_addr == nullptr) continue;
+
+      std::string if_name(ifa->ifa_name);
+
+      if (!interface_map.contains(if_name)) {
+        interface_map[if_name].name = if_name;
+      }
+
+      int family = ifa->ifa_addr->sa_family;
+
+      switch (family) {
+      case AF_INET: {  // IPv4
+        struct sockaddr_in* addr = (struct sockaddr_in*)ifa->ifa_addr;
+        ipv4_t ipv4_addr = ntohl(addr->sin_addr.s_addr);
+        // Ignore loopback address 127.0.0.1
+        if ((ipv4_addr & 0xFF000000) != 0x7F000000) {
+          has_valid_ip = true;
+        }
+        interface_map[if_name].ipv4_addresses.emplace_back(ipv4_addr);
+        break;
+      }
+      case AF_INET6: {  // IPv6
+        struct sockaddr_in6* addr = (struct sockaddr_in6*)ifa->ifa_addr;
+        ipv6_t ipv6_addr = 0;
+        for (int i = 0; i < 4; ++i) {
+          uint32_t part = ntohl(addr->sin6_addr.s6_addr32[i]);
+          ipv6_addr = (ipv6_addr << 32) | part;
+        }
+        interface_map[if_name].ipv6_addresses.emplace_back(ipv6_addr);
+        break;
+      }
+      case AF_PACKET: {  // MAC
+        struct sockaddr_ll* s = (struct sockaddr_ll*)ifa->ifa_addr;
+        if (s->sll_halen >= 6) {
+          interface_map[if_name].mac_address =
+              fmt::format("{:02x}:{:02x}:{:02x}:{:02x}:{:02x}:{:02x}",
+                          s->sll_addr[0], s->sll_addr[1], s->sll_addr[2],
+                          s->sll_addr[3], s->sll_addr[4], s->sll_addr[5]);
+        }
+        break;
+      }
+      }
+    }
+
+    freeifaddrs(ifaddr);
+    
+    // If we found at least one valid non-loopback IP address, consider network ready
+    if (has_valid_ip) {
+      CRANE_INFO("Successfully retrieved network interfaces, found {} interfaces", interface_map.size());
+      break;
+    }
+    
+    if (retry < kMaxRetries - 1) {
+      CRANE_WARN("No valid network interface IP found, waiting for network service to start ({}/{})", 
+                retry + 1, kMaxRetries);
+      std::this_thread::sleep_for(std::chrono::milliseconds(kRetryIntervalMs));
+    } else {
+      CRANE_ERROR("Failed to find valid network interface IPs after multiple attempts");
+    }
+  }
+
+  return interface_map | std::views::values | std::views::common |
+         std::ranges::to<std::vector>();
+}
+
+NetworkInterface::NetworkInterface(
+    const crane::grpc::NetworkInterface& grpc_interface) {
+  name = grpc_interface.name();
+  mac_address = grpc_interface.mac_address();
+
+  for (const auto& addr : grpc_interface.ipv4_addresses()) {
+    ipv4_t ipv4;
+    if (StrToIpv4(addr, &ipv4)) {
+      ipv4_addresses.push_back(ipv4);
+    }
+  }
+
+  for (const auto& addr : grpc_interface.ipv6_addresses()) {
+    ipv6_t ipv6;
+    if (StrToIpv6(addr, &ipv6)) {
+      ipv6_addresses.push_back(ipv6);
+    }
+  }
+}
+
+NetworkInterface::operator crane::grpc::NetworkInterface() const {
+  crane::grpc::NetworkInterface interface;
+  interface.set_name(name);
+  interface.set_mac_address(mac_address);
+
+  for (const auto& addr : ipv4_addresses) {
+    interface.add_ipv4_addresses(Ipv4ToStr(addr));
+  }
+
+  for (const auto& addr : ipv6_addresses) {
+    interface.add_ipv6_addresses(Ipv6ToStr(addr));
+  }
+
+  return interface;
 }
 
 }  // namespace crane

--- a/src/Utilities/PublicHeader/include/crane/Network.h
+++ b/src/Utilities/PublicHeader/include/crane/Network.h
@@ -33,10 +33,24 @@
 #include <fstream>
 #include <string>
 
+#include "protos/PublicDefs.pb.h"
+
 using ipv4_t = uint32_t;
 using ipv6_t = absl::uint128;
 
 namespace crane {
+
+struct NetworkInterface {
+  std::string name;
+  std::string mac_address;
+  std::vector<ipv4_t> ipv4_addresses;
+  std::vector<ipv6_t> ipv6_addresses;
+
+  NetworkInterface() = default;
+  explicit NetworkInterface(
+      const crane::grpc::NetworkInterface& grpc_interface);
+  operator crane::grpc::NetworkInterface() const;
+};
 
 void InitializeNetworkFunctions();
 
@@ -62,5 +76,7 @@ std::string Ipv6ToStr(const ipv6_t& addr);
 int GetIpAddrVer(const std::string& ip);
 
 bool FindTcpInodeByPort(const std::string& tcp_path, int port, ino_t* inode);
+
+std::vector<NetworkInterface> GetNetworkInterfaces();
 
 }  // namespace crane


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced power state management for nodes, including new power state types and the ability to modify node power states (e.g., sleep, power off, wake, power on).
  - Added support for registering and displaying detailed network interface information for nodes.
  - Enhanced filtering capabilities to allow users to filter nodes by power state in cluster queries.
  - Added new RPC methods to update power states and register nodes with network interfaces.

- **Improvements**
  - Extended plugin integration to support power state updates and node registration with network details.
  - Improved network interface detection and integration during node registration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->