### PR TITLE
feat: Add crane user for CraneCtld

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -467,7 +467,42 @@ set(CPACK_RPM_COMPRESSION_TYPE "xz")
 # DEB
 set(CPACK_DEB_COMPONENT_INSTALL ON)
 set(CPACK_DEBIAN_COMPRESSION_TYPE "xz")
-# Seperate the debuginfo to avoid large DEB package
+# Separate the debuginfo to avoid large DEB package
 set(CPACK_DEBIAN_DEBUGINFO_PACKAGE ON)
+
+# Create post-installation script for creating crane user and directory
+file(WRITE ${CMAKE_BINARY_DIR}/post_install.sh 
+"#!/bin/bash
+# Create crane user if it doesn't exist
+if ! id -u crane &>/dev/null; then
+    useradd -r -s /sbin/nologin crane
+fi
+
+# Create /var/crane directory if it doesn't exist
+mkdir -p /var/crane
+
+# Base Directory
+chown -R crane:crane /var/crane
+chmod 750 /var/crane
+
+# Config Directory
+if [ -d /etc/crane ]; then
+    chown -R crane:crane /etc/crane
+    chmod 750 /etc/crane
+fi
+
+if [ -f /etc/crane/database.yaml ]; then
+    chown crane:crane /etc/crane/database.yaml
+    chmod 600 /etc/crane/database.yaml
+fi
+
+exit 0
+")
+
+# Set execute permissions on the post-install script
+file(CHMOD ${CMAKE_BINARY_DIR}/post_install.sh 
+     PERMISSIONS OWNER_READ OWNER_WRITE OWNER_EXECUTE GROUP_READ GROUP_EXECUTE WORLD_READ WORLD_EXECUTE)
+set(CPACK_RPM_POST_INSTALL_SCRIPT_FILE "${CMAKE_BINARY_DIR}/post_install.sh")
+set(CPACK_DEBIAN_PACKAGE_CONTROL_EXTRA "${CMAKE_BINARY_DIR}/post_install.sh;")
 
 include(CPack)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -426,15 +426,23 @@ install(FILES
 # Install configuration files
 install(FILES ${CMAKE_SOURCE_DIR}/etc/config.yaml
         DESTINATION /etc/crane/
+        RENAME config.yaml.sample
         COMPONENT cranectldc
         PERMISSIONS OWNER_READ OWNER_WRITE GROUP_READ WORLD_READ)
 
 install(FILES ${CMAKE_SOURCE_DIR}/etc/config.yaml
         DESTINATION /etc/crane/
+        RENAME config.yaml.sample
         COMPONENT cranedc
         PERMISSIONS OWNER_READ OWNER_WRITE GROUP_READ WORLD_READ)
 
 # Only cranectld needs database.yaml and permission should be 600
+install(FILES ${CMAKE_SOURCE_DIR}/etc/database.yaml
+        DESTINATION /etc/crane/
+        RENAME database.yaml.sample
+        COMPONENT cranectldc
+        PERMISSIONS OWNER_READ OWNER_WRITE)
+
 install(FILES ${CMAKE_SOURCE_DIR}/etc/database.yaml
         DESTINATION /etc/crane/
         COMPONENT cranectldc
@@ -478,22 +486,33 @@ if ! id -u crane &>/dev/null; then
     useradd -r -s /sbin/nologin crane
 fi
 
-# Create /var/crane directory if it doesn't exist
-mkdir -p /var/crane
-
 # Base Directory
+mkdir -p /var/crane
 chown -R crane:crane /var/crane
 chmod 750 /var/crane
 
 # Config Directory
-if [ -d /etc/crane ]; then
-    chown -R crane:crane /etc/crane
-    chmod 750 /etc/crane
+mkdir -p /etc/crane
+chown -R crane:crane /etc/crane
+chmod 750 /etc/crane
+
+# Handle configuration files
+if [ ! -f /etc/crane/config.yaml ]; then
+    if [ -f /etc/crane/config.yaml.sample ]; then
+        cp /etc/crane/config.yaml.sample /etc/crane/config.yaml
+        chown crane:crane /etc/crane/config.yaml
+        chmod 640 /etc/crane/config.yaml
+        echo \"Created new configuration file: /etc/crane/config.yaml\"
+    fi
 fi
 
-if [ -f /etc/crane/database.yaml ]; then
-    chown crane:crane /etc/crane/database.yaml
-    chmod 600 /etc/crane/database.yaml
+if [ ! -f /etc/crane/database.yaml ]; then
+    if [ -f /etc/crane/database.yaml.sample ]; then
+        cp /etc/crane/database.yaml.sample /etc/crane/database.yaml
+        chown crane:crane /etc/crane/database.yaml
+        chmod 600 /etc/crane/database.yaml
+        echo \"Created new configuration file: /etc/crane/database.yaml\"
+    fi
 fi
 
 exit 0

--- a/etc/cranectld.service.in
+++ b/etc/cranectld.service.in
@@ -3,7 +3,8 @@ Description=CraneCtld
 After=network.target nss-lookup.target
 
 [Service]
-User=root
+User=crane
+Group=crane
 ExecStart=@CMAKE_INSTALL_PREFIX@/bin/cranectld
 
 [Install]

--- a/etc/craned.service.in
+++ b/etc/craned.service.in
@@ -4,6 +4,7 @@ After=network.target nss-lookup.target
 
 [Service]
 User=root
+Group=root
 ExecStart=@CMAKE_INSTALL_PREFIX@/bin/craned
 
 [Install]

--- a/src/CraneCtld/CraneCtld.cpp
+++ b/src/CraneCtld/CraneCtld.cpp
@@ -890,8 +890,10 @@ void CreateFolders() {
 int StartServer() {
   constexpr uint64_t file_max = 640000;
   if (!util::os::SetMaxFileDescriptorNumber(file_max)) {
-    CRANE_ERROR("Unable to set file descriptor limits to {}", file_max);
-    std::exit(1);
+    CRANE_WARN(
+        "Unable to set file descriptor limits to {}. Please increase the hard "
+        "limit if needed.",
+        file_max);
   }
   util::os::CheckProxyEnvironmentVariable();
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
	- Added a post-installation script to ensure the "crane" system user exists, set up necessary directories, and apply correct ownership and permissions for configuration and data files after installation.
	- Updated the systemd service for cranectld to run as the "crane" user and group.
	- Modified the craned systemd service to explicitly specify the group as "root".

- **Bug Fixes**
	- Adjusted error handling for file descriptor limits to log a warning instead of terminating the service if the limit cannot be set.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->