### PR TITLE
set supervisor exec name,add CforedClient drain state

### DIFF
--- a/src/Craned/Core/JobManager.cpp
+++ b/src/Craned/Core/JobManager.cpp
@@ -592,7 +592,8 @@ CraneErrCode JobManager::SpawnSupervisor_(JobInD* job, StepInstance* step) {
     std::vector<const char*> argv;
 
     // Argv[0] is the program name which can be anything.
-    argv.emplace_back("csupervisor");
+    auto supervisor_name = fmt::format("csupervisor: [{}]", task_id);
+    argv.emplace_back(supervisor_name.c_str());
 
     argv.push_back(nullptr);
 

--- a/src/Craned/Supervisor/CforedClient.h
+++ b/src/Craned/Supervisor/CforedClient.h
@@ -89,6 +89,7 @@ class CforedClient {
       std::atomic<bool>* write_pending);
 
   std::atomic<bool> m_stopped_{false};
+  std::atomic<bool> m_output_drained_{false};
 
   ConcurrentQueue<std::string> m_output_queue_;
   ConcurrentQueue<std::pair<std::unique_ptr<char[]>, size_t>>


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * The supervisor process name now includes the task ID, making it easier to identify running tasks.
  * Improved shutdown behavior ensures all output is fully forwarded before client unregistration, preventing loss of data during stopping.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->