### PR TITLE
Added BPF CO-RE to cgroup_dev_bpf

### DIFF
--- a/src/Misc/BPF/CMakeLists.txt
+++ b/src/Misc/BPF/CMakeLists.txt
@@ -19,11 +19,8 @@ else ()
     set(BPF_COMPILER ${CMAKE_C_COMPILER})
 endif ()
 
-if (CMAKE_BUILD_TYPE STREQUAL "Debug")
-    list(APPEND BPF_COMPILE_OPTIONS -g)
-endif ()
-
-list(APPEND BPF_COMPILE_OPTIONS -O2)
+# always use -g for BPF CO-RE
+list(APPEND BPF_COMPILE_OPTIONS -O2 -g)
 
 add_custom_command(
         OUTPUT ${BPF_OBJECT_FILE}


### PR DESCRIPTION
Using CO-RE to read ctx fields

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated logging to correctly display 64-bit values for certain identifiers.
  * Improved compatibility by using macros for accessing specific fields, enhancing portability across different kernel versions.

* **Refactor**
  * Streamlined code by replacing direct struct field access with local variables and standardized macros.
  * Unified build settings to always include debug information, regardless of build type.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->