### PR TITLE
Dev/qos limit

### DIFF
--- a/protos/PublicDefs.proto
+++ b/protos/PublicDefs.proto
@@ -448,6 +448,7 @@ enum ErrCode {
   ERR_USER_NO_PRIVILEGE = 66;
   ERR_NOT_IN_ALLOWED_LIST = 67;  // The current account is not in the allowed account list for the partition.
   ERR_IN_DENIED_LIST = 68;       // The current account has been explicitly added to the deny list for the partition.
+  ERR_MAX_JOB_COUNT_PER_ACCOUNT = 69;
 }
 
 enum EntityType {

--- a/protos/PublicDefs.proto
+++ b/protos/PublicDefs.proto
@@ -476,6 +476,9 @@ enum ModifyField {
   MaxJobsPerUser = 31;
   MaxCpusPerUser = 32;
   MaxTimeLimitPerTask = 33;
+  MaxJobsPerAccount = 34;
+  MaxSubmitJobsPerUser = 35;
+  MaxSubmitJobsPerAccount = 36;
 }
 
 message AccountInfo {
@@ -529,6 +532,9 @@ message QosInfo {
   uint32 max_jobs_per_user = 4;
   uint32 max_cpus_per_user = 5;
   uint64 max_time_limit_per_task = 6;
+  uint32 max_jobs_per_account = 7;
+  uint32 max_submit_jobs_per_user = 8;
+  uint32 max_submit_jobs_per_account = 9;
 }
 
 message TimeInterval {

--- a/src/CraneCtld/AccountManager.cpp
+++ b/src/CraneCtld/AccountManager.cpp
@@ -968,8 +968,17 @@ CraneExpected<void> AccountManager::ModifyQos(
   case crane::grpc::ModifyField::MaxJobsPerUser:
     item = "max_jobs_per_user";
     break;
+  case crane::grpc::ModifyField::MaxJobsPerAccount:
+    item = "max_jobs_per_account";
+    break;
   case crane::grpc::ModifyField::MaxCpusPerUser:
     item = "max_cpus_per_user";
+    break;
+  case crane::grpc::ModifyField::MaxSubmitJobsPerUser:
+    item = "max_submit_jobs_per_user";
+    break;
+  case crane::grpc::ModifyField::MaxSubmitJobsPerAccount:
+    item = "max_submit_jobs_per_account";
     break;
   case crane::grpc::ModifyField::MaxTimeLimitPerTask:
     item = "max_time_limit_per_task";

--- a/src/CraneCtld/AccountManager.cpp
+++ b/src/CraneCtld/AccountManager.cpp
@@ -2019,6 +2019,8 @@ CraneExpected<void> AccountManager::DeleteAccount_(const Account& account) {
     m_qos_map_[qos]->reference_count--;
   }
 
+  g_account_meta_container->DeleteAccountResource(name);
+
   return {};
 }
 

--- a/src/CraneCtld/AccountManager.cpp
+++ b/src/CraneCtld/AccountManager.cpp
@@ -1185,7 +1185,7 @@ CraneExpected<void> AccountManager::CheckAndApplyQosLimitOnTask(
   auto result = g_account_meta_container->CheckAndMallocQosResourceFromUser(
       user_share_ptr->name, *task, *qos_share_ptr);
   if (result != CraneErrCode::SUCCESS) {
-    CRANE_ERROR("The requested QoS resources have reached the user's limit.");
+    CRANE_TRACE("The requested QoS resources have reached the user's limit.");
     return std::unexpected(result);
   }
 
@@ -1980,7 +1980,7 @@ CraneExpected<void> AccountManager::DeleteUser_(const User& user,
     m_account_map_[coordinatorAccount]->coordinators.remove(name);
   }
 
-  g_account_meta_container->DeleteUserResource(name);
+  if (res_user.deleted) g_account_meta_container->DeleteUserResource(name);
 
   m_user_map_[name] = std::make_unique<User>(std::move(res_user));
 

--- a/src/CraneCtld/AccountManager.cpp
+++ b/src/CraneCtld/AccountManager.cpp
@@ -1192,12 +1192,14 @@ CraneExpected<void> AccountManager::CheckAndApplyQosLimitOnTask(
     return std::unexpected(CraneErrCode::ERR_TIME_TIMIT_BEYOND);
   }
 
-  auto result = g_account_meta_container->CheckAndMallocQosSubmitResource(
+  auto result = g_account_meta_container->CheckQosSubmitResource(
       *task, *qos_share_ptr, m_account_map_);
   if (!result) {
     CRANE_DEBUG("The requested QoS resources have reached the user's limit.");
     return std::unexpected(result.error());
   }
+
+  g_account_meta_container->MallocQosSubmitResource(*task, m_account_map_);
 
   return {};
 }

--- a/src/CraneCtld/AccountManager.cpp
+++ b/src/CraneCtld/AccountManager.cpp
@@ -1185,7 +1185,7 @@ CraneExpected<void> AccountManager::CheckAndApplyQosLimitOnTask(
   auto result = g_account_meta_container->CheckAndMallocQosResourceFromUser(
       user_share_ptr->name, *task, *qos_share_ptr);
   if (result != CraneErrCode::SUCCESS) {
-    CRANE_TRACE("The requested QoS resources have reached the user's limit.");
+    CRANE_DEBUG("The requested QoS resources have reached the user's limit.");
     return std::unexpected(result);
   }
 

--- a/src/CraneCtld/AccountMetaContainer.cpp
+++ b/src/CraneCtld/AccountMetaContainer.cpp
@@ -210,18 +210,22 @@ bool AccountMetaContainer::CheckQosResourceForUser_(const TaskInCtld& task,
       [&](std::pair<const std::string, QosToResourceMap>& pair) {
         auto& val = pair.second[task.qos];
         if (val.jobs_count >= qos.max_jobs_per_user) {
-          CRANE_DEBUG("User {} has reached the maximum number of jobs per user, task "
-                "{} continues pending.", task.Username(), task.TaskId());
+          CRANE_DEBUG(
+              "User {} has reached the maximum number of jobs per user, task "
+              "{} continues pending.",
+              task.Username(), task.TaskId());
           result = false;
           return;
         }
         if (val.resource.CpuCount() + static_cast<double>(task.cpus_per_task) >
-              qos.max_cpus_per_user) {
-          CRANE_DEBUG("User {} has reached the maximum number of cpus per user, task "
-        "{} continues pending.",task.Username(), task.TaskId());
+            qos.max_cpus_per_user) {
+          CRANE_DEBUG(
+              "User {} has reached the maximum number of cpus per user, task "
+              "{} continues pending.",
+              task.Username(), task.TaskId());
           result = false;
         }
-  });
+      });
 
   return result;
 }

--- a/src/CraneCtld/AccountMetaContainer.cpp
+++ b/src/CraneCtld/AccountMetaContainer.cpp
@@ -18,108 +18,58 @@
 
 #include "AccountMetaContainer.h"
 
-#include "AccountManager.h"
-
 namespace Ctld {
 
-CraneErrCode AccountMetaContainer::CheckAndMallocQosResourceFromUser(
-    const std::string& username, const TaskInCtld& task, const Qos& qos) {
+CraneExpected<void> AccountMetaContainer::CheckAndMallocQosSubmitResource(
+    const TaskInCtld& task, const Qos& qos,
+    const std::unordered_map<std::string, std::unique_ptr<Account>>&
+        account_map) {
   if (static_cast<double>(task.cpus_per_task) > qos.max_cpus_per_user)
-    return CraneErrCode::ERR_CPUS_PER_TASK_BEYOND;
+    return std::unexpected(CraneErrCode::ERR_CPUS_PER_TASK_BEYOND);
 
-  if (qos.max_submit_jobs_per_user == 0 || qos.max_submit_jobs_per_account == 0)
-    return CraneErrCode::ERR_MAX_JOB_COUNT_PER_USER;
+  if (qos.max_submit_jobs_per_user == 0)
+    return std::unexpected(CraneErrCode::ERR_MAX_JOB_COUNT_PER_USER);
 
-  CraneErrCode result = CraneErrCode::SUCCESS;
+  if (qos.max_submit_jobs_per_account == 0)
+    return std::unexpected(CraneErrCode::ERR_MAX_JOB_COUNT_PER_ACCOUNT);
 
-  QosResource qos_resource{ResourceView{}, 0, 1};
+  CraneExpected<void> result{};
 
-  user_meta_map_.try_emplace_l(
-      username,
-      [&](std::pair<const std::string, QosToResourceMap>& pair) {
-        auto& qos_to_resource_map = pair.second;
-        auto iter = qos_to_resource_map.find(task.qos);
-        if (iter == qos_to_resource_map.end()) {
-          qos_to_resource_map.emplace(task.qos, std::move(qos_resource));
-          return;
-        }
+  result = CheckAndMallocQosSubmitResourceForUser_(task, qos);
+  if (!result) return result;
 
-        auto& val = iter->second;
-        if (val.submit_jobs_count >= qos.max_submit_jobs_per_user) {
-          result = CraneErrCode::ERR_MAX_JOB_COUNT_PER_USER;
-          return;
-        }
-        val.submit_jobs_count++;
-      },
-      QosToResourceMap{{task.qos, std::move(qos_resource)}});
+  result = CheckAndMallocQosSubmitResourceForAccount_(task, qos, account_map);
+  if (!result) return result;
 
   return result;
 }
 
-bool AccountMetaContainer::CheckQosResource(const std::string& username,
-                                            const TaskInCtld& task) {
+bool AccountMetaContainer::CheckQosResource(const TaskInCtld& task) {
   bool result = true;
+  Qos qos;
 
-  const auto qos_ptr = g_account_manager->GetExistedQosInfo(task.qos);
+  {
+    const auto qos_ptr = g_account_manager->GetExistedQosInfo(task.qos);
+    qos = *qos_ptr;
+  }
 
-  user_meta_map_.modify_if(
-      username, [&](std::pair<const std::string, QosToResourceMap>& pair) {
-        auto& val = pair.second[task.qos];
-        if (val.jobs_count >= qos_ptr->max_jobs_per_user) {
-          CRANE_DEBUG(
-              "User {} has reached the maximum number of jobs per user, task "
-              "{} continues pending.",
-              username, task.TaskId());
-          result = false;
-          return;
-          if (val.resource.CpuCount() +
-                  static_cast<double>(task.cpus_per_task) >
-              qos_ptr->max_cpus_per_user) {
-            CRANE_DEBUG(
-                "User {} has reached the maximum number of cpus per user, task "
-                "{} continues pending.",
-                username, task.TaskId());
-            result = false;
-            return;
-          }
-        }
-      });
-
-  return result;
+  return CheckQosResourceForUser_(task, qos) &&
+         CheckQosResourceForAccount_(task, qos);
 }
 
-void AccountMetaContainer::MallocQosResource(const std::string& username,
-                                             const TaskInCtld& task) {
-  const auto qos_ptr = g_account_manager->GetExistedQosInfo(task.qos);
-
-  user_meta_map_.modify_if(
-      username, [&](std::pair<const std::string, QosToResourceMap>& pair) {
-        auto& val = pair.second[task.qos];
-        val.jobs_count++;
-        val.resource.GetAllocatableRes() +=
-            (task.requested_node_res_view * task.node_num).GetAllocatableRes();
-      });
+void AccountMetaContainer::MallocQosResource(const TaskInCtld& task) {
+  MallocQosResourceForUser_(task);
+  MallocQosResourceForAccount_(task);
 }
 
-void AccountMetaContainer::FreeQosSubmitResource(const std::string& username,
-                                                 const TaskInCtld& task) {
-  user_meta_map_.modify_if(
-      username, [&](std::pair<const std::string, QosToResourceMap>& pair) {
-        auto& val = pair.second[task.qos];
-        val.submit_jobs_count--;
-      });
+void AccountMetaContainer::FreeQosSubmitResource(const TaskInCtld& task) {
+  FreeQosSubmitResourceForUser_(task);
+  FreeQosSubmitResourceForAccount_(task);
 }
 
-void AccountMetaContainer::FreeQosResource(const std::string& username,
-                                           const TaskInCtld& task) {
-  user_meta_map_.modify_if(
-      username, [&](std::pair<const std::string, QosToResourceMap>& pair) {
-        auto& val = pair.second[task.qos];
-        val.resource.GetAllocatableRes() -=
-            (task.requested_node_res_view * task.node_num).GetAllocatableRes();
-        val.jobs_count--;
-        val.submit_jobs_count--;
-      });
+void AccountMetaContainer::FreeQosResource(const TaskInCtld& task) {
+  FreeQosResourceForUser_(task);
+  FreeQosResourceForAccount_(task);
 }
 
 void AccountMetaContainer::DeleteUserResource(const std::string& username) {
@@ -130,11 +80,230 @@ void AccountMetaContainer::DeleteAccountResource(const std::string& account) {
   account_meta_map_.erase(account);
 }
 
-CraneErrCode AccountMetaContainer::CheckAndMallocQosResourceFromAccount_(
+CraneExpected<void>
+AccountMetaContainer::CheckAndMallocQosSubmitResourceForUser_(
     const TaskInCtld& task, const Qos& qos) {
-  CraneErrCode result = CraneErrCode::SUCCESS;
+  QosResource qos_resource{ResourceView{}, 0, 1};
+
+  CraneExpected<void> result{};
+
+  user_meta_map_.try_emplace_l(
+      task.Username(),
+      [&](std::pair<const std::string, QosToResourceMap>& pair) {
+        auto& qos_to_resource_map = pair.second;
+        auto iter = qos_to_resource_map.find(task.qos);
+        if (iter == qos_to_resource_map.end()) {
+          qos_to_resource_map.emplace(task.qos, std::move(qos_resource));
+          return;
+        }
+
+        auto& val = iter->second;
+        if (val.submit_jobs_count >= qos.max_submit_jobs_per_user) {
+          result = std::unexpected(CraneErrCode::ERR_MAX_JOB_COUNT_PER_USER);
+          return;
+        }
+        val.submit_jobs_count++;
+      },
+      QosToResourceMap{{task.qos, std::move(qos_resource)}});
 
   return result;
+}
+
+CraneExpected<void>
+AccountMetaContainer::CheckAndMallocQosSubmitResourceForAccount_(
+    const TaskInCtld& task, const Qos& qos,
+    const std::unordered_map<std::string, std::unique_ptr<Account>>&
+        account_map) {
+  CraneExpected<void> result{};
+
+  std::string account_name = task.account;
+
+  QosResource qos_resource{ResourceView{}, 0, 1};
+
+  do {
+    account_meta_map_.try_emplace_l(
+        account_name,
+        [&](std::pair<const std::string, QosToResourceMap>& pair) {
+          auto& qos_to_resource_map = pair.second;
+          auto iter = qos_to_resource_map.find(task.qos);
+          if (iter == qos_to_resource_map.end()) {
+            qos_to_resource_map.emplace(task.qos, std::move(qos_resource));
+            return;
+          }
+
+          auto& val = iter->second;
+          if (val.submit_jobs_count >= qos.max_submit_jobs_per_account) {
+            result =
+                std::unexpected(CraneErrCode::ERR_MAX_JOB_COUNT_PER_ACCOUNT);
+            return;
+          }
+          val.submit_jobs_count++;
+        },
+        QosToResourceMap{{task.qos, std::move(qos_resource)}});
+
+    account_name = account_map.at(account_name)->parent_account;
+  } while (!account_name.empty());
+
+  return result;
+}
+
+bool AccountMetaContainer::CheckQosResourceForUser_(const TaskInCtld& task,
+                                                    const Qos& qos) {
+  bool result = true;
+
+  user_meta_map_.modify_if(
+      task.Username(),
+      [&](std::pair<const std::string, QosToResourceMap>& pair) {
+        auto& val = pair.second[task.qos];
+        if (val.jobs_count >= qos.max_jobs_per_user) {
+          CRANE_DEBUG(
+              "User {} has reached the maximum number of jobs per user, task "
+              "{} continues pending.",
+              task.Username(), task.TaskId());
+          result = false;
+          return;
+          if (val.resource.CpuCount() +
+                  static_cast<double>(task.cpus_per_task) >
+              qos.max_cpus_per_user) {
+            CRANE_DEBUG(
+                "User {} has reached the maximum number of cpus per user, task "
+                "{} continues pending.",
+                task.Username(), task.TaskId());
+            result = false;
+            return;
+          }
+        }
+      });
+
+  return result;
+}
+
+bool AccountMetaContainer::CheckQosResourceForAccount_(const TaskInCtld& task,
+                                                       const Qos& qos) {
+  bool result = true;
+  std::string account_name = task.account;
+
+  const auto account_map_ptr = g_account_manager->GetAllAccountInfo();
+
+  do {
+    account_meta_map_.modify_if(account_name, [&](std::pair<const std::string,
+                                                            QosToResourceMap>&
+                                                      pair) {
+      auto& val = pair.second[task.qos];
+      if (val.jobs_count >= qos.max_jobs_per_account) {
+        CRANE_DEBUG(
+            "Account {} has reached the maximum number of jobs per account, "
+            "task {} continues pending.",
+            account_name, task.TaskId());
+        result = false;
+        return;
+        if (val.resource.CpuCount() + static_cast<double>(task.cpus_per_task) >
+            qos.max_cpus_per_account) {
+          CRANE_DEBUG(
+              "Account {} has reached the maximum number of cpus per account, "
+              "task {} continues pending.",
+              account_name, task.TaskId());
+          result = false;
+          return;
+        }
+      }
+    });
+
+    if (!result) break;
+
+    account_name = account_map_ptr->at(account_name)->parent_account;
+
+  } while (!account_name.empty());
+
+  return result;
+}
+
+void AccountMetaContainer::MallocQosResourceForUser_(const TaskInCtld& task) {
+  user_meta_map_.modify_if(
+      task.Username(),
+      [&](std::pair<const std::string, QosToResourceMap>& pair) {
+        auto& val = pair.second[task.qos];
+        val.jobs_count++;
+        val.resource.GetAllocatableRes() +=
+            (task.requested_node_res_view * task.node_num).GetAllocatableRes();
+      });
+}
+
+void AccountMetaContainer::MallocQosResourceForAccount_(
+    const TaskInCtld& task) {
+  std::string account_name = task.account;
+  const auto account_map_ptr = g_account_manager->GetAllAccountInfo();
+
+  do {
+    account_meta_map_.modify_if(
+        account_name,
+        [&](std::pair<const std::string, QosToResourceMap>& pair) {
+          auto& val = pair.second[task.qos];
+          val.jobs_count++;
+          val.resource.GetAllocatableRes() +=
+              (task.requested_node_res_view * task.node_num)
+                  .GetAllocatableRes();
+        });
+
+    account_name = account_map_ptr->at(account_name)->parent_account;
+  } while (!account_name.empty());
+}
+
+void AccountMetaContainer::FreeQosSubmitResourceForUser_(
+    const TaskInCtld& task) {
+  user_meta_map_.modify_if(
+      task.Username(),
+      [&](std::pair<const std::string, QosToResourceMap>& pair) {
+        auto& val = pair.second[task.qos];
+        val.submit_jobs_count--;
+      });
+}
+
+void AccountMetaContainer::FreeQosSubmitResourceForAccount_(
+    const TaskInCtld& task) {
+  std::string account_name = task.account;
+  const auto account_map_ptr = g_account_manager->GetAllAccountInfo();
+
+  do {
+    account_meta_map_.modify_if(
+        account_name,
+        [&](std::pair<const std::string, QosToResourceMap>& pair) {
+          auto& val = pair.second[task.qos];
+          val.submit_jobs_count--;
+        });
+    account_name = account_map_ptr->at(account_name)->parent_account;
+  } while (!account_name.empty());
+}
+
+void AccountMetaContainer::FreeQosResourceForUser_(const TaskInCtld& task) {
+  user_meta_map_.modify_if(
+      task.Username(),
+      [&](std::pair<const std::string, QosToResourceMap>& pair) {
+        auto& val = pair.second[task.qos];
+        val.resource.GetAllocatableRes() -=
+            (task.requested_node_res_view * task.node_num).GetAllocatableRes();
+        val.jobs_count--;
+        val.submit_jobs_count--;
+      });
+}
+
+void AccountMetaContainer::FreeQosResourceForAccount_(const TaskInCtld& task) {
+  std::string account_name = task.account;
+  const auto account_map_ptr = g_account_manager->GetAllAccountInfo();
+
+  do {
+    account_meta_map_.modify_if(
+        account_name,
+        [&](std::pair<const std::string, QosToResourceMap>& pair) {
+          auto& val = pair.second[task.qos];
+          val.resource.GetAllocatableRes() -=
+              (task.requested_node_res_view * task.node_num)
+                  .GetAllocatableRes();
+          val.jobs_count--;
+          val.submit_jobs_count--;
+        });
+    account_name = account_map_ptr->at(account_name)->parent_account;
+  } while (!account_name.empty());
 }
 
 }  // namespace Ctld

--- a/src/CraneCtld/AccountMetaContainer.cpp
+++ b/src/CraneCtld/AccountMetaContainer.cpp
@@ -253,16 +253,6 @@ bool AccountMetaContainer::CheckQosResourceForAccount_(const TaskInCtld& task,
             "task {} continues pending.",
             account_name, task.TaskId());
         result = false;
-        return;
-        if (val.resource.CpuCount() + static_cast<double>(task.cpus_per_task) >
-            qos.max_cpus_per_account) {
-          CRANE_DEBUG(
-              "Account {} has reached the maximum number of cpus per account, "
-              "task {} continues pending.",
-              account_name, task.TaskId());
-          result = false;
-          return;
-        }
       }
     });
 

--- a/src/CraneCtld/AccountMetaContainer.cpp
+++ b/src/CraneCtld/AccountMetaContainer.cpp
@@ -27,7 +27,7 @@ CraneErrCode AccountMetaContainer::CheckAndMallocQosResourceFromUser(
   if (static_cast<double>(task.cpus_per_task) > qos.max_cpus_per_user)
     return CraneErrCode::ERR_CPUS_PER_TASK_BEYOND;
 
-  if (qos.max_submit_jobs_per_user == 0)
+  if (qos.max_submit_jobs_per_user == 0 || qos.max_submit_jobs_per_account == 0)
     return CraneErrCode::ERR_MAX_JOB_COUNT_PER_USER;
 
   CraneErrCode result = CraneErrCode::SUCCESS;
@@ -124,6 +124,17 @@ void AccountMetaContainer::FreeQosResource(const std::string& username,
 
 void AccountMetaContainer::DeleteUserResource(const std::string& username) {
   user_meta_map_.erase(username);
+}
+
+void AccountMetaContainer::DeleteAccountResource(const std::string& account) {
+  account_meta_map_.erase(account);
+}
+
+CraneErrCode AccountMetaContainer::CheckAndMallocQosResourceFromAccount_(
+    const TaskInCtld& task, const Qos& qos) {
+  CraneErrCode result = CraneErrCode::SUCCESS;
+
+  return result;
 }
 
 }  // namespace Ctld

--- a/src/CraneCtld/AccountMetaContainer.h
+++ b/src/CraneCtld/AccountMetaContainer.h
@@ -42,6 +42,13 @@ class AccountMetaContainer final {
                                                  const TaskInCtld& task,
                                                  const Qos& qos);
 
+  bool CheckQosResource(const std::string& username, const TaskInCtld& task);
+
+  void MallocQosResource(const std::string& username, const TaskInCtld& task);
+
+  void FreeQosSubmitResource(const std::string& username,
+                             const TaskInCtld& task);
+
   void FreeQosResource(const std::string& username, const TaskInCtld& task);
 
   void DeleteUserResource(const std::string& username);

--- a/src/CraneCtld/AccountMetaContainer.h
+++ b/src/CraneCtld/AccountMetaContainer.h
@@ -18,14 +18,13 @@
 
 #pragma once
 
-#include <memory>
-#include <shared_mutex>
-#include <string>
-
 #include "CtldPublicDefs.h"
+// Precompiled header comes first!
+
+#include "AccountManager.h"
+#include "crane/PublicHeader.h"
 #include "parallel_hashmap/phmap.h"
 #include "parallel_hashmap/phmap_fwd_decl.h"
-// Precompiled header comes first!
 
 namespace Ctld {
 
@@ -51,18 +50,18 @@ class AccountMetaContainer final {
   AccountMetaContainer() = default;
   ~AccountMetaContainer() = default;
 
-  CraneErrCode CheckAndMallocQosResourceFromUser(const std::string& username,
-                                                 const TaskInCtld& task,
-                                                 const Qos& qos);
+  CraneExpected<void> CheckAndMallocQosSubmitResource(
+      const TaskInCtld& task, const Qos& qos,
+      const std::unordered_map<std::string, std::unique_ptr<Account>>&
+          account_map);
 
-  bool CheckQosResource(const std::string& username, const TaskInCtld& task);
+  bool CheckQosResource(const TaskInCtld& task);
 
-  void MallocQosResource(const std::string& username, const TaskInCtld& task);
+  void MallocQosResource(const TaskInCtld& task);
 
-  void FreeQosSubmitResource(const std::string& username,
-                             const TaskInCtld& task);
+  void FreeQosSubmitResource(const TaskInCtld& task);
 
-  void FreeQosResource(const std::string& username, const TaskInCtld& task);
+  void FreeQosResource(const TaskInCtld& task);
 
   void DeleteUserResource(const std::string& username);
 
@@ -73,16 +72,29 @@ class AccountMetaContainer final {
 
   AccountResourceMetaMap account_meta_map_;
 
-  CraneErrCode CheckAndMallocQosResourceFromAccount_(const TaskInCtld& task,
-                                                     const Qos& qos);
+  CraneExpected<void> CheckAndMallocQosSubmitResourceForUser_(
+      const TaskInCtld& task, const Qos& qos);
 
-  bool CheckQosResourceFromAccount_(const TaskInCtld& task);
+  CraneExpected<void> CheckAndMallocQosSubmitResourceForAccount_(
+      const TaskInCtld& task, const Qos& qos,
+      const std::unordered_map<std::string, std::unique_ptr<Account>>&
+          account_map);
 
-  void MallocQosResourceFromAccount_(const TaskInCtld& task);
+  bool CheckQosResourceForUser_(const TaskInCtld& task, const Qos& qos);
 
-  void FreeQosSubmitResourceFromAccount_(const TaskInCtld& task);
+  bool CheckQosResourceForAccount_(const TaskInCtld& task, const Qos& qos);
 
-  void FreeQosResourceFromAccount_(const TaskInCtld& task);
+  void MallocQosResourceForUser_(const TaskInCtld& task);
+
+  void MallocQosResourceForAccount_(const TaskInCtld& task);
+
+  void FreeQosSubmitResourceForUser_(const TaskInCtld& task);
+
+  void FreeQosSubmitResourceForAccount_(const TaskInCtld& task);
+
+  void FreeQosResourceForUser_(const TaskInCtld& task);
+
+  void FreeQosResourceForAccount_(const TaskInCtld& task);
 };
 
 inline std::unique_ptr<Ctld::AccountMetaContainer> g_account_meta_container;

--- a/src/CraneCtld/AccountMetaContainer.h
+++ b/src/CraneCtld/AccountMetaContainer.h
@@ -50,16 +50,21 @@ class AccountMetaContainer final {
   AccountMetaContainer() = default;
   ~AccountMetaContainer() = default;
 
-  CraneExpected<void> CheckAndMallocQosSubmitResource(
+  CraneExpected<void> CheckQosSubmitResource(
       const TaskInCtld& task, const Qos& qos,
       const std::unordered_map<std::string, std::unique_ptr<Account>>&
           account_map);
 
+  void MallocQosSubmitResource(
+      const TaskInCtld& task,
+      const std::unordered_map<std::string, std::unique_ptr<Account>>&
+          account_map);
+
+  void FreeQosSubmitResource(const TaskInCtld& task);
+
   bool CheckQosResource(const TaskInCtld& task);
 
   void MallocQosResource(const TaskInCtld& task);
-
-  void FreeQosSubmitResource(const TaskInCtld& task);
 
   void FreeQosResource(const TaskInCtld& task);
 
@@ -72,13 +77,24 @@ class AccountMetaContainer final {
 
   AccountResourceMetaMap account_meta_map_;
 
-  CraneExpected<void> CheckAndMallocQosSubmitResourceForUser_(
-      const TaskInCtld& task, const Qos& qos);
+  CraneExpected<void> CheckQosSubmitResourceForUser_(const TaskInCtld& task,
+                                                     const Qos& qos);
 
-  CraneExpected<void> CheckAndMallocQosSubmitResourceForAccount_(
+  CraneExpected<void> CheckQosSubmitResourceForAccount_(
       const TaskInCtld& task, const Qos& qos,
       const std::unordered_map<std::string, std::unique_ptr<Account>>&
           account_map);
+
+  void MallocQosSubmitResourceForUser_(const TaskInCtld& task);
+
+  void MallocQosSubmitResourceForAccount_(
+      const TaskInCtld& task,
+      const std::unordered_map<std::string, std::unique_ptr<Account>>&
+          account_map);
+
+  void FreeQosSubmitResourceForUser_(const TaskInCtld& task);
+
+  void FreeQosSubmitResourceForAccount_(const TaskInCtld& task);
 
   bool CheckQosResourceForUser_(const TaskInCtld& task, const Qos& qos);
 
@@ -87,10 +103,6 @@ class AccountMetaContainer final {
   void MallocQosResourceForUser_(const TaskInCtld& task);
 
   void MallocQosResourceForAccount_(const TaskInCtld& task);
-
-  void FreeQosSubmitResourceForUser_(const TaskInCtld& task);
-
-  void FreeQosSubmitResourceForAccount_(const TaskInCtld& task);
 
   void FreeQosResourceForUser_(const TaskInCtld& task);
 

--- a/src/CraneCtld/CtldGrpcServer.cpp
+++ b/src/CraneCtld/CtldGrpcServer.cpp
@@ -535,6 +535,9 @@ grpc::Status CraneCtldServiceImpl::AddQos(
       qos_info->priority() == 0 ? kDefaultQosPriority : qos_info->priority();
   qos.max_jobs_per_user = qos_info->max_jobs_per_user();
   qos.max_cpus_per_user = qos_info->max_cpus_per_user();
+  qos.max_jobs_per_account = qos_info->max_jobs_per_account();
+  qos.max_submit_jobs_per_user = qos_info->max_submit_jobs_per_user();
+  qos.max_submit_jobs_per_account = qos_info->max_submit_jobs_per_account();
 
   int64_t sec = qos_info->max_time_limit_per_task();
   if (!CheckIfTimeLimitSecIsValid(sec)) {
@@ -983,7 +986,10 @@ grpc::Status CraneCtldServiceImpl::QueryQosInfo(
     qos_info->set_description(qos.description);
     qos_info->set_priority(qos.priority);
     qos_info->set_max_jobs_per_user(qos.max_jobs_per_user);
+    qos_info->set_max_jobs_per_account(qos.max_jobs_per_account);
     qos_info->set_max_cpus_per_user(qos.max_cpus_per_user);
+    qos_info->set_max_submit_jobs_per_user(qos.max_submit_jobs_per_user);
+    qos_info->set_max_submit_jobs_per_account(qos.max_submit_jobs_per_account);
     qos_info->set_max_time_limit_per_task(
         absl::ToInt64Seconds(qos.max_time_limit_per_task));
   }

--- a/src/CraneCtld/CtldGrpcServer.cpp
+++ b/src/CraneCtld/CtldGrpcServer.cpp
@@ -1524,7 +1524,7 @@ CraneExpected<std::future<task_id_t>> CtldServer::SubmitTaskToScheduler(
     return {std::move(future)};
   }
 
-  g_account_meta_container->FreeQosSubmitResource(task->Username(), *task);
+  g_account_meta_container->FreeQosSubmitResource(*task);
 
   return std::unexpected(result.error());
 }

--- a/src/CraneCtld/CtldPublicDefs.h
+++ b/src/CraneCtld/CtldPublicDefs.h
@@ -701,10 +701,13 @@ struct Qos {
   uint32_t reference_count = 0;
   uint32_t priority;
   uint32_t max_jobs_per_user;
+  uint32_t max_jobs_per_account;
   uint32_t max_running_tasks_per_user;
   absl::Duration max_time_limit_per_task;
   uint32_t max_cpus_per_user;
   uint32_t max_cpus_per_account;
+  uint32_t max_submit_jobs_per_user;
+  uint32_t max_submit_jobs_per_account;
 
   static constexpr const char* FieldStringOfDeleted() { return "deleted"; }
   static constexpr const char* FieldStringOfName() { return "name"; }
@@ -718,6 +721,9 @@ struct Qos {
   static constexpr const char* FieldStringOfMaxJobsPerUser() {
     return "max_jobs_per_user";
   }
+  static constexpr const char* FieldStringOfMaxJobsPerAccount() {
+    return "max_jobs_per_account";
+  }
   static constexpr const char* FieldStringOfMaxTimeLimitPerTask() {
     return "max_time_limit_per_task";
   }
@@ -726,6 +732,12 @@ struct Qos {
   }
   static constexpr const char* FieldStringOfMaxCpusPerAccount() {
     return "max_cpus_per_account";
+  }
+  static constexpr const char* FieldStringOfMaxSubmitJobsPerUser() {
+    return "max_submit_jobs_per_user";
+  }
+  static constexpr const char* FieldStringOfMaxSubmitJobsPerAccount() {
+    return "max_submit_jobs_per_account";
   }
 };
 

--- a/src/CraneCtld/CtldPublicDefs.h
+++ b/src/CraneCtld/CtldPublicDefs.h
@@ -802,7 +802,8 @@ inline bool CheckIfTimeLimitIsValid(absl::Duration d) {
 
 struct QosResource {
   ResourceView resource;
-  uint32_t jobs_per_user;
+  uint32_t jobs_count;
+  uint32_t submit_jobs_count;
 };
 
 }  // namespace Ctld

--- a/src/CraneCtld/DbClient.cpp
+++ b/src/CraneCtld/DbClient.cpp
@@ -785,7 +785,7 @@ void MongodbClient::ViewToQos_(const bsoncxx::document::view& qos_view,
     qos->max_submit_jobs_per_user =
         qos_view[Qos::FieldStringOfMaxSubmitJobsPerUser()].get_int64().value;
     qos->max_submit_jobs_per_account =
-        qos_view[Qos::FieldStringOfMaxJobsPerAccount()].get_int64().value;
+        qos_view[Qos::FieldStringOfMaxSubmitJobsPerAccount()].get_int64().value;
     qos->max_time_limit_per_task = absl::Seconds(
         qos_view[Qos::FieldStringOfMaxTimeLimitPerTask()].get_int64().value);
   } catch (const bsoncxx::exception& e) {

--- a/src/CraneCtld/DbClient.cpp
+++ b/src/CraneCtld/DbClient.cpp
@@ -778,8 +778,14 @@ void MongodbClient::ViewToQos_(const bsoncxx::document::view& qos_view,
     qos->priority = qos_view[Qos::FieldStringOfPriority()].get_int64().value;
     qos->max_jobs_per_user =
         qos_view[Qos::FieldStringOfMaxJobsPerUser()].get_int64().value;
+    qos->max_jobs_per_account =
+        qos_view[Qos::FieldStringOfMaxJobsPerAccount()].get_int64().value;
     qos->max_cpus_per_user =
         qos_view[Qos::FieldStringOfMaxCpusPerUser()].get_int64().value;
+    qos->max_submit_jobs_per_user =
+        qos_view[Qos::FieldStringOfMaxSubmitJobsPerUser()].get_int64().value;
+    qos->max_submit_jobs_per_account =
+        qos_view[Qos::FieldStringOfMaxJobsPerAccount()].get_int64().value;
     qos->max_time_limit_per_task = absl::Seconds(
         qos_view[Qos::FieldStringOfMaxTimeLimitPerTask()].get_int64().value);
   } catch (const bsoncxx::exception& e) {
@@ -789,7 +795,7 @@ void MongodbClient::ViewToQos_(const bsoncxx::document::view& qos_view,
 
 bsoncxx::builder::basic::document MongodbClient::QosToDocument_(
     const Ctld::Qos& qos) {
-  std::array<std::string, 8> fields{
+  std::array<std::string, 11> fields{
       Qos::FieldStringOfDeleted(),
       Qos::FieldStringOfName(),
       Qos::FieldStringOfDescription(),
@@ -798,9 +804,11 @@ bsoncxx::builder::basic::document MongodbClient::QosToDocument_(
       Qos::FieldStringOfMaxJobsPerUser(),
       Qos::FieldStringOfMaxCpusPerUser(),
       Qos::FieldStringOfMaxTimeLimitPerTask(),
-  };
+      Qos::FieldStringOfMaxJobsPerAccount(),
+      Qos::FieldStringOfMaxSubmitJobsPerUser(),
+      Qos::FieldStringOfMaxSubmitJobsPerAccount()};
   std::tuple<bool, std::string, std::string, int, int64_t, int64_t, int64_t,
-             int64_t>
+             int64_t, int64_t, int64_t, int64_t>
       values{false,
              qos.name,
              qos.description,
@@ -808,7 +816,10 @@ bsoncxx::builder::basic::document MongodbClient::QosToDocument_(
              qos.priority,
              qos.max_jobs_per_user,
              qos.max_cpus_per_user,
-             absl::ToInt64Seconds(qos.max_time_limit_per_task)};
+             absl::ToInt64Seconds(qos.max_time_limit_per_task),
+             qos.max_jobs_per_account,
+             qos.max_submit_jobs_per_user,
+             qos.max_submit_jobs_per_account};
 
   return DocumentConstructor_(fields, values);
 }

--- a/src/CraneCtld/TaskScheduler.cpp
+++ b/src/CraneCtld/TaskScheduler.cpp
@@ -2776,6 +2776,7 @@ void MinLoadFirst::NodeSelect(
 
     bool ok = g_account_meta_container->CheckQosResource(*task);
     if (!ok) {
+      task->pending_reason = "QosResource";
       continue;
     }
 

--- a/src/CraneCtld/TaskScheduler.cpp
+++ b/src/CraneCtld/TaskScheduler.cpp
@@ -114,6 +114,8 @@ bool TaskScheduler::Init() {
                                                        task->uid);
           }
 
+          g_account_meta_container->FreeQosSubmitResource(*task);
+
           ok = g_db_client->InsertJob(task.get());
           if (!ok) {
             CRANE_ERROR(

--- a/src/CraneCtld/TaskScheduler.cpp
+++ b/src/CraneCtld/TaskScheduler.cpp
@@ -576,7 +576,7 @@ void TaskScheduler::PutRecoveredTaskIntoRunningQueueLock_(
         {task->EndTime(), task->Resources()});
   }
 
-  g_account_meta_container->MallocQosResource(task->Username(), *task);
+  g_account_meta_container->MallocQosResource(*task);
   // The order of LockGuards matters.
   LockGuard running_guard(&m_running_task_map_mtx_);
   LockGuard indexes_guard(&m_task_indexes_mtx_);

--- a/src/Utilities/PublicHeader/include/crane/PublicHeader.h
+++ b/src/Utilities/PublicHeader/include/crane/PublicHeader.h
@@ -199,9 +199,12 @@ constexpr std::array<std::string_view, crane::grpc::ErrCode_ARRAYSIZE>
         "LibEvent error",
         "No available node",
 
-        // 65 - 67
+        // 65 - 69
         "The current running job exceeds the QoS limit (MaxJobPerUser)",
-        "User has insufficient privilege"
+        "User has insufficient privilege",
+        "The current account is not in the allowed account list for the partition",
+        "The current account has been explicitly added to the deny list for the partition",
+        "The current submitted job exceeds the QoS limit (MaxSubmitJobsPerAccount)"
     };
 // clang-format on
 }  // namespace Internal


### PR DESCRIPTION
**目前Qos 资源限制列表：**
1. max_cpus_per_user
2. max_jobs_per_user
3. max_submit_jobs_per_user
4. max_jobs_per_account
5. max_submit_jobs_per_account


**Qos资源分配以及释放时机：**

MallocQosSubmitResource:

1. 正常提交作业
2. 作业从数据库中恢复

FreeQosSubmitResource:
1. SubmitTaskToScheduler中CheckTaskValidity失败时
2. 恢复pending作业，CheckTaskValidity失败时
4. 恢复Interactive作业时，将其设置为failed时
5. SubmitTaskAsync失败，包括AppendTasksToPendingAndAdvanceTaskIds失败以及作业被rejected时
6. 作业在pending队列中被cancel时

MallocQosResource、FreeQosResource：与MallocResourceFromNode和FreeResourceFromNode一致

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced new Quality of Service (QoS) limits for job and submission counts at both user and account levels.
  - Added support for tracking and enforcing maximum jobs per account, maximum submitted jobs per user, and maximum submitted jobs per account.
  - Enhanced error reporting with new error codes for exceeding account-level job and submission limits.

- **Bug Fixes**
  - Improved resource cleanup and validation during task submission, cancellation, and recovery processes.

- **Refactor**
  - Streamlined resource management for jobs and submissions, ensuring consistent handling across user and account scopes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->