### PR TITLE
fix: Fix duplicated task status changes when err_before_exec is set

### DIFF
--- a/src/Craned/TaskManager.cpp
+++ b/src/Craned/TaskManager.cpp
@@ -242,13 +242,13 @@ void TaskManager::TaskStopAndDoStatusChangeAsync(uint32_t task_id) {
     ActivateTaskStatusChangeAsync_(task_id, crane::grpc::TaskStatus::Failed,
                                    ExitCode::kExitCodeSpawnProcessFail,
                                    std::nullopt);
-    break;
+    return;
 
   case CraneErrCode::ERR_CGROUP:
     ActivateTaskStatusChangeAsync_(task_id, crane::grpc::TaskStatus::Failed,
                                    ExitCode::kExitCodeCgroupError,
                                    std::nullopt);
-    break;
+    return;
 
   default:
     break;


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Improved error handling to prevent further processing when certain task errors occur, ensuring more accurate task status updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->