### PR TITLE
refactor: Change CgroupManager to stateless, add jobmanager.

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -23,6 +23,9 @@ EmptyLineBeforeAccessModifier: LogicalBlock
 IndentPPDirectives: AfterHash
 IndentCaseLabels: false
 
+PointerAlignment: Left
+ReferenceAlignment: Left
+
 SpacesInAngles: Never
 SpacesInConditionalStatement: false
 SpacesInContainerLiterals: false

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -368,6 +368,9 @@ if (CRANE_ENABLE_TESTS)
     add_subdirectory(test EXCLUDE_FROM_ALL)
 endif ()
 
+# Adopt GNU standard installation directories
+include(GNUInstallDirs)
+
 # Generate the configuration file
 configure_file(${CMAKE_SOURCE_DIR}/etc/cranectld.service.in ${CMAKE_BINARY_DIR}/etc/cranectld.service)
 configure_file(${CMAKE_SOURCE_DIR}/etc/craned.service.in ${CMAKE_BINARY_DIR}/etc/craned.service)
@@ -391,13 +394,13 @@ set(CPACK_COMPONENTS_ALL cranedc cranectldc)
 
 # Install binaries
 install(TARGETS cranectld
-        DESTINATION ${CMAKE_INSTALL_PREFIX}/bin
+        DESTINATION ${CMAKE_INSTALL_BINDIR}
         COMPONENT cranectldc
         PERMISSIONS OWNER_READ OWNER_WRITE OWNER_EXECUTE GROUP_READ GROUP_WRITE GROUP_EXECUTE WORLD_READ WORLD_WRITE WORLD_EXECUTE
 )
 
 install(TARGETS craned
-        DESTINATION ${CMAKE_INSTALL_PREFIX}/bin
+        DESTINATION ${CMAKE_INSTALL_BINDIR}
         COMPONENT cranedc
         PERMISSIONS OWNER_READ OWNER_WRITE OWNER_EXECUTE GROUP_READ GROUP_WRITE GROUP_EXECUTE WORLD_READ WORLD_WRITE WORLD_EXECUTE
 )

--- a/protos/Crane.proto
+++ b/protos/Crane.proto
@@ -99,10 +99,7 @@ message ExecuteTasksReply {
 }
 
 message CreateCgroupForTasksRequest {
-  repeated uint32 task_id_list = 1;
-  repeated uint32 uid_list = 2;
-  repeated ResourceInNode res_list = 3;
-  repeated string execution_node = 4;
+  repeated JobSpec job_spec_vec = 1;
 }
 
 message CreateCgroupForTasksReply {}

--- a/protos/PublicDefs.proto
+++ b/protos/PublicDefs.proto
@@ -176,6 +176,13 @@ message RuntimeAttrOfTask {
   double cached_priority = 20;
 }
 
+message JobSpec {
+  uint32 job_id = 1;
+  uint32 uid = 2;
+  ResourceInNode res = 3;
+  string execution_node = 4;
+}
+
 message TaskToD {
   uint32 task_id = 1;
   TaskType type = 2;
@@ -441,13 +448,15 @@ enum ErrCode {
   ERR_INVALID_STUB = 60;
   ERR_CGROUP = 61;
   ERR_PROTOBUF = 62;
-  ERR_LIB_EVENT = 63;
+  ERR_LIB_EVENT = 63 [deprecated = true];
   ERR_NO_AVAIL_NODE = 64;
 
   ERR_MAX_JOB_COUNT_PER_USER = 65;
   ERR_USER_NO_PRIVILEGE = 66;
   ERR_NOT_IN_ALLOWED_LIST = 67;  // The current account is not in the allowed account list for the partition.
   ERR_IN_DENIED_LIST = 68;       // The current account has been explicitly added to the deny list for the partition.
+  ERR_EBPF = 69;
+  ERR_SUPERVISOR = 70;
 }
 
 enum EntityType {

--- a/src/CraneCtld/CraneCtld.cpp
+++ b/src/CraneCtld/CraneCtld.cpp
@@ -40,7 +40,7 @@
 #include "crane/PluginClient.h"
 
 void ParseConfig(int argc, char** argv) {
-  using util::value_or;
+  using util::YamlValueOr;
   cxxopts::Options options("cranectld");
 
   // clang-format off
@@ -86,14 +86,14 @@ void ParseConfig(int argc, char** argv) {
         g_config.CraneClusterName = config["ClusterName"].as<std::string>();
 
       g_config.CraneBaseDir =
-          value_or(config["CraneBaseDir"], kDefaultCraneBaseDir);
+          YamlValueOr(config["CraneBaseDir"], kDefaultCraneBaseDir);
 
       g_config.CraneCtldLogFile =
           g_config.CraneBaseDir /
-          value_or(config["CraneCtldLogFile"], kDefaultCraneCtldLogPath);
+          YamlValueOr(config["CraneCtldLogFile"], kDefaultCraneCtldLogPath);
 
       g_config.CraneCtldDebugLevel =
-          value_or(config["CraneCtldDebugLevel"], "info");
+          YamlValueOr(config["CraneCtldDebugLevel"], "info");
 
       // spdlog should be initialized as soon as possible
       std::optional log_level = StrToLogLevel(g_config.CraneCtldDebugLevel);
@@ -110,14 +110,14 @@ void ParseConfig(int argc, char** argv) {
       }
 
       g_config.CraneCtldMutexFilePath =
-          g_config.CraneBaseDir / value_or(config["CraneCtldMutexFilePath"],
+          g_config.CraneBaseDir / YamlValueOr(config["CraneCtldMutexFilePath"],
                                            kDefaultCraneCtldMutexFile);
 
       g_config.ListenConf.CraneCtldListenAddr =
-          value_or(config["CraneCtldListenAddr"], "0.0.0.0");
+          YamlValueOr(config["CraneCtldListenAddr"], "0.0.0.0");
 
       g_config.ListenConf.CraneCtldListenPort =
-          value_or(config["CraneCtldListenPort"], kCtldDefaultPort);
+          YamlValueOr(config["CraneCtldListenPort"], kCtldDefaultPort);
 
       if (config["CompressedRpc"])
         g_config.CompressedRpc = config["CompressedRpc"].as<bool>();
@@ -180,7 +180,7 @@ void ParseConfig(int argc, char** argv) {
       }
 
       g_config.CranedListenConf.CranedListenPort =
-          value_or(config["CranedListenPort"], kCranedDefaultPort);
+          YamlValueOr(config["CranedListenPort"], kCranedDefaultPort);
 
       g_config.PriorityConfig.MaxAge = kPriorityDefaultMaxAge;
       if (config["PriorityMaxAge"]) {
@@ -287,7 +287,7 @@ void ParseConfig(int argc, char** argv) {
       }
 
       g_config.RejectTasksBeyondCapacity =
-          value_or<bool>(config["RejectJobsBeyondCapacity"],
+          YamlValueOr<bool>(config["RejectJobsBeyondCapacity"],
                          Ctld::kDefaultRejectTasksBeyondCapacity);
 
       if (config["JobFileAppend"]) {
@@ -552,7 +552,7 @@ void ParseConfig(int argc, char** argv) {
 
         g_config.Plugin.PlugindSockPath =
             fmt::format("unix://{}{}", g_config.CraneBaseDir,
-                        value_or(plugin_config["PlugindSockPath"],
+                        YamlValueOr(plugin_config["PlugindSockPath"],
                                  kDefaultPlugindUnixSockPath));
       }
     } catch (YAML::BadFile& e) {

--- a/src/CraneCtld/CraneCtld.cpp
+++ b/src/CraneCtld/CraneCtld.cpp
@@ -111,7 +111,7 @@ void ParseConfig(int argc, char** argv) {
 
       g_config.CraneCtldMutexFilePath =
           g_config.CraneBaseDir / YamlValueOr(config["CraneCtldMutexFilePath"],
-                                           kDefaultCraneCtldMutexFile);
+                                              kDefaultCraneCtldMutexFile);
 
       g_config.ListenConf.CraneCtldListenAddr =
           YamlValueOr(config["CraneCtldListenAddr"], "0.0.0.0");
@@ -288,7 +288,7 @@ void ParseConfig(int argc, char** argv) {
 
       g_config.RejectTasksBeyondCapacity =
           YamlValueOr<bool>(config["RejectJobsBeyondCapacity"],
-                         Ctld::kDefaultRejectTasksBeyondCapacity);
+                            Ctld::kDefaultRejectTasksBeyondCapacity);
 
       if (config["JobFileAppend"]) {
         g_config.JobFileOpenModeAppend = config["JobFileAppend"].as<bool>();
@@ -553,7 +553,7 @@ void ParseConfig(int argc, char** argv) {
         g_config.Plugin.PlugindSockPath =
             fmt::format("unix://{}{}", g_config.CraneBaseDir,
                         YamlValueOr(plugin_config["PlugindSockPath"],
-                                 kDefaultPlugindUnixSockPath));
+                                    kDefaultPlugindUnixSockPath));
       }
     } catch (YAML::BadFile& e) {
       CRANE_CRITICAL("Can't open config file {}: {}", config_path, e.what());

--- a/src/CraneCtld/CraneCtld.cpp
+++ b/src/CraneCtld/CraneCtld.cpp
@@ -40,6 +40,7 @@
 #include "crane/PluginClient.h"
 
 void ParseConfig(int argc, char** argv) {
+  using util::value_or;
   cxxopts::Options options("cranectld");
 
   // clang-format off
@@ -84,68 +85,39 @@ void ParseConfig(int argc, char** argv) {
       if (config["ClusterName"])
         g_config.CraneClusterName = config["ClusterName"].as<std::string>();
 
-      if (config["CraneBaseDir"])
-        g_config.CraneBaseDir = config["CraneBaseDir"].as<std::string>();
-      else
-        g_config.CraneBaseDir = kDefaultCraneBaseDir;
+      g_config.CraneBaseDir =
+          value_or(config["CraneBaseDir"], kDefaultCraneBaseDir);
 
-      if (config["CraneCtldLogFile"])
-        g_config.CraneCtldLogFile =
-            g_config.CraneBaseDir +
-            config["CraneCtldLogFile"].as<std::string>();
-      else
-        g_config.CraneCtldLogFile =
-            g_config.CraneBaseDir + kDefaultCraneCtldLogPath;
+      g_config.CraneCtldLogFile =
+          g_config.CraneBaseDir /
+          value_or(config["CraneCtldLogFile"], kDefaultCraneCtldLogPath);
 
-      if (config["CraneCtldDebugLevel"])
-        g_config.CraneCtldDebugLevel =
-            config["CraneCtldDebugLevel"].as<std::string>();
-      else
-        g_config.CraneCtldDebugLevel = "info";
+      g_config.CraneCtldDebugLevel =
+          value_or(config["CraneCtldDebugLevel"], "info");
 
       // spdlog should be initialized as soon as possible
-      spdlog::level::level_enum log_level;
-      if (g_config.CraneCtldDebugLevel == "trace") {
-        log_level = spdlog::level::trace;
-      } else if (g_config.CraneCtldDebugLevel == "debug") {
-        log_level = spdlog::level::debug;
-      } else if (g_config.CraneCtldDebugLevel == "info") {
-        log_level = spdlog::level::info;
-      } else if (g_config.CraneCtldDebugLevel == "warn") {
-        log_level = spdlog::level::warn;
-      } else if (g_config.CraneCtldDebugLevel == "error") {
-        log_level = spdlog::level::err;
+      std::optional log_level = StrToLogLevel(g_config.CraneCtldDebugLevel);
+      if (log_level.has_value()) {
+        InitLogger(log_level.value(), g_config.CraneCtldLogFile, true);
       } else {
         fmt::print(stderr, "Illegal debug-level format.");
         std::exit(1);
       }
-
-      InitLogger(log_level, g_config.CraneCtldLogFile);
 
       // External configuration file path
       if (!parsed_args.count("db-config") && config["DbConfigPath"]) {
         db_config_path = config["DbConfigPath"].as<std::string>();
       }
 
-      if (config["CraneCtldMutexFilePath"])
-        g_config.CraneCtldMutexFilePath =
-            g_config.CraneBaseDir +
-            config["CraneCtldMutexFilePath"].as<std::string>();
-      else
-        g_config.CraneCtldMutexFilePath =
-            g_config.CraneBaseDir + kDefaultCraneCtldMutexFile;
+      g_config.CraneCtldMutexFilePath =
+          g_config.CraneBaseDir / value_or(config["CraneCtldMutexFilePath"],
+                                           kDefaultCraneCtldMutexFile);
 
-      if (config["CraneCtldListenAddr"])
-        g_config.ListenConf.CraneCtldListenAddr =
-            config["CraneCtldListenAddr"].as<std::string>();
-      else
-        g_config.ListenConf.CraneCtldListenAddr = "0.0.0.0";
+      g_config.ListenConf.CraneCtldListenAddr =
+          value_or(config["CraneCtldListenAddr"], "0.0.0.0");
 
-      if (config["CraneCtldListenPort"])
-        g_config.ListenConf.CraneCtldListenPort =
-            config["CraneCtldListenPort"].as<std::string>();
-      else
-        g_config.ListenConf.CraneCtldListenPort = kCtldDefaultPort;
+      g_config.ListenConf.CraneCtldListenPort =
+          value_or(config["CraneCtldListenPort"], kCtldDefaultPort);
 
       if (config["CompressedRpc"])
         g_config.CompressedRpc = config["CompressedRpc"].as<bool>();
@@ -207,11 +179,8 @@ void ParseConfig(int argc, char** argv) {
         g_config.CraneCtldForeground = config["CraneCtldForeground"].as<bool>();
       }
 
-      if (config["CranedListenPort"])
-        g_config.CranedListenConf.CranedListenPort =
-            config["CranedListenPort"].as<std::string>();
-      else
-        g_config.CranedListenConf.CranedListenPort = kCranedDefaultPort;
+      g_config.CranedListenConf.CranedListenPort =
+          value_or(config["CranedListenPort"], kCranedDefaultPort);
 
       g_config.PriorityConfig.MaxAge = kPriorityDefaultMaxAge;
       if (config["PriorityMaxAge"]) {
@@ -317,13 +286,9 @@ void ParseConfig(int argc, char** argv) {
         g_config.ScheduledBatchSize = Ctld::kDefaultScheduledBatchSize;
       }
 
-      if (config["RejectJobsBeyondCapacity"]) {
-        g_config.RejectTasksBeyondCapacity =
-            config["RejectJobsBeyondCapacity"].as<bool>();
-      } else {
-        g_config.RejectTasksBeyondCapacity =
-            Ctld::kDefaultRejectTasksBeyondCapacity;
-      }
+      g_config.RejectTasksBeyondCapacity =
+          value_or<bool>(config["RejectJobsBeyondCapacity"],
+                         Ctld::kDefaultRejectTasksBeyondCapacity);
 
       if (config["JobFileAppend"]) {
         g_config.JobFileOpenModeAppend = config["JobFileAppend"].as<bool>();
@@ -585,15 +550,10 @@ void ParseConfig(int argc, char** argv) {
         if (plugin_config["Enabled"])
           g_config.Plugin.Enabled = plugin_config["Enabled"].as<bool>();
 
-        if (plugin_config["PlugindSockPath"]) {
-          g_config.Plugin.PlugindSockPath =
-              fmt::format("unix://{}{}", g_config.CraneBaseDir,
-                          plugin_config["PlugindSockPath"].as<std::string>());
-        } else {
-          g_config.Plugin.PlugindSockPath =
-              fmt::format("unix://{}{}", g_config.CraneBaseDir,
-                          kDefaultPlugindUnixSockPath);
-        }
+        g_config.Plugin.PlugindSockPath =
+            fmt::format("unix://{}{}", g_config.CraneBaseDir,
+                        value_or(plugin_config["PlugindSockPath"],
+                                 kDefaultPlugindUnixSockPath));
       }
     } catch (YAML::BadFile& e) {
       CRANE_CRITICAL("Can't open config file {}: {}", config_path, e.what());
@@ -618,12 +578,12 @@ void ParseConfig(int argc, char** argv) {
       if (config["CraneCtldDbPath"] && !config["CraneCtldDbPath"].IsNull()) {
         std::filesystem::path path(config["CraneCtldDbPath"].as<std::string>());
         if (path.is_absolute())
-          g_config.CraneCtldDbPath = path.string();
+          g_config.CraneCtldDbPath = path;
         else
-          g_config.CraneCtldDbPath = g_config.CraneBaseDir + path.string();
+          g_config.CraneCtldDbPath = g_config.CraneBaseDir / path;
       } else
         g_config.CraneCtldDbPath =
-            g_config.CraneBaseDir + kDefaultCraneCtldDbPath;
+            g_config.CraneBaseDir / kDefaultCraneCtldDbPath;
 
       if (config["DbUser"] && !config["DbUser"].IsNull()) {
         g_config.DbUser = config["DbUser"].as<std::string>();

--- a/src/CraneCtld/CranedKeeper.cpp
+++ b/src/CraneCtld/CranedKeeper.cpp
@@ -159,11 +159,8 @@ CraneErrCode CranedStub::CreateCgroupForTasks(
   context.set_deadline(std::chrono::system_clock::now() +
                        std::chrono::seconds(kCtldRpcTimeoutSeconds));
 
-  for (const CgroupSpec &spec : cgroup_specs) {
-    request.mutable_task_id_list()->Add(spec.task_id);
-    request.mutable_uid_list()->Add(spec.uid);
-    *request.mutable_res_list()->Add() = std::move(spec.res_in_node);
-    request.add_execution_node(spec.execution_node);
+  for (const auto &spec : cgroup_specs) {
+    spec.SetJobSpec(request.add_job_spec_vec());
   }
 
   status = m_stub_->CreateCgroupForTasks(&context, request, &reply);

--- a/src/CraneCtld/CranedKeeper.h
+++ b/src/CraneCtld/CranedKeeper.h
@@ -37,8 +37,9 @@ class CranedStub {
  public:
   explicit CranedStub(CranedKeeper *craned_keeper);
   CranedStub(const CranedStub &) = delete;
-
+  CranedStub(CranedStub &&) = delete;
   CranedStub &operator=(const CranedStub &) = delete;
+  CranedStub &operator=(CranedStub &&) = delete;
 
   ~CranedStub();
 
@@ -134,6 +135,10 @@ class CranedKeeper {
 
  public:
   explicit CranedKeeper(uint32_t node_num);
+  CranedKeeper(const CranedKeeper &) = delete;
+  CranedKeeper(CranedKeeper &&) = delete;
+  CranedKeeper &operator=(const CranedKeeper &) = delete;
+  CranedKeeper &operator=(CranedKeeper &&) = delete;
 
   ~CranedKeeper();
 
@@ -164,7 +169,7 @@ class CranedKeeper {
 
  private:
   struct CqTag {
-    enum Type { kInitializingCraned, kEstablishedCraned };
+    enum Type : uint8_t { kInitializingCraned, kEstablishedCraned };
     Type type;
     CranedStub *craned;
   };

--- a/src/CraneCtld/CtldPublicDefs.h
+++ b/src/CraneCtld/CtldPublicDefs.h
@@ -133,13 +133,13 @@ struct Config {
 
   std::string CraneClusterName;
   std::string CraneCtldDebugLevel;
-  std::string CraneCtldLogFile;
+  std::filesystem::path CraneCtldLogFile;
 
   std::string CraneEmbeddedDbBackend;
-  std::string CraneCtldDbPath;
+  std::filesystem::path CraneCtldDbPath;
 
-  std::string CraneBaseDir;
-  std::string CraneCtldMutexFilePath;
+  std::filesystem::path CraneBaseDir;
+  std::filesystem::path CraneCtldMutexFilePath;
 
   bool CraneCtldForeground{};
 

--- a/src/CraneCtld/TaskScheduler.cpp
+++ b/src/CraneCtld/TaskScheduler.cpp
@@ -818,12 +818,9 @@ void TaskScheduler::ScheduleThread_() {
       for (auto& it : selection_result_list) {
         auto& task = it.first;
         for (CranedId const& craned_id : task->CranedIds()) {
-          CgroupSpec spec{
-              .uid = task->uid,
-              .task_id = task->TaskId(),
-              .res_in_node =
-                  (crane::grpc::ResourceInNode)task->Resources().at(craned_id),
-              .execution_node = task->executing_craned_ids.front()};
+          CgroupSpec spec(task->TaskId(), task->uid,
+                          task->Resources().at(craned_id),
+                          task->executing_craned_ids.front());
           craned_cgroup_map[craned_id].emplace_back(std::move(spec));
         }
       }
@@ -856,7 +853,7 @@ void TaskScheduler::ScheduleThread_() {
 
           failed_craned_set.emplace(craned_id);
           for (const auto& spec : cgroup_specs)
-            failed_task_id_set.emplace(spec.task_id);
+            failed_task_id_set.emplace(spec.job_id);
 
           thread_pool_mtx.Unlock();
 

--- a/src/Craned/CMakeLists.txt
+++ b/src/Craned/CMakeLists.txt
@@ -3,6 +3,8 @@ add_executable(craned
         CtldClient.cpp
         CgroupManager.h
         CgroupManager.cpp
+        JobManager.cpp
+        JobManager.h
         CforedClient.h
         CforedClient.cpp
         TaskManager.h
@@ -15,6 +17,7 @@ add_executable(craned
         Craned.cpp
 
         CranedPreCompiledHeader.h
+
 )
 
 target_precompile_headers(craned PRIVATE CranedPreCompiledHeader.h)

--- a/src/Craned/CgroupManager.cpp
+++ b/src/Craned/CgroupManager.cpp
@@ -246,7 +246,7 @@ CraneErrCode CgroupManager::Recover(
       if (cg_unique_ptr == nullptr) {
         CRANE_ERROR("Failed to reopen cgroup for job #{}.", job_id);
       }
-      // cg_unique_ptr.reset();
+      cg_unique_ptr->Destroy();
     }
   }
   return CraneErrCode::SUCCESS;
@@ -1206,8 +1206,8 @@ void BpfRuntimeInfo::CloseBpfObj() {
 }
 
 void BpfRuntimeInfo::Destroy() {
-  if (!Valid()) return;
   absl::MutexLock lock(bpf_mtx_.get());
+  if (!Valid()) return;
   auto pre_key = std::make_unique<BpfKey>();
   if (bpf_map__get_next_key(dev_map_, nullptr, pre_key.get(), sizeof(BpfKey)) <
       0) {

--- a/src/Craned/CgroupManager.cpp
+++ b/src/Craned/CgroupManager.cpp
@@ -1140,7 +1140,6 @@ bool BpfRuntimeInfo::InitializeBpfObj() {
     if (!bpf_obj_) {
       CRANE_ERROR("Failed to open BPF object file {}",
                   CgConstant::kBpfObjectFilePath);
-      bpf_object__close(bpf_obj_);
       return false;
     }
 

--- a/src/Craned/CgroupManager.cpp
+++ b/src/Craned/CgroupManager.cpp
@@ -707,6 +707,7 @@ CgroupManager::GetJobBpfMapCgroupsV2(const std::string &root_cgroup_path) {
   while (bpf_map__get_next_key(bpf_runtime_info.BpfDevMap(), pre_key.get(),
                                cur_key.get(), sizeof(BpfKey)) == 0) {
     add_task(cur_key.get());
+    pre_key.swap(cur_key);
   }
   if (init_ebpf) bpf_runtime_info.CloseBpfObj();
 

--- a/src/Craned/CgroupManager.cpp
+++ b/src/Craned/CgroupManager.cpp
@@ -39,15 +39,34 @@
 namespace Craned {
 
 #ifdef CRANE_ENABLE_BPF
-BpfRuntimeInfo CgroupV2::bpf_runtime_info_{};
+BpfRuntimeInfo CgroupManager::bpf_runtime_info{};
+
+CgroupManager::~CgroupManager() {
+  // Release BpfDeviceMap if no cgroups
+  if (!bpf_runtime_info.Valid()) return;
+  int bpf_map_count = 0;
+  auto pre_key = std::make_unique<BpfKey>();
+  if (bpf_map__get_next_key(bpf_runtime_info.BpfDevMap(), nullptr,
+                            pre_key.get(), sizeof(BpfKey)) < 0) {
+    CRANE_ERROR("Failed to get first key of bpf map");
+    return;
+  } else {
+    bpf_map_count++;
+  }
+  auto cur_key = std::make_unique<BpfKey>();
+  while (bpf_map__get_next_key(bpf_runtime_info.BpfDevMap(), pre_key.get(),
+                               cur_key.get(), sizeof(BpfKey)) == 0) {
+    ++bpf_map_count;
+  }
+  // always one key for logging
+  if (bpf_map_count == 1) {
+    // All task end
+    BpfRuntimeInfo::RmBpfDeviceMap();
+  }
+}
 #endif
 
-/*
- * Initialize libcgroup and mount the controllers Condor will use (if possible)
- *
- * Returns 0 on success, -1 otherwise.
- */
-int CgroupManager::Init() {
+CraneErrCode CgroupManager::Init() {
   // Initialize library and data structures
   CRANE_DEBUG("Initializing cgroup library.");
   cgroup_init();
@@ -133,7 +152,7 @@ int CgroupManager::Init() {
     if (ret != ECGEOF) {
       CRANE_WARN("Error iterating through cgroups mount information: {}\n",
                  cgroup_strerror(ret));
-      return -1;
+      return CraneErrCode::ERR_CGROUP;
     }
   }
   // cgroup don't use /proc/cgroups to manage controller
@@ -141,13 +160,13 @@ int CgroupManager::Init() {
     cgroup *root = cgroup_new_cgroup("/");
     if (root == nullptr) {
       CRANE_WARN("Unable to construct new root cgroup object.");
-      return -1;
+      return CraneErrCode::ERR_CGROUP;
     }
 
     int ret = cgroup_get_cgroup(root);
     if (ret != 0) {
       CRANE_WARN("Error : root cgroup not exist.");
-      return -1;
+      return CraneErrCode::ERR_CGROUP;
     }
 
     if ((cgroup_get_controller(
@@ -186,29 +205,68 @@ int CgroupManager::Init() {
 
   } else {
     CRANE_WARN("Error Cgroup version is not supported");
-    return -1;
+    return CraneErrCode::ERR_CGROUP;
   }
-
-  if (m_cg_version_ == CgroupConstant::CgroupVersion::CGROUP_V1) {
-    RmAllTaskCgroups_();
-  } else if (m_cg_version_ == CgroupConstant::CgroupVersion::CGROUP_V2) {
-#ifdef CRANE_ENABLE_BPF
-    RmBpfDevMap();
-#endif
-    RmAllTaskCgroupsV2_();
-  } else {
-    CRANE_WARN("Error Cgroup version is not supported");
-  }
-
-  return 0;
+  return CraneErrCode::SUCCESS;
 }
 
-void CgroupManager::RmAllTaskCgroups_() {
-  RmAllTaskCgroupsUnderController_(CgroupConstant::Controller::CPU_CONTROLLER);
-  RmAllTaskCgroupsUnderController_(
-      CgroupConstant::Controller::MEMORY_CONTROLLER);
-  RmAllTaskCgroupsUnderController_(
-      CgroupConstant::Controller::DEVICES_CONTROLLER);
+CraneErrCode CgroupManager::Recover(
+    const std::unordered_set<task_id_t> &running_job_ids) {
+  std::set<task_id_t> cg_running_job_ids{};
+  if (m_cg_version_ == CgroupConstant::CgroupVersion::CGROUP_V1) {
+    cg_running_job_ids.merge(
+        GetJobIdsFromCgroupV1(CgroupConstant::Controller::CPU_CONTROLLER));
+    cg_running_job_ids.merge(
+        GetJobIdsFromCgroupV1(CgroupConstant::Controller::MEMORY_CONTROLLER));
+    cg_running_job_ids.merge(
+        GetJobIdsFromCgroupV1(CgroupConstant::Controller::DEVICES_CONTROLLER));
+  } else if (m_cg_version_ == CgroupConstant::CgroupVersion::CGROUP_V2) {
+    cg_running_job_ids =
+        GetJobIdsFromCgroupV2(CgroupConstant::RootCgroupFullPath);
+#ifdef CRANE_ENABLE_BPF
+    auto job_id_bpf_key_vec_map =
+        GetJobBpfMapCgroupsV2(CgroupConstant::RootCgroupFullPath);
+    if (!job_id_bpf_key_vec_map) {
+      CRANE_ERROR("Failed to read job ebpf info, skip recovery.");
+      return CraneErrCode::ERR_EBPF;
+    }
+
+    for (const auto &[job_id, bpf_key_vec] : job_id_bpf_key_vec_map.value()) {
+      if (running_job_ids.contains(job_id)) continue;
+      CRANE_DEBUG("Erase bpf map entry for not running job {}", job_id);
+      for (const auto &key : bpf_key_vec) {
+        if (bpf_map__delete_elem(bpf_runtime_info.BpfDevMap(), &key,
+                                 sizeof(BpfKey), BPF_ANY)) {
+          CRANE_ERROR(
+              "Failed to delete BPF map major {},minor {} in cgroup id {}",
+              key.major, key.minor, key.cgroup_id);
+        }
+      }
+    }
+#endif
+  } else {
+    CRANE_WARN("Error Cgroup version is not supported");
+    return CraneErrCode::ERR_CGROUP;
+  }
+  for (auto job_id : cg_running_job_ids) {
+    if (!running_job_ids.contains(job_id)) {
+      CRANE_DEBUG("Removing cgroup for job #{}.", job_id);
+      std::unique_ptr<CgroupInterface> cg_unique_ptr{nullptr};
+      if (GetCgroupVersion() == CgroupConstant::CgroupVersion::CGROUP_V1) {
+        cg_unique_ptr = CgroupManager::CreateOrOpen_(
+            job_id, CgV1PreferredControllers, NO_CONTROLLER_FLAG, true);
+      } else if (GetCgroupVersion() ==
+                 CgroupConstant::CgroupVersion::CGROUP_V2) {
+        cg_unique_ptr = CgroupManager::CreateOrOpen_(
+            job_id, CgV2PreferredControllers, NO_CONTROLLER_FLAG, true);
+      }
+      if (cg_unique_ptr == nullptr) {
+        CRANE_ERROR("Failed to reopen cgroup for job #{}.", job_id);
+      }
+      // cg_unique_ptr.reset();
+    }
+  }
+  return CraneErrCode::SUCCESS;
 }
 
 void CgroupManager::ControllersMounted() {
@@ -272,7 +330,7 @@ int CgroupManager::InitializeController_(struct cgroup &cgroup,
                  CgroupConstant::GetControllerStringView(controller));
       return 1;
     } else {
-      fmt::print("cgroup controller {} is already mounted",
+      CRANE_WARN("cgroup controller {} is not mounted but not required.",
                  CgroupConstant::GetControllerStringView(controller));
       return 0;
     }
@@ -306,6 +364,17 @@ std::string CgroupManager::CgroupStrByTaskId_(task_id_t task_id) {
   return fmt::format("Crane_Task_{}", task_id);
 }
 
+std::optional<task_id_t> CgroupManager::GetJobIdFromCg_(
+    const std::string &path) {
+  static constexpr LazyRE2 cg_pattern(R"(Crane_Task_(\d+))");
+  std::string job_id;
+  if (RE2::FullMatch(path, *cg_pattern, &job_id)) {
+    return std::stoul(job_id);
+  } else {
+    return std::nullopt;
+  }
+}
+
 /*
  * Create a new cgroup.
  * Parameters:
@@ -317,11 +386,21 @@ std::string CgroupManager::CgroupStrByTaskId_(task_id_t task_id) {
  *   - -1 on error
  * On failure, the state of cgroup is undefined.
  */
+/**
+ * @brief Create or open cgroup for task, not guarantee cg spec exists.
+ * @param task_id task id of cgroup to create.
+ * @param preferred_controllers bitset of the controllers we would prefer.
+ * @param required_controllers bitset of the controllers which are required.
+ * @param retrieve just retrieve an existing cgroup.
+ * @return unique_ptr to CgroupInterface, null if failed.
+ */
 std::unique_ptr<CgroupInterface> CgroupManager::CreateOrOpen_(
-    const std::string &cgroup_string, ControllerFlags preferred_controllers,
+    task_id_t task_id, ControllerFlags preferred_controllers,
     ControllerFlags required_controllers, bool retrieve) {
   using CgroupConstant::Controller;
   using CgroupConstant::GetControllerStringView;
+
+  std::string cgroup_string = CgroupStrByTaskId_(task_id);
 
   bool changed_cgroup = false;
   struct cgroup *native_cgroup = cgroup_new_cgroup(cgroup_string.c_str());
@@ -337,6 +416,8 @@ std::unique_ptr<CgroupInterface> CgroupManager::CreateOrOpen_(
   bool has_cgroup = retrieve;
   if (retrieve && (ECGROUPNOTEXIST == cgroup_get_cgroup(native_cgroup))) {
     has_cgroup = false;
+    cgroup_free(&native_cgroup);
+    return nullptr;
   }
   // Work through the various controllers.
 
@@ -440,222 +521,82 @@ std::unique_ptr<CgroupInterface> CgroupManager::CreateOrOpen_(
   if (GetCgroupVersion() == CgroupConstant::CgroupVersion::CGROUP_V1) {
     return std::make_unique<CgroupV1>(cgroup_string, native_cgroup);
   } else if (GetCgroupVersion() == CgroupConstant::CgroupVersion::CGROUP_V2) {
+    // For cgroup V2,we put task cgroup under RootCgroupFullPath.
     struct stat cgroup_stat;
     std::string slash = "/";
-    std::string cgroup_full_path =
+    std::filesystem::path cgroup_full_path =
         CgroupConstant::RootCgroupFullPath + slash + cgroup_string;
     if (stat(cgroup_full_path.c_str(), &cgroup_stat)) {
-      CRANE_ERROR("Failed to get cgroup {} stat", cgroup_string);
+      CRANE_ERROR("Cgroup {} created but stat failed: {}", cgroup_string,
+                  std::strerror(errno));
       return nullptr;
     }
-    return std::make_unique<CgroupV2>(
-        cgroup_string, native_cgroup,
-        static_cast<uint64_t>(cgroup_stat.st_ino));
+
+    return std::make_unique<CgroupV2>(cgroup_string, native_cgroup,
+                                      cgroup_stat.st_ino);
   } else {
     CRANE_WARN("Unable to create cgroup {}. Cgroup version is not supported",
-               cgroup_string.c_str());
+               cgroup_string);
     return nullptr;
   }
 }
 
-bool CgroupManager::CheckIfCgroupForTasksExists(task_id_t task_id) {
-  return m_task_id_to_cg_map_.Contains(task_id);
-}
+std::unique_ptr<CgroupInterface> CgroupManager::AllocateAndGetJobCgroup(
+    const CgroupSpec &cg_spec) {
+  crane::grpc::ResourceInNode res = cg_spec.res_in_node;
+  bool recover = cg_spec.recovered;
+  auto job_id = cg_spec.job_id;
 
-bool CgroupManager::AllocateAndGetCgroup(task_id_t task_id,
-                                         CgroupInterface **cg) {
-  crane::grpc::ResourceInNode res;
-  CgroupInterface *pcg;
-
-  {
-    auto cg_spec_it = m_task_id_to_cg_spec_map_[task_id];
-    if (!cg_spec_it) return false;
-    res = cg_spec_it->res_in_node;
+  std::unique_ptr<CgroupInterface> cg_unique_ptr{nullptr};
+  if (GetCgroupVersion() == CgroupConstant::CgroupVersion::CGROUP_V1) {
+    cg_unique_ptr = CgroupManager::CreateOrOpen_(
+        job_id, CgV1PreferredControllers, NO_CONTROLLER_FLAG, recover);
+  } else if (GetCgroupVersion() == CgroupConstant::CgroupVersion::CGROUP_V2) {
+    cg_unique_ptr = CgroupManager::CreateOrOpen_(
+        job_id, CgV2PreferredControllers, NO_CONTROLLER_FLAG, recover);
+  } else {
+    CRANE_WARN("cgroup version is not supported.");
+    return nullptr;
   }
 
-  {
-    auto cg_it = m_task_id_to_cg_map_[task_id];
-    auto &cg_unique_ptr = *cg_it;
-    if (!cg_unique_ptr) {
-      if (GetCgroupVersion() == CgroupConstant::CgroupVersion::CGROUP_V1) {
-        cg_unique_ptr = CgroupManager::CreateOrOpen_(
-            CgroupStrByTaskId_(task_id),
-            NO_CONTROLLER_FLAG | CgroupConstant::Controller::CPU_CONTROLLER |
-                CgroupConstant::Controller::MEMORY_CONTROLLER |
-                CgroupConstant::Controller::DEVICES_CONTROLLER |
-                CgroupConstant::Controller::BLOCK_CONTROLLER,
-            NO_CONTROLLER_FLAG, false);
-      } else if (GetCgroupVersion() ==
-                 CgroupConstant::CgroupVersion::CGROUP_V2) {
-        cg_unique_ptr = CgroupManager::CreateOrOpen_(
-            CgroupStrByTaskId_(task_id),
-            NO_CONTROLLER_FLAG | CgroupConstant::Controller::CPU_CONTROLLER_V2 |
-                CgroupConstant::Controller::MEMORY_CONTORLLER_V2,
-            NO_CONTROLLER_FLAG, false);
-      } else {
-        CRANE_WARN("cgroup version is not supported.");
-      }
+  // If just recover cgroup, do not trigger plugin and apply res limit.
+  if (recover) {
+#ifdef CRANE_ENABLE_BPF
+    if (GetCgroupVersion() != CgroupConstant::CgroupVersion::CGROUP_V2) {
+      return cg_unique_ptr;
     }
+    CgroupV2 *cg_v2_ptr = dynamic_cast<CgroupV2 *>(cg_unique_ptr.get());
+    cg_v2_ptr->RecoverFromCgSpec(cg_spec);
+#endif
 
-    if (!cg_unique_ptr) return false;
-
-    pcg = cg_unique_ptr.get();
-    if (cg) *cg = pcg;
+    return cg_unique_ptr;
   }
 
   if (g_config.Plugin.Enabled) {
-    g_plugin_client->CreateCgroupHookAsync(task_id, pcg->GetCgroupString(),
+    g_plugin_client->CreateCgroupHookAsync(cg_spec.job_id,
+                                           cg_unique_ptr->GetCgroupString(),
                                            res.dedicated_res_in_node());
   }
 
   CRANE_TRACE(
-      "Setting cgroup limit of task #{}. CPU: {:.2f}, Mem: {:.2f} MB Gres: {}.",
-      task_id, res.allocatable_res_in_node().cpu_core_limit(),
+      "Setting cgroup for job #{}. CPU: {:.2f}, Mem: {:.2f} MB, Gres: {}.",
+      job_id, res.allocatable_res_in_node().cpu_core_limit(),
       res.allocatable_res_in_node().memory_limit_bytes() / (1024.0 * 1024.0),
       util::ReadableGrpcDresInNode(res.dedicated_res_in_node()));
 
   bool ok = AllocatableResourceAllocator::Allocate(
-      res.allocatable_res_in_node(), pcg);
+      res.allocatable_res_in_node(), cg_unique_ptr.get());
   if (ok)
-    ok &=
-        DedicatedResourceAllocator::Allocate(res.dedicated_res_in_node(), pcg);
-  return ok;
+    ok &= DedicatedResourceAllocator::Allocate(res.dedicated_res_in_node(),
+                                               cg_unique_ptr.get());
+  return ok ? std::move(cg_unique_ptr) : nullptr;
 }
 
-bool CgroupManager::CreateCgroups(std::vector<CgroupSpec> &&cg_specs) {
-  std::chrono::steady_clock::time_point begin;
-  std::chrono::steady_clock::time_point end;
-
-  CRANE_DEBUG("Creating cgroups for {} tasks", cg_specs.size());
-
-  begin = std::chrono::steady_clock::now();
-
-  for (int i = 0; i < cg_specs.size(); i++) {
-    uid_t uid = cg_specs[i].uid;
-    task_id_t task_id = cg_specs[i].task_id;
-
-    CRANE_TRACE("Create lazily allocated cgroups for task #{}, uid {}", task_id,
-                uid);
-
-    this->m_task_id_to_cg_spec_map_.Emplace(task_id, std::move(cg_specs[i]));
-
-    this->m_task_id_to_cg_map_.Emplace(task_id, nullptr);
-
-    // Acquire map lock to avoid using [uid]set deleted by ReleaseCgroup
-    // after checking contains(uid)
-    auto uid_task_id_map_ptr =
-        this->m_uid_to_task_ids_map_.GetMapExclusivePtr();
-    if (!uid_task_id_map_ptr->contains(uid))
-      uid_task_id_map_ptr->emplace(uid, absl::flat_hash_set<uint32_t>{task_id});
-    else
-      uid_task_id_map_ptr->at(uid).RawPtr()->emplace(task_id);
-  }
-
-  end = std::chrono::steady_clock::now();
-  CRANE_TRACE("Create cgroups costed {} ms",
-              std::chrono::duration_cast<std::chrono::milliseconds>(end - begin)
-                  .count());
-
-  return true;
-}
-
-bool CgroupManager::ReleaseCgroupByTaskIdOnly(task_id_t task_id) {
-  uid_t uid;
-  {
-    auto vp = this->m_task_id_to_cg_spec_map_.GetValueExclusivePtr(task_id);
-    if (!vp) return false;
-
-    CRANE_DEBUG(
-        "Remove cgroup for task #{} for potential crashes of other craned.",
-        task_id);
-    uid = vp->uid;
-  }
-  return this->ReleaseCgroup(task_id, uid);
-}
-
-bool CgroupManager::ReleaseCgroup(uint32_t task_id, uid_t uid) {
-  this->m_task_id_to_cg_spec_map_.Erase(task_id);
-
-  {
-    // The termination of all processes in a cgroup is a time-consuming work.
-    // Therefore, once we are sure that the cgroup for this task exists, we
-    // let gRPC call return and put the termination work into the thread pool
-    // to avoid blocking the event loop of TaskManager.
-    // Kind of async behavior.
-
-    // avoid deadlock by Erase at next line
-    auto task_id_to_cg_map_ptr =
-        this->m_task_id_to_cg_map_.GetMapExclusivePtr();
-    auto it = task_id_to_cg_map_ptr->find(task_id);
-    if (it == task_id_to_cg_map_ptr->end()) {
-      CRANE_DEBUG(
-          "Trying to release a non-existent cgroup for task #{}. Ignoring "
-          "it...",
-          task_id);
-
-      return false;
-    }
-    CgroupInterface *cgroup = it->second.GetExclusivePtr()->release();
-
-    task_id_to_cg_map_ptr->erase(task_id);
-
-    if (cgroup != nullptr) {
-      if (g_config.Plugin.Enabled) {
-        g_plugin_client->DestroyCgroupHookAsync(task_id,
-                                                cgroup->GetCgroupString());
-      }
-
-      g_thread_pool->detach_task([cgroup]() {
-        bool rc;
-        int cnt = 0;
-
-        while (true) {
-          if (cgroup->Empty()) break;
-
-          if (cnt >= 5) {
-            CRANE_ERROR(
-                "Couldn't kill the processes in cgroup {} after {} times. "
-                "Skipping it.",
-                cgroup->GetCgroupString(), cnt);
-            break;
-          }
-
-          cgroup->KillAllProcesses();
-          ++cnt;
-          std::this_thread::sleep_for(std::chrono::milliseconds(100));
-        }
-
-        delete cgroup;
-      });
-    }
-  }
-
-  {
-    auto uid_task_ids_map_ptr =
-        this->m_uid_to_task_ids_map_.GetMapExclusivePtr();
-    auto it = uid_task_ids_map_ptr->find(uid);
-    if (it == uid_task_ids_map_ptr->end()) {
-      CRANE_DEBUG(
-          "Trying to release a non-existent cgroup for uid #{}. Ignoring it...",
-          uid);
-      return false;
-    }
-
-    auto task_id_set_ptr = uid_task_ids_map_ptr->at(uid).RawPtr();
-
-    task_id_set_ptr->erase(task_id);
-    if (task_id_set_ptr->empty()) {
-      uid_task_ids_map_ptr->erase(uid);
-    }
-    // Do not access task_id_set_ptr after erasing form map
-  }
-  return true;
-}
-
-void CgroupManager::RmAllTaskCgroupsUnderController_(
+std::set<task_id_t> CgroupManager::GetJobIdsFromCgroupV1(
     CgroupConstant::Controller controller) {
   void *handle = nullptr;
   cgroup_file_info info{};
+  std::set<task_id_t> job_ids;
 
   const char *controller_str =
       CgroupConstant::GetControllerStringView(controller).data();
@@ -665,114 +606,103 @@ void CgroupManager::RmAllTaskCgroupsUnderController_(
   int ret = cgroup_walk_tree_begin(controller_str, "/", depth, &handle, &info,
                                    &base_level);
   while (ret == 0) {
-    if (info.type == cgroup_file_type::CGROUP_FILE_TYPE_DIR &&
-        strstr(info.path, CgroupConstant::kTaskCgPathPrefix) != nullptr) {
-      CRANE_DEBUG("Removing remaining task cgroup: {}", info.full_path);
-      int err = rmdir(info.full_path);
-      if (err != 0)
-        CRANE_ERROR("Failed to remove cgroup {}: {}", info.full_path,
-                    strerror(errno));
+    if (info.type == cgroup_file_type::CGROUP_FILE_TYPE_DIR) {
+      if (auto job_id = GetJobIdFromCg_(info.path); job_id.has_value())
+        job_ids.emplace(job_id.value());
     }
-
     ret = cgroup_walk_tree_next(depth, &handle, &info, base_level);
   }
 
   if (handle) cgroup_walk_tree_end(&handle);
+  return job_ids;
 }
 
-void CgroupManager::RmAllTaskCgroupsV2_() {
-  RmCgroupsV2_(CgroupConstant::RootCgroupFullPath,
-               CgroupConstant::kTaskCgPathPrefix);
-}
-
-void CgroupManager::RmCgroupsV2_(const std::string &root_cgroup_path,
-                                 const std::string &match_str) {
-  DIR *dir = nullptr;
-  if ((dir = opendir(root_cgroup_path.c_str())) == nullptr) {
-    CRANE_ERROR("Failed to open cgroup dir {}", root_cgroup_path);
-  }
-  struct dirent *entry;
-  std::vector<std::string> cgroup_full_path_to_delete;
-  while ((entry = readdir(dir)) != nullptr) {
-    // Skip "." and ".." directories
-    if (strcmp(entry->d_name, ".") == 0 || strcmp(entry->d_name, "..") == 0) {
-      continue;
-    }
-
-    std::string dir_name = entry->d_name;
-    std::string full_path = root_cgroup_path + "/" + dir_name;
-
-    // Check if it's a directory and if it contains the match_str
-    struct stat info;
-    if (stat(full_path.c_str(), &info) == 0 && S_ISDIR(info.st_mode)) {
-      if (dir_name.find(match_str) != std::string::npos) {
-        cgroup_full_path_to_delete.push_back(full_path);
-      }
-    }
-  }
-  closedir(dir);
-  for (const auto &tf : cgroup_full_path_to_delete) {
-    int err = rmdir(tf.c_str());
-    if (err != 0) {
-      CRANE_ERROR("Failed to remove cgroup {}: {}", tf.c_str(),
-                  strerror(errno));
-    }
-  }
-}
-
-#ifdef CRANE_ENABLE_BPF
-void CgroupManager::RmBpfDevMap() {
+std::set<task_id_t> CgroupManager::GetJobIdsFromCgroupV2(
+    const std::string &root_cgroup_path) {
+  std::set<task_id_t> job_ids;
   try {
-    if (std::filesystem::exists(CgroupConstant::BpfDeviceMapFile)) {
-      std::filesystem::remove(CgroupConstant::BpfDeviceMapFile);
-      CRANE_TRACE("Successfully removed: {}", CgroupConstant::BpfDeviceMapFile);
-    } else {
-      CRANE_TRACE("File does not exist: {}", CgroupConstant::BpfDeviceMapFile);
+    for (const auto &it :
+         std::filesystem::directory_iterator(root_cgroup_path)) {
+      std::string job_id_str;
+      if (it.is_directory()) {
+        if (auto job_id = GetJobIdFromCg_(it.path().filename());
+            job_id.has_value())
+          job_ids.emplace(job_id.value());
+      }
     }
   } catch (const std::filesystem::filesystem_error &e) {
     CRANE_ERROR("Error: {}", e.what());
   }
+  return job_ids;
+}
+
+std::unordered_map<ino_t, task_id_t> CgroupManager::GetCgJobIdMapCgroupV2(
+    const std::string &root_cgroup_path) {
+  std::unordered_map<ino_t, task_id_t> cg_job_id_map;
+  try {
+    for (const auto &it :
+         std::filesystem::directory_iterator(root_cgroup_path)) {
+      std::string job_id_str;
+      if (it.is_directory()) {
+        if (auto job_id = GetJobIdFromCg_(it.path().filename());
+            job_id.has_value()) {
+          struct stat cg_stat{};
+          if (stat(it.path().c_str(), &cg_stat)) {
+            CRANE_ERROR("Cgroup {} stat failed: {}", it.path().c_str(),
+                        std::strerror(errno));
+            continue;
+          }
+          cg_job_id_map.emplace(cg_stat.st_ino, job_id.value());
+        }
+      }
+    }
+  } catch (const std::filesystem::filesystem_error &e) {
+    CRANE_ERROR("Error: {}", e.what());
+  }
+  return cg_job_id_map;
+}
+
+#ifdef CRANE_ENABLE_BPF
+
+CraneExpected<std::unordered_map<task_id_t, std::vector<BpfKey>>>
+CgroupManager::GetJobBpfMapCgroupsV2(const std::string &root_cgroup_path) {
+  std::unordered_map cg_ino_job_id_map =
+      GetCgJobIdMapCgroupV2(root_cgroup_path);
+  bool init_ebpf = !bpf_runtime_info.Valid();
+  if (init_ebpf) {
+    if (!bpf_runtime_info.InitializeBpfObj())
+      return std::unexpected(CraneErrCode::ERR_EBPF);
+  }
+
+  std::unordered_map<task_id_t, std::vector<BpfKey>> results;
+
+  auto add_task = [&results, &cg_ino_job_id_map](BpfKey *key) {
+    // Skip log level record.
+    if (key->cgroup_id == 0) {
+      return;
+    }
+    CRANE_ASSERT(cg_ino_job_id_map.contains(key->cgroup_id));
+    results[cg_ino_job_id_map[key->cgroup_id]].emplace_back(*key);
+  };
+
+  auto pre_key = std::make_unique<BpfKey>();
+  if (bpf_map__get_next_key(bpf_runtime_info.BpfDevMap(), nullptr,
+                            pre_key.get(), sizeof(BpfKey)) < 0) {
+    CRANE_ERROR("Failed to get first key of bpf map or no running jobs.");
+    return results;
+  }
+
+  add_task(pre_key.get());
+  auto cur_key = std::make_unique<BpfKey>();
+  while (bpf_map__get_next_key(bpf_runtime_info.BpfDevMap(), pre_key.get(),
+                               cur_key.get(), sizeof(BpfKey)) == 0) {
+    add_task(cur_key.get());
+  }
+  if (init_ebpf) bpf_runtime_info.CloseBpfObj();
+
+  return results;
 }
 #endif
-
-bool CgroupManager::QueryTaskInfoOfUidAsync(uid_t uid, TaskInfoOfUid *info) {
-  CRANE_DEBUG("Query task info for uid {}", uid);
-
-  info->job_cnt = 0;
-  info->cgroup_exists = false;
-
-  if (auto task_ids = this->m_uid_to_task_ids_map_[uid]) {
-    if (!task_ids) {
-      CRANE_WARN("Uid {} not found in uid_to_task_ids_map", uid);
-      return false;
-    }
-    info->job_cnt = task_ids->size();
-    info->first_task_id = *task_ids->begin();
-  }
-  return info->job_cnt > 0;
-}
-
-bool CgroupManager::MigrateProcToCgroupOfTask(pid_t pid, task_id_t task_id) {
-  CgroupInterface *cg;
-  bool ok = AllocateAndGetCgroup(task_id, &cg);
-  if (!ok) return false;
-
-  return cg->MigrateProcIn(pid);
-}
-
-std::optional<std::string> CgroupManager::QueryTaskExecutionNode(
-    task_id_t task_id) {
-  if (!this->m_task_id_to_cg_spec_map_.Contains(task_id)) return std::nullopt;
-  return this->m_task_id_to_cg_spec_map_[task_id]->execution_node;
-}
-
-CraneExpected<crane::grpc::ResourceInNode> CgroupManager::GetTaskResourceInNode(
-    task_id_t task_id) {
-  auto cg_spec_ptr = this->m_task_id_to_cg_spec_map_[task_id];
-  if (cg_spec_ptr) return cg_spec_ptr->res_in_node;
-
-  return std::unexpected(CraneErrCode::ERR_CGROUP);
-}
 
 EnvMap CgroupManager::GetResourceEnvMapByResInNode(
     const crane::grpc::ResourceInNode &res_in_node) {
@@ -788,16 +718,36 @@ EnvMap CgroupManager::GetResourceEnvMapByResInNode(
   return env_map;
 }
 
-CraneExpected<EnvMap> CgroupManager::GetResourceEnvMapOfTask(
-    task_id_t task_id) {
-  auto task_res = GetTaskResourceInNode(task_id);
-  if (task_res.has_value()) {
-    return GetResourceEnvMapByResInNode(task_res.value());
+CraneExpected<task_id_t> CgroupManager::GetJobIdFromPid(pid_t pid) const {
+  static constexpr LazyRE2 cg_pattern(R"(.*/Crane_Task_(\d+).*)");
+  std::string job_id_str;
+  std::string cgroup_file = fmt::format("/proc/{}/cgroup", pid);
+  std::ifstream infile(cgroup_file);
+  if (!infile.is_open()) {
+    CRANE_ERROR("Failed to open cgroup file for pid {}", pid);
+    return std::unexpected(CraneErrCode::ERR_CGROUP);
   }
-
-  CRANE_ERROR("Trying to get resource env list of a non-existent task #{}",
-              task_id);
-  return std::unexpected(CraneErrCode::ERR_SYSTEM_ERR);
+  if (m_cg_version_ == CgroupConstant::CgroupVersion::CGROUP_V1) {
+    std::string line;
+    while (std::getline(infile, line)) {
+      if (RE2::FullMatch(line, *cg_pattern, &job_id_str)) {
+        CRANE_TRACE("Get task Id {}", job_id_str);
+        return std::stoi(job_id_str);
+      }
+    }
+  } else if (m_cg_version_ == CgroupConstant::CgroupVersion::CGROUP_V2) {
+    std::string line;
+    if (!std::getline(infile, line)) {
+      CRANE_ERROR("Failed to read cgroup file");
+      return std::unexpected(CraneErrCode::ERR_SYSTEM_ERR);
+    }
+    if (RE2::FullMatch(line, *cg_pattern, &job_id_str)) {
+      return std::stoi(job_id_str);
+    }
+  } else {
+    std::unreachable();
+  }
+  return std::unexpected(CraneErrCode::ERR_NON_EXISTENT);
 }
 
 /*
@@ -806,6 +756,7 @@ CraneExpected<EnvMap> CgroupManager::GetResourceEnvMapOfTask(
  */
 Cgroup::~Cgroup() {
   if (m_cgroup_) {
+    CRANE_DEBUG("Destroying cgroup {}.", m_cgroup_path_);
     int err;
     if ((err = cgroup_delete_cgroup_ext(
              m_cgroup_,
@@ -974,7 +925,7 @@ bool Cgroup::SetControllerStrs(CgroupConstant::Controller controller,
   return true;
 }
 
-bool CgroupV1::MigrateProcIn(pid_t pid) {
+bool CgroupInterface::MigrateProcIn(pid_t pid) {
   using CgroupConstant::Controller;
   using CgroupConstant::GetControllerStringView;
 
@@ -1050,6 +1001,31 @@ bool CgroupV1::SetBlockioWeight(uint64_t weight) {
       CgroupConstant::ControllerFile::BLOCKIO_WEIGHT, weight);
 }
 
+bool CgroupV1::SetDeviceAccess(const std::unordered_set<SlotId> &devices,
+                               bool set_read, bool set_write, bool set_mknod) {
+  std::string op;
+  if (set_read) op += "r";
+  if (set_write) op += "w";
+  if (set_mknod) op += "m";
+  std::vector<std::string> deny_limits;
+  for (const auto &this_device :
+       Craned::g_this_node_device | std::views::values) {
+    if (!devices.contains(this_device->slot_id)) {
+      for (const auto &dev_meta : this_device->device_file_metas) {
+        deny_limits.emplace_back(fmt::format("{} {}:{} {}", dev_meta.op_type,
+                                             dev_meta.major, dev_meta.minor,
+                                             op));
+      }
+    }
+  }
+  auto ok = true;
+  if (!deny_limits.empty())
+    ok &= m_cgroup_info_.SetControllerStrs(
+        CgroupConstant::Controller::DEVICES_CONTROLLER,
+        CgroupConstant::ControllerFile::DEVICES_DENY, deny_limits);
+  return ok;
+}
+
 bool CgroupV1::KillAllProcesses() {
   using namespace CgroupConstant::Internal;
 
@@ -1101,29 +1077,6 @@ bool CgroupV1::Empty() {
     return false;
   }
 }
-bool CgroupV1::SetDeviceAccess(const std::unordered_set<SlotId> &devices,
-                               bool set_read, bool set_write, bool set_mknod) {
-  std::string op;
-  if (set_read) op += "r";
-  if (set_write) op += "w";
-  if (set_mknod) op += "m";
-  std::vector<std::string> deny_limits;
-  for (const auto &[_, this_device] : Craned::g_this_node_device) {
-    if (!devices.contains(this_device->slot_id)) {
-      for (const auto &dev_meta : this_device->device_file_metas) {
-        deny_limits.emplace_back(fmt::format("{} {}:{} {}", dev_meta.op_type,
-                                             dev_meta.major, dev_meta.minor,
-                                             op));
-      }
-    }
-  }
-  auto ok = true;
-  if (!deny_limits.empty())
-    ok &= m_cgroup_info_.SetControllerStrs(
-        CgroupConstant::Controller::DEVICES_CONTROLLER,
-        CgroupConstant::ControllerFile::DEVICES_DENY, deny_limits);
-  return ok;
-}
 
 #ifdef CRANE_ENABLE_BPF
 
@@ -1131,8 +1084,8 @@ BpfRuntimeInfo::BpfRuntimeInfo() {
   bpf_obj_ = nullptr;
   bpf_prog_ = nullptr;
   dev_map_ = nullptr;
-  bpf_debug_log_level_ = 0;
-  bpf_mtx_ = new std::mutex;
+  bpf_enable_logging_ = false;
+  bpf_mtx_ = std::make_unique<absl::Mutex>();
   bpf_prog_fd_ = -1;
   cgroup_count_ = 0;
 }
@@ -1141,19 +1094,18 @@ BpfRuntimeInfo::~BpfRuntimeInfo() {
   bpf_obj_ = nullptr;
   bpf_prog_ = nullptr;
   dev_map_ = nullptr;
-  delete bpf_mtx_;
   bpf_prog_fd_ = -1;
   cgroup_count_ = 0;
 }
 
 bool BpfRuntimeInfo::InitializeBpfObj() {
-  std::unique_lock<std::mutex> lk(*bpf_mtx_);
+  absl::MutexLock lk(bpf_mtx_.get());
 
   if (cgroup_count_ == 0) {
-    bpf_obj_ = bpf_object__open_file(CgroupConstant::BpfObjectFile, NULL);
+    bpf_obj_ = bpf_object__open_file(CgroupConstant::BpfObjectFilePath, NULL);
     if (!bpf_obj_) {
       CRANE_ERROR("Failed to open BPF object file {}",
-                  CgroupConstant::BpfObjectFile);
+                  CgroupConstant::BpfObjectFilePath);
       bpf_object__close(bpf_obj_);
       return false;
     }
@@ -1163,7 +1115,7 @@ bool BpfRuntimeInfo::InitializeBpfObj() {
 
     if (bpf_object__load(bpf_obj_)) {
       CRANE_ERROR("Failed to load BPF object {}",
-                  CgroupConstant::BpfObjectFile);
+                  CgroupConstant::BpfObjectFilePath);
       bpf_object__close(bpf_obj_);
       return false;
     }
@@ -1180,7 +1132,7 @@ bool BpfRuntimeInfo::InitializeBpfObj() {
     bpf_prog_fd_ = bpf_program__fd(bpf_prog_);
     if (bpf_prog_fd_ < 0) {
       CRANE_ERROR("Failed to get BPF program file descriptor {}",
-                  CgroupConstant::BpfObjectFile);
+                  CgroupConstant::BpfObjectFilePath);
       bpf_object__close(bpf_obj_);
       return false;
     }
@@ -1196,7 +1148,7 @@ bool BpfRuntimeInfo::InitializeBpfObj() {
 
     struct BpfKey key = {static_cast<uint64_t>(0), static_cast<uint32_t>(0),
                          static_cast<uint32_t>(0)};
-    struct BpfDeviceMeta meta = {static_cast<uint32_t>(bpf_debug_log_level_),
+    struct BpfDeviceMeta meta = {static_cast<uint32_t>(bpf_enable_logging_),
                                  static_cast<uint32_t>(0), static_cast<int>(0),
                                  static_cast<short>(0), static_cast<short>(0)};
     if (bpf_map__update_elem(dev_map_, &key, sizeof(BpfKey), &meta,
@@ -1209,8 +1161,8 @@ bool BpfRuntimeInfo::InitializeBpfObj() {
 }
 
 void BpfRuntimeInfo::CloseBpfObj() {
-  std::unique_lock<std::mutex> lk(*bpf_mtx_);
-  if (BpfInvalid() && --cgroup_count_ == 0) {
+  absl::MutexLock lk(bpf_mtx_.get());
+  if (Valid() && --cgroup_count_ == 0) {
     close(bpf_prog_fd_);
     bpf_object__close(bpf_obj_);
     bpf_prog_fd_ = -1;
@@ -1223,11 +1175,13 @@ void BpfRuntimeInfo::CloseBpfObj() {
 
 void BpfRuntimeInfo::RmBpfDeviceMap() {
   try {
-    if (std::filesystem::exists(CgroupConstant::BpfDeviceMapFile)) {
-      std::filesystem::remove(CgroupConstant::BpfDeviceMapFile);
-      CRANE_TRACE("Successfully removed: {}", CgroupConstant::BpfDeviceMapFile);
+    if (std::filesystem::exists(CgroupConstant::BpfDeviceMapFilePath)) {
+      std::filesystem::remove(CgroupConstant::BpfDeviceMapFilePath);
+      CRANE_TRACE("Successfully removed: {}",
+                  CgroupConstant::BpfDeviceMapFilePath);
     } else {
-      CRANE_TRACE("File does not exist: {}", CgroupConstant::BpfDeviceMapFile);
+      CRANE_TRACE("File does not exist: {}",
+                  CgroupConstant::BpfDeviceMapFilePath);
     }
   } catch (const std::filesystem::filesystem_error &e) {
     CRANE_ERROR("Error: {}", e.what());
@@ -1236,9 +1190,9 @@ void BpfRuntimeInfo::RmBpfDeviceMap() {
 #endif
 
 CgroupV2::CgroupV2(const std::string &path, struct cgroup *handle, uint64_t id)
-    : m_cgroup_info_(path, handle, id) {
+    : CgroupInterface(path, handle, id) {
 #ifdef CRANE_ENABLE_BPF
-  if (bpf_runtime_info_.InitializeBpfObj()) {
+  if (CgroupManager::bpf_runtime_info.InitializeBpfObj()) {
     CRANE_TRACE("Bpf object initialization succeed");
   } else {
     CRANE_TRACE("Bpf object initialization failed");
@@ -1246,12 +1200,22 @@ CgroupV2::CgroupV2(const std::string &path, struct cgroup *handle, uint64_t id)
 #endif
 }
 
+#ifdef CRANE_ENABLE_BPF
+// For recovery
+CgroupV2::CgroupV2(const std::string &path, struct cgroup *handle, uint64_t id,
+                   std::vector<BpfDeviceMeta> &cgroup_bpf_devices)
+    : CgroupV2(path, handle, id) {
+  m_cgroup_bpf_devices = std::move(cgroup_bpf_devices);
+  m_bpf_attached_ = true;
+}
+#endif
+
 CgroupV2::~CgroupV2() {
 #ifdef CRANE_ENABLE_BPF
   if (!m_cgroup_bpf_devices.empty()) {
     EraseBpfDeviceMap();
   }
-  bpf_runtime_info_.CloseBpfObj();
+  CgroupManager::bpf_runtime_info.CloseBpfObj();
 #endif
 }
 
@@ -1305,14 +1269,14 @@ bool CgroupV2::SetBlockioWeight(uint64_t weight) {
 bool CgroupV2::SetDeviceAccess(const std::unordered_set<SlotId> &devices,
                                bool set_read, bool set_write, bool set_mknod) {
 #ifdef CRANE_ENABLE_BPF
-  if (!bpf_runtime_info_.BpfInvalid()) {
+  if (!CgroupManager::bpf_runtime_info.Valid()) {
     CRANE_WARN("BPF is not initialized.");
     return false;
   }
   int cgroup_fd;
   std::string slash = "/";
-  std::string cgroup_path = CgroupConstant::RootCgroupFullPath + slash +
-                            m_cgroup_info_.m_cgroup_path_;
+  std::filesystem::path cgroup_path = CgroupConstant::RootCgroupFullPath +
+                                      slash + m_cgroup_info_.m_cgroup_path_;
   cgroup_fd = open(cgroup_path.c_str(), O_RDONLY);
   if (cgroup_fd < 0) {
     CRANE_ERROR("Failed to open cgroup");
@@ -1325,7 +1289,8 @@ bool CgroupV2::SetDeviceAccess(const std::unordered_set<SlotId> &devices,
   if (set_mknod) access |= BPF_DEVCG_ACC_MKNOD;
 
   auto &bpf_devices = m_cgroup_bpf_devices;
-  for (const auto &[_, this_device] : Craned::g_this_node_device) {
+  for (const auto &this_device :
+       Craned::g_this_node_device | std::views::values) {
     if (!devices.contains(this_device->slot_id)) {
       for (const auto &dev_meta : this_device->device_file_metas) {
         short op_type = 0;
@@ -1342,12 +1307,12 @@ bool CgroupV2::SetDeviceAccess(const std::unordered_set<SlotId> &devices,
     }
   }
   {
-    std::unique_lock<std::mutex> lk(*bpf_runtime_info_.BpfMutex());
+    absl::MutexLock lk(CgroupManager::bpf_runtime_info.BpfMutex());
     for (int i = 0; i < bpf_devices.size(); i++) {
       struct BpfKey key = {m_cgroup_info_.m_cgroup_id, bpf_devices[i].major,
                            bpf_devices[i].minor};
-      if (bpf_map__update_elem(bpf_runtime_info_.BpfDevMap(), &key,
-                               sizeof(BpfKey), &bpf_devices[i],
+      if (bpf_map__update_elem(CgroupManager::bpf_runtime_info.BpfDevMap(),
+                               &key, sizeof(BpfKey), &bpf_devices[i],
                                sizeof(BpfDeviceMeta), BPF_ANY)) {
         CRANE_ERROR("Failed to update BPF map major {},minor {} cgroup id {}",
                     bpf_devices[i].major, bpf_devices[i].minor, key.cgroup_id);
@@ -1356,11 +1321,15 @@ bool CgroupV2::SetDeviceAccess(const std::unordered_set<SlotId> &devices,
       }
     }
 
-    if (bpf_prog_attach(bpf_runtime_info_.BpfProgFd(), cgroup_fd,
-                        BPF_CGROUP_DEVICE, 0) < 0) {
-      CRANE_ERROR("Failed to attach BPF program");
-      close(cgroup_fd);
-      return false;
+    // No need to attach ebpf prog twice.
+    if (!m_bpf_attached_) {
+      if (bpf_prog_attach(CgroupManager::bpf_runtime_info.BpfProgFd(),
+                          cgroup_fd, BPF_CGROUP_DEVICE, 0) < 0) {
+        CRANE_ERROR("Failed to attach BPF program");
+        close(cgroup_fd);
+        return false;
+      }
+      m_bpf_attached_ = true;
     }
   }
   close(cgroup_fd);
@@ -1375,19 +1344,67 @@ bool CgroupV2::SetDeviceAccess(const std::unordered_set<SlotId> &devices,
 }
 
 #ifdef CRANE_ENABLE_BPF
+bool CgroupV2::RecoverFromCgSpec(const CgroupSpec &cg_spec) {
+  if (!CgroupManager::bpf_runtime_info.Valid()) {
+    CRANE_WARN("BPF is not initialized.");
+    return false;
+  }
+  int cgroup_fd;
+  std::string slash = "/";
+  std::filesystem::path cgroup_path = CgroupConstant::RootCgroupFullPath +
+                                      slash + m_cgroup_info_.m_cgroup_path_;
+  cgroup_fd = open(cgroup_path.c_str(), O_RDONLY);
+  if (cgroup_fd < 0) {
+    CRANE_ERROR("Failed to open cgroup");
+    return false;
+  }
+
+  short access = 0;
+  if (CgroupConstant::CgroupLimitDeviceRead) access |= BPF_DEVCG_ACC_READ;
+  if (CgroupConstant::CgroupLimitDeviceWrite) access |= BPF_DEVCG_ACC_WRITE;
+  if (CgroupConstant::CgroupLimitDeviceMknod) access |= BPF_DEVCG_ACC_MKNOD;
+
+  std::unordered_set<std::string> all_request_slots;
+  for (const auto &[_, type_slots_map] :
+       cg_spec.res_in_node.dedicated_res_in_node().name_type_map()) {
+    for (const auto &[__, slots] : type_slots_map.type_slots_map())
+      all_request_slots.insert(slots.slots().cbegin(), slots.slots().cend());
+  };
+
+  auto &bpf_devices = m_cgroup_bpf_devices;
+  for (const auto &[_, this_device] : Craned::g_this_node_device) {
+    if (!all_request_slots.contains(this_device->slot_id)) {
+      for (const auto &dev_meta : this_device->device_file_metas) {
+        short op_type = 0;
+        if (dev_meta.op_type == 'c') {
+          op_type |= BPF_DEVCG_DEV_CHAR;
+        } else if (dev_meta.op_type == 'b') {
+          op_type |= BPF_DEVCG_DEV_BLOCK;
+        } else {
+          op_type |= 0xffff;
+        }
+        bpf_devices.push_back({dev_meta.major, dev_meta.minor,
+                               BPF_PERMISSION::DENY, access, op_type});
+      }
+    }
+  }
+  m_bpf_attached_ = true;
+  return true;
+}
+
 bool CgroupV2::EraseBpfDeviceMap() {
   {
-    if (!bpf_runtime_info_.BpfInvalid()) {
+    if (!CgroupManager::bpf_runtime_info.Valid()) {
       CRANE_WARN("BPF is not initialized.");
       return false;
     }
-    std::unique_lock<std::mutex> lk(*bpf_runtime_info_.BpfMutex());
+    absl::MutexLock lk(CgroupManager::bpf_runtime_info.BpfMutex());
     auto &bpf_devices = m_cgroup_bpf_devices;
     for (int i = 0; i < bpf_devices.size(); i++) {
       struct BpfKey key = {m_cgroup_info_.m_cgroup_id, bpf_devices[i].major,
                            bpf_devices[i].minor};
-      if (bpf_map__delete_elem(bpf_runtime_info_.BpfDevMap(), &key,
-                               sizeof(BpfKey), BPF_ANY)) {
+      if (bpf_map__delete_elem(CgroupManager::bpf_runtime_info.BpfDevMap(),
+                               &key, sizeof(BpfKey), BPF_ANY)) {
         CRANE_ERROR(
             "Failed to delete BPF map major {},minor {} in cgroup id {}",
             bpf_devices[i].major, bpf_devices[i].minor, key.cgroup_id);
@@ -1451,22 +1468,6 @@ bool CgroupV2::Empty() {
   }
 }
 
-bool CgroupV2::MigrateProcIn(pid_t pid) {
-  using CgroupConstant::Controller;
-  using CgroupConstant::GetControllerStringView;
-  int err;
-after_migrate:
-
-  err = cgroup_attach_task_pid(m_cgroup_info_.m_cgroup_, pid);
-  if (err != 0) {
-    CRANE_WARN("Cannot attach pid {} to cgroup {}: {} {}", pid,
-               m_cgroup_info_.m_cgroup_path_.c_str(), err,
-               cgroup_strerror(err));
-  }
-end:
-  return err == 0;
-}
-
 bool AllocatableResourceAllocator::Allocate(const AllocatableResource &resource,
                                             CgroupInterface *cg) {
   bool ok;
@@ -1497,12 +1498,17 @@ bool DedicatedResourceAllocator::Allocate(
     const crane::grpc::DedicatedResourceInNode &request_resource,
     CgroupInterface *cg) {
   std::unordered_set<std::string> all_request_slots;
-  for (const auto &[_, type_slots_map] : request_resource.name_type_map()) {
-    for (const auto &[__, slots] : type_slots_map.type_slots_map())
+  for (const auto &type_slots_map :
+       request_resource.name_type_map() | std::ranges::views::values) {
+    for (const auto &slots :
+         type_slots_map.type_slots_map() | std::ranges::views::values)
       all_request_slots.insert(slots.slots().cbegin(), slots.slots().cend());
   };
 
-  if (!cg->SetDeviceAccess(all_request_slots, true, true, true)) {
+  if (!cg->SetDeviceAccess(all_request_slots,
+                           CgroupConstant::CgroupLimitDeviceRead,
+                           CgroupConstant::CgroupLimitDeviceWrite,
+                           CgroupConstant::CgroupLimitDeviceMknod)) {
     if (g_cg_mgr->GetCgroupVersion() ==
         CgroupConstant::CgroupVersion::CGROUP_V1) {
       CRANE_WARN("Allocate devices access failed in Cgroup V1.");

--- a/src/Craned/CgroupManager.h
+++ b/src/Craned/CgroupManager.h
@@ -537,6 +537,8 @@ class CgroupManager {
   static std::unordered_map<ino_t, task_id_t> GetCgJobIdMapCgroupV2(
       const std::string &root_cgroup_path);
 
+  void RmAllJobCgroups_();
+
 #ifdef CRANE_ENABLE_BPF
   CraneExpected<std::unordered_map<task_id_t, std::vector<BpfKey>>>
   GetJobBpfMapCgroupsV2(const std::string &root_cgroup_path);

--- a/src/Craned/CgroupManager.h
+++ b/src/Craned/CgroupManager.h
@@ -352,7 +352,7 @@ class CgroupInterface {
  public:
   CgroupInterface(const std::string &path, struct cgroup *handle,
                   uint64_t id = 0)
-      : m_cgroup_info_(path, handle, id) {};
+      : m_cgroup_info(path, handle, id) {};
   virtual ~CgroupInterface() = default;
   virtual bool SetCpuCoreLimit(double core_num) = 0;
   virtual bool SetCpuShares(uint64_t share) = 0;
@@ -372,11 +372,11 @@ class CgroupInterface {
 
   bool MigrateProcIn(pid_t pid);
   const std::string &GetCgroupString() const {
-    return m_cgroup_info_.m_cgroup_path_;
+    return m_cgroup_info.m_cgroup_path_;
   };
 
  protected:
-  Cgroup m_cgroup_info_;
+  Cgroup m_cgroup_info;
 };
 
 class CgroupV1 : public CgroupInterface {

--- a/src/Craned/CgroupManager.h
+++ b/src/Craned/CgroupManager.h
@@ -294,6 +294,7 @@ class BpfRuntimeInfo {
   ~BpfRuntimeInfo();
   bool InitializeBpfObj();
   void CloseBpfObj();
+  void Destroy();
   static void RmBpfDeviceMap();
 
   struct bpf_object *BpfObj() { return bpf_obj_; }
@@ -478,9 +479,13 @@ class DedicatedResourceAllocator {
 
 class CgroupManager {
  public:
-#ifdef CRANE_ENABLE_BPF
-  ~CgroupManager();
-#endif
+  CgroupManager() = default;
+  ~CgroupManager() = default;
+
+  CgroupManager(const CgroupManager &) = delete;
+  CgroupManager(CgroupManager &&) = delete;
+  CgroupManager &operator=(const CgroupManager &) = delete;
+  CgroupManager &operator=(CgroupManager &&) = delete;
 
   CraneErrCode Init();
 

--- a/src/Craned/CgroupManager.h
+++ b/src/Craned/CgroupManager.h
@@ -512,7 +512,7 @@ class CgroupManager {
     return m_cg_version_;
   }
 #ifdef CRANE_ENABLE_BPF
-  static BpfRuntimeInfo bpf_runtime_info;
+  BpfRuntimeInfo bpf_runtime_info;
 #endif
  private:
   inline static std::string CgroupStrByTaskId_(task_id_t task_id);
@@ -538,7 +538,7 @@ class CgroupManager {
       const std::string &root_cgroup_path);
 
 #ifdef CRANE_ENABLE_BPF
-  static CraneExpected<std::unordered_map<task_id_t, std::vector<BpfKey>>>
+  CraneExpected<std::unordered_map<task_id_t, std::vector<BpfKey>>>
   GetJobBpfMapCgroupsV2(const std::string &root_cgroup_path);
 #endif
 

--- a/src/Craned/CgroupManager.h
+++ b/src/Craned/CgroupManager.h
@@ -467,7 +467,7 @@ class CgroupV2 : public CgroupInterface {
 
  private:
 #ifdef CRANE_ENABLE_BPF
-  bool m_bpf_attached_;
+  bool m_bpf_attached_{false};
   std::vector<BpfDeviceMeta> m_cgroup_bpf_devices{};
 #endif
 };

--- a/src/Craned/Craned.cpp
+++ b/src/Craned/Craned.cpp
@@ -110,10 +110,6 @@ void ParseConfig(int argc, char** argv) {
         std::exit(1);
       }
 
-#ifdef CRANE_ENABLE_BPF
-      Craned::CgroupManager::bpf_runtime_info.SetLogEnabled(
-          log_level.value() < spdlog::level::info);
-#endif
       g_config.CranedUnixSockPath =
           g_config.CraneBaseDir /
           value_or(config["CranedUnixSockPath"], kDefaultCranedUnixSockPath);

--- a/src/Craned/Craned.cpp
+++ b/src/Craned/Craned.cpp
@@ -635,6 +635,7 @@ void StartServer() {
   g_server.reset();
   g_ctld_client.reset();
   g_job_mgr.reset();
+  g_cg_mgr.reset();
 
   g_thread_pool->wait();
   g_thread_pool.reset();

--- a/src/Craned/CranedPublicDefs.h
+++ b/src/Craned/CranedPublicDefs.h
@@ -74,11 +74,11 @@ struct Config {
   std::string CraneCtldListenPort;
   std::string CranedDebugLevel;
 
-  std::string CraneBaseDir;
-  std::string CranedLogFile;
-  std::string CranedMutexFilePath;
-  std::string CranedScriptDir;
-  std::string CranedUnixSockPath;
+  std::filesystem::path CraneBaseDir;
+  std::filesystem::path CranedLogFile;
+  std::filesystem::path CranedMutexFilePath;
+  std::filesystem::path CranedScriptDir;
+  std::filesystem::path CranedUnixSockPath;
 
   bool CranedForeground{};
 

--- a/src/Craned/CranedServer.cpp
+++ b/src/Craned/CranedServer.cpp
@@ -20,8 +20,8 @@
 
 #include <yaml-cpp/yaml.h>
 
-#include "JobManager.h"
 #include "CtldClient.h"
+#include "JobManager.h"
 #include "TaskManager.h"
 
 namespace Craned {

--- a/src/Craned/JobManager.cpp
+++ b/src/Craned/JobManager.cpp
@@ -127,7 +127,7 @@ bool JobManager::FreeJobs(const std::vector<task_id_t>& job_ids) {
 
     if (g_config.Plugin.Enabled) {
       g_plugin_client->DestroyCgroupHookAsync(job_ids[idx],
-                                              cgroup->GetCgroupString());
+                                              cgroup->CgroupPathStr());
     }
     g_thread_pool->detach_task([cgroup]() {
       int cnt = 0;
@@ -139,7 +139,7 @@ bool JobManager::FreeJobs(const std::vector<task_id_t>& job_ids) {
           CRANE_ERROR(
               "Couldn't kill the processes in cgroup {} after {} times. "
               "Skipping it.",
-              cgroup->GetCgroupString(), cnt);
+              cgroup->CgroupPathStr(), cnt);
           break;
         }
 

--- a/src/Craned/JobManager.cpp
+++ b/src/Craned/JobManager.cpp
@@ -1,0 +1,179 @@
+/**
+ * Copyright (c) 2025 Peking University and Peking University
+ * Changsha Institute for Computing and Digital Economy
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+#include "JobManager.h"
+
+#include "crane/PluginClient.h"
+
+namespace Craned {
+
+EnvMap JobSpec::GetJobEnvMap() const {
+  auto env_map = CgroupManager::GetResourceEnvMapByResInNode(
+      this->cgroup_spec.res_in_node);
+
+  // TODO: Move all job level env to here.
+  env_map.emplace("CRANE_JOB_ID", std::to_string(this->cgroup_spec.job_id));
+  return env_map;
+}
+
+JobInstance::JobInstance(JobSpec&& spec)
+    : job_id(spec.cgroup_spec.job_id), job_spec(spec) {}
+
+JobInstance::JobInstance(const JobSpec& spec)
+    : job_id(spec.cgroup_spec.job_id), job_spec(spec) {}
+
+bool JobManager::AllocJobs(std::vector<JobSpec>&& job_specs) {
+  CRANE_DEBUG("Allocating {} tasks", job_specs.size());
+
+  auto begin = std::chrono::steady_clock::now();
+
+  for (auto& job_spec : job_specs) {
+    task_id_t job_id = job_spec.cgroup_spec.job_id;
+    uid_t uid = job_spec.cgroup_spec.uid;
+    CRANE_TRACE("Create lazily allocated cgroups for task #{}, uid {}", job_id,
+                uid);
+    m_job_map_.Emplace(job_id, JobInstance(job_spec));
+
+    auto uid_map = m_uid_to_job_ids_map_.GetMapExclusivePtr();
+    if (uid_map->contains(uid)) {
+      uid_map->at(uid).RawPtr()->emplace(job_id);
+    } else {
+      uid_map->emplace(uid, absl::flat_hash_set<task_id_t>({job_id}));
+    }
+  }
+
+  auto end = std::chrono::steady_clock::now();
+  CRANE_TRACE("Create cgroups costed {} ms",
+              std::chrono::duration_cast<std::chrono::milliseconds>(end - begin)
+                  .count());
+  return true;
+}
+
+bool JobManager::FreeJobs(const std::vector<task_id_t>& job_ids) {
+  {
+    auto map_ptr = m_job_map_.GetMapExclusivePtr();
+    for (auto job_id : job_ids) {
+      if (!map_ptr->contains(job_id)) {
+        CRANE_WARN("Try to free nonexistent job#{}", job_id);
+        return false;
+      }
+    }
+  }
+
+  std::vector<CgroupInterface*> cg_ptr_vec;
+  std::vector<uid_t> uid_vec;
+  {
+    auto map_ptr = m_job_map_.GetMapExclusivePtr();
+    for (auto job_id : job_ids) {
+      cg_ptr_vec.emplace_back(map_ptr->at(job_id).RawPtr()->cgroup.release());
+      uid_vec.emplace_back(
+          map_ptr->at(job_id).RawPtr()->job_spec.cgroup_spec.uid);
+      map_ptr->erase(job_id);
+    }
+  }
+  {
+    auto uid_map = m_uid_to_job_ids_map_.GetMapExclusivePtr();
+    for (auto [idx, job_id] : job_ids | std::ranges::views::enumerate) {
+      bool erase{false};
+      {
+        auto& value = uid_map->at(uid_vec[idx]);
+        value.RawPtr()->erase(job_id);
+        erase = value.RawPtr()->empty();
+      }
+      if (erase) {
+        uid_map->erase(uid_vec[idx]);
+      }
+    }
+  }
+  for (auto [idx, cgroup] : cg_ptr_vec | std::ranges::views::enumerate) {
+    if (g_config.Plugin.Enabled) {
+      g_plugin_client->DestroyCgroupHookAsync(job_ids[idx],
+                                              cgroup->GetCgroupString());
+    }
+
+    if (cgroup != nullptr) {
+      g_thread_pool->detach_task([cgroup]() {
+        int cnt = 0;
+
+        while (true) {
+          if (cgroup->Empty()) break;
+
+          if (cnt >= 5) {
+            CRANE_ERROR(
+                "Couldn't kill the processes in cgroup {} after {} times. "
+                "Skipping it.",
+                cgroup->GetCgroupString(), cnt);
+            break;
+          }
+
+          cgroup->KillAllProcesses();
+          ++cnt;
+          std::this_thread::sleep_for(std::chrono::milliseconds(100));
+        }
+
+        delete cgroup;
+      });
+    }
+  }
+  return true;
+}
+
+std::optional<TaskInfoOfUid> JobManager::QueryTaskInfoOfUid(uid_t uid) {
+  TaskInfoOfUid info;
+  info.job_cnt = 0;
+  info.cgroup_exists = false;
+
+  if (auto task_ids = this->m_uid_to_job_ids_map_[uid]; task_ids) {
+    if (!task_ids) {
+      CRANE_WARN("Uid {} not found in uid_to_task_ids_map", uid);
+      return std::nullopt;
+    }
+    info.cgroup_exists = true;
+    info.job_cnt = task_ids->size();
+    info.first_task_id = *task_ids->begin();
+  }
+  return info;
+}
+
+bool JobManager::MigrateProcToCgroupOfJob(pid_t pid, task_id_t job_id) {
+  auto job_instance = m_job_map_.GetValueExclusivePtr(job_id);
+  if (!job_instance) return false;
+  auto& cg = job_instance->cgroup;
+  if (!cg) {
+    cg = g_cg_mgr->AllocateAndGetJobCgroup(job_instance->job_spec.cgroup_spec);
+  }
+  if (!cg) return false;
+
+  return cg->MigrateProcIn(pid);
+}
+
+CraneExpected<JobSpec> JobManager::QueryJobSpec(task_id_t job_id) {
+  auto instance = m_job_map_.GetValueExclusivePtr(job_id);
+  if (!instance) return std::unexpected(CraneErrCode::ERR_NON_EXISTENT);
+  return instance->job_spec;
+};
+
+std::unordered_set<task_id_t> JobManager::QueryExistentJobIds() {
+  std::unordered_set<task_id_t> job_ids;
+  auto job_map_ptr = m_job_map_.GetMapConstSharedPtr();
+  job_ids.reserve(job_map_ptr->size());
+  return *job_map_ptr | std::ranges::views::keys |
+         std::ranges::to<std::unordered_set<task_id_t>>();
+}
+
+};  // namespace Craned

--- a/src/Craned/JobManager.cpp
+++ b/src/Craned/JobManager.cpp
@@ -32,14 +32,14 @@ EnvMap JobSpec::GetJobEnvMap() const {
 }
 
 bool JobManager::AllocJobs(std::vector<JobSpec>&& job_specs) {
-  CRANE_DEBUG("Allocating {} tasks", job_specs.size());
+  CRANE_DEBUG("Allocating {} job", job_specs.size());
 
   auto begin = std::chrono::steady_clock::now();
 
   for (auto& job_spec : job_specs) {
     task_id_t job_id = job_spec.cgroup_spec.job_id;
     uid_t uid = job_spec.cgroup_spec.uid;
-    CRANE_TRACE("Create lazily allocated cgroups for task #{}, uid {}", job_id,
+    CRANE_TRACE("Create lazily allocated cgroups for job #{}, uid {}", job_id,
                 uid);
     m_job_map_.Emplace(job_id, JobInstance(job_spec));
 
@@ -52,7 +52,7 @@ bool JobManager::AllocJobs(std::vector<JobSpec>&& job_specs) {
   }
 
   auto end = std::chrono::steady_clock::now();
-  CRANE_TRACE("Create cgroups costed {} ms",
+  CRANE_TRACE("Allocating cgroups costed {} ms",
               std::chrono::duration_cast<std::chrono::milliseconds>(end - begin)
                   .count());
   return true;

--- a/src/Craned/JobManager.h
+++ b/src/Craned/JobManager.h
@@ -1,0 +1,83 @@
+/**
+ * Copyright (c) 2025 Peking University and Peking University
+ * Changsha Institute for Computing and Digital Economy
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+#pragma once
+
+#include "CranedPublicDefs.h"
+// Precompiled header comes first.
+
+#include "CgroupManager.h"
+#include "protos/Crane.grpc.pb.h"
+
+namespace Craned {
+
+struct JobSpec {
+  JobSpec() = default;
+  explicit JobSpec(const crane::grpc::JobSpec& spec) : cgroup_spec(spec) {}
+
+  CgroupSpec cgroup_spec;
+  EnvMap GetJobEnvMap() const;
+};
+
+struct JobInstance {
+  explicit JobInstance(JobSpec&& spec);
+  explicit JobInstance(const JobSpec& spec);
+  JobInstance(JobInstance&& other) noexcept
+      : job_id(std::move(other.job_id)),
+        job_spec(std::move(other.job_spec)),
+        cgroup(std::move(other.cgroup)) {};
+  JobInstance& operator=(JobInstance&& other) noexcept {
+    if (this != &other) {
+      job_id = std::move(other.job_id);
+      job_spec = std::move(other.job_spec);
+      cgroup = std::move(other.cgroup);
+    }
+    return *this;
+  }
+  ~JobInstance() = default;
+
+  task_id_t job_id;
+  JobSpec job_spec;
+
+  std::unique_ptr<CgroupInterface> cgroup{nullptr};
+};
+
+class JobManager {
+ public:
+  JobManager() = default;
+  bool AllocJobs(std::vector<JobSpec>&& job_specs);
+
+  bool FreeJobs(const std::vector<task_id_t>& job_ids);
+
+  std::optional<TaskInfoOfUid> QueryTaskInfoOfUid(uid_t uid);
+
+  bool MigrateProcToCgroupOfJob(pid_t pid, task_id_t job_id);
+
+  CraneExpected<JobSpec> QueryJobSpec(task_id_t job_id);
+
+  std::unordered_set<task_id_t> QueryExistentJobIds();
+
+ private:
+  util::AtomicHashMap<absl::node_hash_map, task_id_t, JobInstance> m_job_map_;
+  util::AtomicHashMap<absl::flat_hash_map, uid_t /*uid*/,
+                      absl::flat_hash_set<task_id_t>>
+      m_uid_to_job_ids_map_;
+};
+
+};  // namespace Craned
+
+inline std::unique_ptr<Craned::JobManager> g_job_mgr;

--- a/src/Craned/JobManager.h
+++ b/src/Craned/JobManager.h
@@ -64,7 +64,10 @@ struct JobInstance {
 class JobManager {
  public:
   JobManager() = default;
+
   bool AllocJobs(std::vector<JobSpec>&& job_specs);
+
+  CgroupInterface* GetCgForJob(task_id_t job_id);
 
   bool FreeJobs(const std::vector<task_id_t>& job_ids);
 

--- a/src/Craned/JobManager.h
+++ b/src/Craned/JobManager.h
@@ -38,10 +38,13 @@ struct JobInstance {
       : job_id(spec.cgroup_spec.job_id), job_spec(spec) {}
   explicit JobInstance(const JobSpec& spec)
       : job_id(spec.cgroup_spec.job_id), job_spec(std::move(spec)) {}
+  JobInstance(const JobInstance& other) = delete;
   JobInstance(JobInstance&& other) noexcept
       : job_id(std::move(other.job_id)),
         job_spec(std::move(other.job_spec)),
         cgroup(std::move(other.cgroup)) {};
+
+  JobInstance& operator=(const JobInstance& other) = delete;
   JobInstance& operator=(JobInstance&& other) noexcept {
     if (this != &other) {
       job_id = std::move(other.job_id);

--- a/src/Craned/JobManager.h
+++ b/src/Craned/JobManager.h
@@ -27,33 +27,35 @@ namespace Craned {
 
 struct JobSpec {
   JobSpec() = default;
-  explicit JobSpec(const crane::grpc::JobSpec& spec) : cgroup_spec(spec) {}
+  explicit JobSpec(const crane::grpc::JobSpec& spec) : cg_spec(spec) {}
 
-  CgroupSpec cgroup_spec;
+  CgroupSpec cg_spec;
   EnvMap GetJobEnvMap() const;
 };
 
 struct JobInstance {
   explicit JobInstance(JobSpec&& spec)
-      : job_id(spec.cgroup_spec.job_id), job_spec(spec) {}
+      : job_id(spec.cg_spec.job_id), job_spec(spec) {}
   explicit JobInstance(const JobSpec& spec)
-      : job_id(spec.cgroup_spec.job_id), job_spec(std::move(spec)) {}
+      : job_id(spec.cg_spec.job_id), job_spec(spec) {}
+
   JobInstance(const JobInstance& other) = delete;
   JobInstance(JobInstance&& other) noexcept
-      : job_id(std::move(other.job_id)),
+      : job_id(other.job_id),
         job_spec(std::move(other.job_spec)),
         cgroup(std::move(other.cgroup)) {};
+
+  ~JobInstance() = default;
 
   JobInstance& operator=(const JobInstance& other) = delete;
   JobInstance& operator=(JobInstance&& other) noexcept {
     if (this != &other) {
-      job_id = std::move(other.job_id);
+      job_id = other.job_id;
       job_spec = std::move(other.job_spec);
       cgroup = std::move(other.cgroup);
     }
     return *this;
   }
-  ~JobInstance() = default;
 
   task_id_t job_id;
   JobSpec job_spec;

--- a/src/Craned/JobManager.h
+++ b/src/Craned/JobManager.h
@@ -34,8 +34,10 @@ struct JobSpec {
 };
 
 struct JobInstance {
-  explicit JobInstance(JobSpec&& spec);
-  explicit JobInstance(const JobSpec& spec);
+  explicit JobInstance(JobSpec&& spec)
+      : job_id(spec.cgroup_spec.job_id), job_spec(spec) {}
+  explicit JobInstance(const JobSpec& spec)
+      : job_id(spec.cgroup_spec.job_id), job_spec(std::move(spec)) {}
   JobInstance(JobInstance&& other) noexcept
       : job_id(std::move(other.job_id)),
         job_spec(std::move(other.job_spec)),

--- a/src/Craned/TaskManager.cpp
+++ b/src/Craned/TaskManager.cpp
@@ -1039,7 +1039,7 @@ CraneErrCode TaskManager::SpawnProcessInInstance_(TaskInstance* instance,
 }
 
 CraneErrCode TaskManager::ExecuteTaskAsync(crane::grpc::TaskToD const& task) {
-  CRANE_INFO("Executing task #{}", task.task_id());
+  CRANE_INFO("Executing task #{} {}", task.task_id(), task.DebugString());
 
   auto instance = std::make_unique<TaskInstance>();
 

--- a/src/Craned/TaskManager.cpp
+++ b/src/Craned/TaskManager.cpp
@@ -1039,7 +1039,7 @@ CraneErrCode TaskManager::SpawnProcessInInstance_(TaskInstance* instance,
 }
 
 CraneErrCode TaskManager::ExecuteTaskAsync(crane::grpc::TaskToD const& task) {
-  CRANE_INFO("Executing task #{} {}", task.task_id(), task.DebugString());
+  CRANE_INFO("Executing task #{}.", task.task_id());
 
   auto instance = std::make_unique<TaskInstance>();
 

--- a/src/Craned/TaskManager.cpp
+++ b/src/Craned/TaskManager.cpp
@@ -1126,7 +1126,7 @@ void TaskManager::LaunchTaskInstanceMt_(TaskInstance* instance) {
     return;
   }
   instance->cgroup = cg;
-  instance->cgroup_path = instance->cgroup->GetCgroupString();
+  instance->cgroup_path = instance->cgroup->CgroupPathStr();
 
   // Calloc tasks have no scripts to run. Just return.
   if (instance->IsCalloc()) return;

--- a/src/Craned/TaskManager.cpp
+++ b/src/Craned/TaskManager.cpp
@@ -292,7 +292,7 @@ void TaskManager::TaskStopAndDoStatusChangeAsync(uint32_t task_id) {
 }
 
 void TaskManager::EvSigchldCb_() {
-  assert(s_instance_ptr_->s_instance_ptr_ != nullptr);
+  CRANE_ASSERT(s_instance_ptr_ != nullptr);
 
   int status;
   pid_t pid;

--- a/src/Craned/TaskManager.cpp
+++ b/src/Craned/TaskManager.cpp
@@ -1115,7 +1115,7 @@ void TaskManager::LaunchTaskInstanceMt_(TaskInstance* instance) {
     return;
   }
 
-  auto cg = g_cg_mgr->AllocateAndGetJobCgroup(job_expt.value().cgroup_spec);
+  auto* cg = g_job_mgr->GetCgForJob(task_id);
   if (!cg) {
     CRANE_ERROR("Failed to allocate cgroup for task #{}", task_id);
     ActivateTaskStatusChangeAsync_(
@@ -1124,7 +1124,7 @@ void TaskManager::LaunchTaskInstanceMt_(TaskInstance* instance) {
         fmt::format("Failed to allocate cgroup for task #{}", task_id));
     return;
   }
-  instance->cgroup = std::move(cg);
+  instance->cgroup = cg;
   instance->cgroup_path = instance->cgroup->GetCgroupString();
 
   // Calloc tasks have no scripts to run. Just return.

--- a/src/Craned/TaskManager.cpp
+++ b/src/Craned/TaskManager.cpp
@@ -27,6 +27,7 @@
 
 #include "CforedClient.h"
 #include "CtldClient.h"
+#include "JobManager.h"
 #include "crane/String.h"
 #include "protos/CraneSubprocess.pb.h"
 #include "protos/PublicDefs.pb.h"
@@ -146,14 +147,6 @@ TaskManager::TaskManager() {
   if (m_sigterm_handle_->start(SIGTERM) != 0) {
     CRANE_ERROR("Failed to start the SIGTERM handle");
   }
-
-  // gRPC: QueryTaskIdFromPid
-  m_query_task_id_from_pid_async_handle_ =
-      m_uvw_loop_->resource<uvw::async_handle>();
-  m_query_task_id_from_pid_async_handle_->on<uvw::async_event>(
-      [this](const uvw::async_event&, uvw::async_handle&) {
-        EvCleanGrpcQueryTaskIdFromPidQueueCb_();
-      });
 
   // gRPC: QueryTaskEnvironmentVariable
   m_query_task_environment_variables_async_handle_ =
@@ -445,9 +438,8 @@ void TaskManager::EvGracefulExitCb_() {
     // SIGTERM to all tasks to kill them immediately.
 
     CRANE_INFO(
-        "Caught SIGINT or SIGTERM, graceful exit. Sending SIGTERM to all "
-        "running "
-        "tasks...");
+        "SIGINT or SIGTERM was caught, exit gracefully. "
+        "Sending SIGTERM to all running tasks...");
 
     m_is_ending_now_ = true;
 
@@ -562,8 +554,8 @@ CraneErrCode TaskManager::SpawnProcessInInstance_(TaskInstance* instance,
   // If the lock is held in the parent process during fork, the forked thread
   // in the child proc will block forever. That's why we should copy it here
   // and the child proc should not hold any lock.
-  auto res_in_node = g_cg_mgr->GetTaskResourceInNode(instance->task.task_id());
-  if (!res_in_node.has_value()) {
+  auto job_expt = g_job_mgr->QueryJobSpec(instance->task.task_id());
+  if (!job_expt.has_value()) {
     CRANE_ERROR("[Task #{}] Failed to get resource info",
                 instance->task.task_id());
     return CraneErrCode::ERR_CGROUP;
@@ -1000,8 +992,8 @@ CraneErrCode TaskManager::SpawnProcessInInstance_(TaskInstance* instance,
     }
 
     EnvMap task_env_map = instance->GetTaskEnvMap();
-    EnvMap res_env_map =
-        CgroupManager::GetResourceEnvMapByResInNode(res_in_node.value());
+    EnvMap res_env_map = CgroupManager::GetResourceEnvMapByResInNode(
+        job_expt.value().cgroup_spec.res_in_node);
 
     // clearenv() should be called just before fork!
     if (clearenv()) fmt::print(stderr, "[Subproc] clearenv() failed.\n");
@@ -1047,11 +1039,6 @@ CraneErrCode TaskManager::SpawnProcessInInstance_(TaskInstance* instance,
 }
 
 CraneErrCode TaskManager::ExecuteTaskAsync(crane::grpc::TaskToD const& task) {
-  if (!g_cg_mgr->CheckIfCgroupForTasksExists(task.task_id())) {
-    CRANE_DEBUG("Executing task #{} without an allocated cgroup. Ignoring it.",
-                task.task_id());
-    return CraneErrCode::ERR_CGROUP;
-  }
   CRANE_INFO("Executing task #{}", task.task_id());
 
   auto instance = std::make_unique<TaskInstance>();
@@ -1106,7 +1093,8 @@ void TaskManager::LaunchTaskInstanceMt_(TaskInstance* instance) {
   // Take care of thread safety.
   task_id_t task_id = instance->task.task_id();
 
-  if (!g_cg_mgr->CheckIfCgroupForTasksExists(task_id)) {
+  auto job_expt = g_job_mgr->QueryJobSpec(instance->task.task_id());
+  if (!job_expt.has_value()) {
     CRANE_ERROR("Failed to find created cgroup for task #{}", task_id);
     ActivateTaskStatusChangeAsync_(
         task_id, crane::grpc::TaskStatus::Failed,
@@ -1127,9 +1115,8 @@ void TaskManager::LaunchTaskInstanceMt_(TaskInstance* instance) {
     return;
   }
 
-  CgroupInterface* cg;
-  bool ok = g_cg_mgr->AllocateAndGetCgroup(task_id, &cg);
-  if (!ok) {
+  auto cg = g_cg_mgr->AllocateAndGetJobCgroup(job_expt.value().cgroup_spec);
+  if (!cg) {
     CRANE_ERROR("Failed to allocate cgroup for task #{}", task_id);
     ActivateTaskStatusChangeAsync_(
         task_id, crane::grpc::TaskStatus::Failed,
@@ -1137,8 +1124,8 @@ void TaskManager::LaunchTaskInstanceMt_(TaskInstance* instance) {
         fmt::format("Failed to allocate cgroup for task #{}", task_id));
     return;
   }
-  instance->cgroup = cg;
-  instance->cgroup_path = cg->GetCgroupString();
+  instance->cgroup = std::move(cg);
+  instance->cgroup_path = instance->cgroup->GetCgroupString();
 
   // Calloc tasks have no scripts to run. Just return.
   if (instance->IsCalloc()) return;
@@ -1334,34 +1321,6 @@ void TaskManager::EvCleanGrpcQueryTaskEnvQueueCb_() {
   }
 }
 
-CraneExpected<task_id_t> TaskManager::QueryTaskIdFromPidAsync(pid_t pid) {
-  EvQueueQueryTaskIdFromPid elem{.pid = pid};
-  std::future<CraneExpected<task_id_t>> task_id_opt_future =
-      elem.task_id_prom.get_future();
-  m_query_task_id_from_pid_queue_.enqueue(std::move(elem));
-  m_query_task_id_from_pid_async_handle_->send();
-  return task_id_opt_future.get();
-}
-
-void TaskManager::EvCleanGrpcQueryTaskIdFromPidQueueCb_() {
-  EvQueueQueryTaskIdFromPid elem;
-  while (m_query_task_id_from_pid_queue_.try_dequeue(elem)) {
-    m_mtx_.Lock();
-
-    auto task_iter = m_pid_task_map_.find(elem.pid);
-    if (task_iter == m_pid_task_map_.end())
-      elem.task_id_prom.set_value(
-          std::unexpected(CraneErrCode::ERR_SYSTEM_ERR));
-    else {
-      TaskInstance* instance = task_iter->second;
-      uint32_t task_id = instance->task.task_id();
-      elem.task_id_prom.set_value(task_id);
-    }
-
-    m_mtx_.Unlock();
-  }
-}
-
 void TaskManager::EvTaskTimerCb_(task_id_t task_id) {
   CRANE_TRACE("Task #{} exceeded its time limit. Terminating it...", task_id);
 
@@ -1425,7 +1384,7 @@ void TaskManager::EvCleanTerminateTaskQueueCb_() {
       // we just remove the cgroup for such task, Ctld will fail in the
       // following ExecuteTasks and the task will go to the right place as
       // well as the completed queue.
-      g_cg_mgr->ReleaseCgroupByTaskIdOnly(elem.task_id);
+      g_job_mgr->FreeJobs({elem.task_id});
       continue;
     }
 

--- a/src/Craned/TaskManager.h
+++ b/src/Craned/TaskManager.h
@@ -178,7 +178,7 @@ struct TaskInstance {
   std::unique_ptr<MetaInTaskInstance> meta;
 
   std::string cgroup_path;
-  std::unique_ptr<CgroupInterface> cgroup;
+  CgroupInterface* cgroup;
   std::shared_ptr<uvw::timer_handle> termination_timer{nullptr};
 
   // Task execution results

--- a/src/Craned/TaskManager.h
+++ b/src/Craned/TaskManager.h
@@ -84,7 +84,7 @@ class ProcessInstance {
 
  private:
   /* ------------- Fields set by SpawnProcessInInstance_  ---------------- */
-  pid_t m_pid_;
+  pid_t m_pid_{-1};
 
   /* ------- Fields set by the caller of SpawnProcessInInstance_  -------- */
   std::string m_executive_path_;
@@ -105,7 +105,7 @@ class ProcessInstance {
    */
   std::function<void(bool, int, void*)> m_finish_cb_;
 
-  void* m_user_data_;
+  void* m_user_data_{nullptr};
   std::function<void(void*)> m_clean_cb_;
 };
 
@@ -131,9 +131,9 @@ struct CrunMetaInTaskInstance : MetaInTaskInstance {
 
 // also arg for EvSigchldTimerCb_
 struct ProcSigchldInfo {
-  pid_t pid;
-  bool is_terminated_by_signal;
-  int value;
+  pid_t pid{};
+  bool is_terminated_by_signal{};
+  int value{};
 
   std::shared_ptr<uvw::timer_handle> resend_timer{nullptr};
 };
@@ -437,7 +437,7 @@ class TaskManager {
 
   std::thread m_uvw_thread_;
 
-  static inline TaskManager* m_instance_ptr_;
+  static inline TaskManager* s_instance_ptr_;
 };
 }  // namespace Craned
 

--- a/src/Misc/BPF/cgroup_dev_bpf.c
+++ b/src/Misc/BPF/cgroup_dev_bpf.c
@@ -35,26 +35,25 @@ struct {
 SEC("cgroup/dev")
 int craned_device_access(struct bpf_cgroup_dev_ctx *ctx) {
   struct BpfKey key = {bpf_get_current_cgroup_id(), ctx->major, ctx->minor};
-  // value.major in map(0,0,0) contains log level 
+  // value.major in map(0,0,0) contains log level
   struct BpfKey log_key = {(uint64_t)0, (uint32_t)0, (uint32_t)0};
   struct BpfDeviceMeta *log_level_meta;
 
   log_level_meta =
       (struct BpfDeviceMeta *)bpf_map_lookup_elem(&craned_dev_map, &log_key);
-  // 0 means trace mode ,1 means debug mode
-  uint32_t log_level;
+  int enable_logging;
   if (!log_level_meta) {
-    log_level = 0;
+    enable_logging = 0;
   } else {
-    log_level = log_level_meta->major;
+    enable_logging = log_level_meta->major;
   }
 
-  if (log_level <= 1) bpf_printk("ctx cgroup ID : %lu\n", key.cgroup_id);
+  if (enable_logging) bpf_printk("ctx cgroup ID : %lu\n", key.cgroup_id);
   struct BpfDeviceMeta *meta;
 
   meta = (struct BpfDeviceMeta *)bpf_map_lookup_elem(&craned_dev_map, &key);
   if (!meta) {
-    if (log_level <= 1) {
+    if (enable_logging) {
       bpf_printk("BpfDeviceMeta not found for key cgroup ID: %d,\n",
                  key.cgroup_id);
       bpf_printk("Access allowed for device major=%d, minor=%d\n", ctx->major,
@@ -66,7 +65,7 @@ int craned_device_access(struct bpf_cgroup_dev_ctx *ctx) {
   short type = ctx->access_type & 0xFFFF;
   short access = ctx->access_type >> 16;
 
-  if (log_level <= 1)
+  if (enable_logging)
     bpf_printk("meta Device major=%d, minor=%d, access_type=%d\n", meta->major,
                meta->minor, meta->access);
 
@@ -75,21 +74,21 @@ int craned_device_access(struct bpf_cgroup_dev_ctx *ctx) {
       int flag = 1;
       if (access & BPF_DEVCG_ACC_READ)
         if (meta->access & BPF_DEVCG_ACC_READ) {
-          if (log_level <= 1)
+          if (enable_logging)
             bpf_printk("Read access denied for device major=%d, minor=%d\n",
                        ctx->major, ctx->minor);
           flag &= 0;
         }
       if (access & BPF_DEVCG_ACC_WRITE)
         if (meta->access & BPF_DEVCG_ACC_WRITE) {
-          if (log_level <= 1)
+          if (enable_logging)
             bpf_printk("Write access denied for device major=%d, minor=%d\n",
                        ctx->major, ctx->minor);
           flag &= 0;
         }
       if (access & BPF_DEVCG_ACC_MKNOD)
         if (meta->access & BPF_DEVCG_ACC_MKNOD) {
-          if (log_level <= 1)
+          if (enable_logging)
             bpf_printk("Write access denied for device major=%d, minor=%d\n",
                        ctx->major, ctx->minor);
           flag &= 0;
@@ -98,7 +97,7 @@ int craned_device_access(struct bpf_cgroup_dev_ctx *ctx) {
     }
   }
 
-  if (log_level <= 1)
+  if (enable_logging)
     bpf_printk("Access allowed for device major=%d, minor=%d\n", ctx->major,
                ctx->minor);
   return 1;

--- a/src/Utilities/PublicHeader/Logger.cpp
+++ b/src/Utilities/PublicHeader/Logger.cpp
@@ -18,23 +18,45 @@
 
 #include "crane/Logger.h"
 
+std::optional<spdlog::level::level_enum> StrToLogLevel(
+    const std::string& level) {
+  if (level == "trace") {
+    return spdlog::level::trace;
+  } else if (level == "debug") {
+    return spdlog::level::debug;
+  } else if (level == "info") {
+    return spdlog::level::info;
+  } else if (level == "warn") {
+    return spdlog::level::warn;
+  } else if (level == "error") {
+    return spdlog::level::err;
+  } else if (level == "off") {
+    return spdlog::level::off;
+  } else {
+    return std::nullopt;
+  }
+}
+
 void InitLogger(spdlog::level::level_enum level,
-                const std::string& log_file_path) {
+                const std::string& log_file_path, bool console) {
   spdlog::set_pattern("[%^%L%$ %C-%m-%d %s:%#] %v");
 
+  std::vector<spdlog::sink_ptr> sinks;
   auto file_sink = std::make_shared<spdlog::sinks::rotating_file_sink_mt>(
       log_file_path, 1048576 * 50 /*MB*/, 3);
+  file_sink->set_level(level);
+  sinks.push_back(file_sink);
 
-  auto console_sink = std::make_shared<spdlog::sinks::stderr_color_sink_mt>();
+  if (console) {
+    auto console_sink = std::make_shared<spdlog::sinks::stderr_color_sink_mt>();
+    console_sink->set_level(level);
+    sinks.push_back(console_sink);
+  }
 
   spdlog::init_thread_pool(256, 1);
   auto logger = std::make_shared<spdlog::async_logger>(
-      "default", spdlog::sinks_init_list{file_sink, console_sink},
-      spdlog::thread_pool(), spdlog::async_overflow_policy::block);
-
-  file_sink->set_level(level);
-  console_sink->set_level(level);
-
+      "default", sinks.begin(), sinks.end(), spdlog::thread_pool(),
+      spdlog::async_overflow_policy::block);
   spdlog::set_default_logger(logger);
 
   spdlog::flush_on(spdlog::level::err);

--- a/src/Utilities/PublicHeader/Logger.cpp
+++ b/src/Utilities/PublicHeader/Logger.cpp
@@ -38,7 +38,7 @@ std::optional<spdlog::level::level_enum> StrToLogLevel(
 }
 
 void InitLogger(spdlog::level::level_enum level,
-                const std::string& log_file_path, bool console) {
+                const std::string& log_file_path, bool enable_console) {
   spdlog::set_pattern("[%^%L%$ %C-%m-%d %s:%#] %v");
 
   std::vector<spdlog::sink_ptr> sinks;
@@ -47,7 +47,7 @@ void InitLogger(spdlog::level::level_enum level,
   file_sink->set_level(level);
   sinks.push_back(file_sink);
 
-  if (console) {
+  if (enable_console) {
     auto console_sink = std::make_shared<spdlog::sinks::stderr_color_sink_mt>();
     console_sink->set_level(level);
     sinks.push_back(console_sink);

--- a/src/Utilities/PublicHeader/PublicHeader.cpp
+++ b/src/Utilities/PublicHeader/PublicHeader.cpp
@@ -785,3 +785,27 @@ bool operator<=(const ResourceView& lhs, const ResourceView& rhs) {
   return lhs.device_map <= rhs.device_map &&
          lhs.allocatable_res <= rhs.allocatable_res;
 }
+
+CgroupSpec::CgroupSpec(const crane::grpc::JobSpec& job_spec) {
+  job_id = job_spec.job_id();
+  uid = job_spec.uid();
+  res_in_node = job_spec.res();
+  execution_node = job_spec.execution_node();
+  recovered = false;
+}
+
+CgroupSpec::CgroupSpec(const task_id_t job_id, const uid_t uid,
+                       const ResourceInNode& res_in_node,
+                       const std::string& execution_node)
+    : job_id(job_id),
+      uid(uid),
+      res_in_node(res_in_node),
+      execution_node(execution_node),
+      recovered(false) {}
+
+void CgroupSpec::SetJobSpec(crane::grpc::JobSpec* job_spec) const {
+  job_spec->set_job_id(this->job_id);
+  job_spec->set_uid(this->uid);
+  *job_spec->mutable_res() = this->res_in_node;
+  job_spec->set_execution_node(this->execution_node);
+}

--- a/src/Utilities/PublicHeader/PublicHeader.cpp
+++ b/src/Utilities/PublicHeader/PublicHeader.cpp
@@ -790,7 +790,7 @@ CgroupSpec::CgroupSpec(const crane::grpc::JobSpec& job_spec)
     : job_id(job_spec.job_id()),
       uid(job_spec.uid()),
       res_in_node(static_cast<crane::grpc::ResourceInNode>(job_spec.res())),
-      execution_node(job_spec.execution_node()),
+      exec_node(job_spec.execution_node()),
       recovered(false) {}
 
 CgroupSpec::CgroupSpec(const task_id_t job_id, const uid_t uid,
@@ -799,12 +799,12 @@ CgroupSpec::CgroupSpec(const task_id_t job_id, const uid_t uid,
     : job_id(job_id),
       uid(uid),
       res_in_node(static_cast<crane::grpc::ResourceInNode>(res_in_node)),
-      execution_node(execution_node),
+      exec_node(execution_node),
       recovered(false) {}
 
 void CgroupSpec::SetJobSpec(crane::grpc::JobSpec* job_spec) const {
   job_spec->set_job_id(this->job_id);
   job_spec->set_uid(this->uid);
   *job_spec->mutable_res() = this->res_in_node;
-  job_spec->set_execution_node(this->execution_node);
+  job_spec->set_execution_node(this->exec_node);
 }

--- a/src/Utilities/PublicHeader/PublicHeader.cpp
+++ b/src/Utilities/PublicHeader/PublicHeader.cpp
@@ -786,20 +786,19 @@ bool operator<=(const ResourceView& lhs, const ResourceView& rhs) {
          lhs.allocatable_res <= rhs.allocatable_res;
 }
 
-CgroupSpec::CgroupSpec(const crane::grpc::JobSpec& job_spec) {
-  job_id = job_spec.job_id();
-  uid = job_spec.uid();
-  res_in_node = job_spec.res();
-  execution_node = job_spec.execution_node();
-  recovered = false;
-}
+CgroupSpec::CgroupSpec(const crane::grpc::JobSpec& job_spec)
+    : job_id(job_spec.job_id()),
+      uid(job_spec.uid()),
+      res_in_node(static_cast<crane::grpc::ResourceInNode>(job_spec.res())),
+      execution_node(job_spec.execution_node()),
+      recovered(false) {}
 
 CgroupSpec::CgroupSpec(const task_id_t job_id, const uid_t uid,
                        const ResourceInNode& res_in_node,
                        const std::string& execution_node)
     : job_id(job_id),
       uid(uid),
-      res_in_node(res_in_node),
+      res_in_node(static_cast<crane::grpc::ResourceInNode>(res_in_node)),
       execution_node(execution_node),
       recovered(false) {}
 

--- a/src/Utilities/PublicHeader/include/crane/AtomicHashMap.h
+++ b/src/Utilities/PublicHeader/include/crane/AtomicHashMap.h
@@ -71,6 +71,8 @@ class Synchronized {
 };
 
 template <template <typename...> class MapType, typename Key, typename T>
+  requires std::constructible_from<T, T&&> ||
+           std::constructible_from<T, const T&>
 class AtomicHashMap {
  public:
   class CombinedLock;

--- a/src/Utilities/PublicHeader/include/crane/AtomicHashMap.h
+++ b/src/Utilities/PublicHeader/include/crane/AtomicHashMap.h
@@ -71,8 +71,6 @@ class Synchronized {
 };
 
 template <template <typename...> class MapType, typename Key, typename T>
-  requires std::constructible_from<T, T&&> ||
-           std::constructible_from<T, const T&>
 class AtomicHashMap {
  public:
   class CombinedLock;

--- a/src/Utilities/PublicHeader/include/crane/Logger.h
+++ b/src/Utilities/PublicHeader/include/crane/Logger.h
@@ -154,7 +154,7 @@ std::optional<spdlog::level::level_enum> StrToLogLevel(
     const std::string &level);
 
 void InitLogger(spdlog::level::level_enum level,
-                const std::string &log_file_path, bool console);
+                const std::string &log_file_path, bool enable_console);
 
 // Custom type formatting
 namespace fmt {

--- a/src/Utilities/PublicHeader/include/crane/Logger.h
+++ b/src/Utilities/PublicHeader/include/crane/Logger.h
@@ -150,8 +150,11 @@
     } while (false)
 #endif
 
+std::optional<spdlog::level::level_enum> StrToLogLevel(
+    const std::string &level);
+
 void InitLogger(spdlog::level::level_enum level,
-                const std::string &log_file_path);
+                const std::string &log_file_path, bool console);
 
 // Custom type formatting
 namespace fmt {
@@ -166,6 +169,19 @@ struct formatter<cpu_t> {
   template <typename FormatContext>
   auto format(const cpu_t &v, FormatContext &ctx) const {
     return fmt::format_to(ctx.out(), "{:.2f}", static_cast<double>(v));
+  }
+};
+
+template <>
+struct formatter<std::filesystem::path> {
+  template <typename ParseContext>
+  constexpr auto parse(ParseContext &ctx) {
+    return ctx.begin();
+  };
+
+  template <typename FormatContext>
+  auto format(const std::filesystem::path &v, FormatContext &ctx) const {
+    return fmt::format_to(ctx.out(), "{}", v.string());
   }
 };
 

--- a/src/Utilities/PublicHeader/include/crane/PublicHeader.h
+++ b/src/Utilities/PublicHeader/include/crane/PublicHeader.h
@@ -496,5 +496,5 @@ struct CgroupSpec {
   crane::grpc::ResourceInNode res_in_node;
   std::string execution_node;
   // Recovered on start,no need to apply res limit.
-  bool recovered;
+  bool recovered{false};
 };

--- a/src/Utilities/PublicHeader/include/crane/PublicHeader.h
+++ b/src/Utilities/PublicHeader/include/crane/PublicHeader.h
@@ -484,8 +484,7 @@ struct CgroupSpec {
   CgroupSpec(const CgroupSpec& spce) = default;
   explicit CgroupSpec(const crane::grpc::JobSpec& job_spec);
   CgroupSpec(const task_id_t job_id, const uid_t uid,
-             const ResourceInNode& res_in_node,
-             const std::string& execution_node);
+             const ResourceInNode& res_in_node, const CranedId& execution_node);
 
   /**
    * @brief set grpc struct,will move res_in_node field

--- a/src/Utilities/PublicHeader/include/crane/PublicHeader.h
+++ b/src/Utilities/PublicHeader/include/crane/PublicHeader.h
@@ -494,7 +494,7 @@ struct CgroupSpec {
   task_id_t job_id;
   uid_t uid;
   crane::grpc::ResourceInNode res_in_node;
-  std::string execution_node;
+  std::string exec_node;
   // Recovered on start,no need to apply res limit.
   bool recovered{false};
 };

--- a/src/Utilities/PublicHeader/include/crane/PublicHeader.h
+++ b/src/Utilities/PublicHeader/include/crane/PublicHeader.h
@@ -44,6 +44,8 @@ using CraneExpected = std::expected<T, CraneErrCode>;
 template <typename T>
 using CraneExpectedRich = std::expected<T, CraneRichError>;
 
+inline const char* const kDefaultHost = "0.0.0.0";
+
 inline const char* const kCtldDefaultPort = "10011";
 inline const char* const kCranedDefaultPort = "10010";
 inline const char* const kCforedDefaultPort = "10012";
@@ -478,8 +480,22 @@ bool operator<=(const ResourceView& lhs, const ResourceInNode& rhs);
 bool operator<=(const ResourceView& lhs, const ResourceView& rhs);
 
 struct CgroupSpec {
+  CgroupSpec() = default;
+  CgroupSpec(const CgroupSpec& spce) = default;
+  explicit CgroupSpec(const crane::grpc::JobSpec& job_spec);
+  CgroupSpec(const task_id_t job_id, const uid_t uid,
+             const ResourceInNode& res_in_node,
+             const std::string& execution_node);
+
+  /**
+   * @brief set grpc struct,will move res_in_node field
+   * @param job_spec grpc job_spce to set
+   */
+  void SetJobSpec(crane::grpc::JobSpec* job_spec) const;
+  task_id_t job_id;
   uid_t uid;
-  task_id_t task_id;
   crane::grpc::ResourceInNode res_in_node;
   std::string execution_node;
+  // Recovered on start,no need to apply res limit.
+  bool recovered;
 };

--- a/src/Utilities/PublicHeader/include/crane/String.h
+++ b/src/Utilities/PublicHeader/include/crane/String.h
@@ -35,12 +35,12 @@
 
 namespace util {
 
-template <typename D = std::string, typename T1, typename T2>
-  requires requires(const T1 &node) {
-    { node.template as<D>() };
-  } && std::convertible_to<T2, D>
-D value_or(const T1 &node, const T2 &default_value) {
-  return node ? node.template as<D>() : default_value;
+template <typename T = std::string, typename YamlNode, typename DefaultType>
+  requires requires(const YamlNode &node) {
+    { node.template as<T>() };
+  } && std::convertible_to<DefaultType, T>
+T YamlValueOr(const YamlNode &node, const DefaultType &default_value) {
+  return node ? node.template as<T>() : default_value;
 }
 
 std::string ReadFileIntoString(std::filesystem::path const &p);

--- a/src/Utilities/PublicHeader/include/crane/String.h
+++ b/src/Utilities/PublicHeader/include/crane/String.h
@@ -35,6 +35,14 @@
 
 namespace util {
 
+template <typename D = std::string, typename T1, typename T2>
+  requires requires(const T1 &node) {
+    { node.template as<D>() };
+  } && std::convertible_to<T2, D>
+D value_or(const T1 &node, const T2 &default_value) {
+  return node ? node.template as<D>() : default_value;
+}
+
 std::string ReadFileIntoString(std::filesystem::path const &p);
 
 std::string ReadableMemory(uint64_t memory_bytes);


### PR DESCRIPTION
This is part of Supervisor https://github.com/PKUHPC/CraneSched/pull/399

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced job-level resource and cgroup management with a new JobManager component.
  - Added job-based APIs replacing task-centric operations for cgroup creation, release, and querying.
  - Enhanced recovery and cleanup mechanisms for cgroups and BPF integration.

- **Improvements**
  - Standardized configuration parsing with improved filesystem path handling.
  - Refined logging initialization and log level parsing with optional console output.
  - Streamlined protobuf message structures for job specifications.
  - Improved robustness and clarity in cgroup and device management.
  - Added support for filesystem path types in configuration and logging.
  - Enhanced cgroup interface abstraction and unified resource control methods.

- **Bug Fixes**
  - Fixed resource and cgroup allocation inconsistencies during job scheduling and cleanup.

- **Refactor**
  - Simplified cgroup, job, and resource management code; removed deprecated task-level methods.
  - Eliminated asynchronous PID-to-task ID query mechanism.
  - Updated code style and formatting rules for consistency.
  - Reorganized BPF runtime management and improved error handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->