### PR TITLE
feat: Split cgroup into 3 levels

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -7,6 +7,7 @@ Checks: >
 
   bugprone-*,
   -bugprone-easily-swappable-parameters,
+  -bugprone-assignment-in-if-condition,
 
   performance-*,
 

--- a/src/Craned/Core/CgroupManager.h
+++ b/src/Craned/Core/CgroupManager.h
@@ -496,6 +496,10 @@ class DedicatedResourceAllocator {
       CgroupInterface *cg);
 };
 
+using CgroupStrParsedIds =
+    std::tuple<std::optional<job_id_t>, std::optional<step_id_t>,
+               std::optional<task_id_t>>;
+
 class CgroupManager {
  public:
   CgroupManager() = default;
@@ -543,8 +547,7 @@ class CgroupManager {
     return m_cg_version_;
   }
 
-  static CraneExpected<std::tuple<job_id_t, step_id_t, task_id_t>> GetIdsByPid(
-      pid_t pid);
+  static CraneExpected<CgroupStrParsedIds> GetIdsByPid(pid_t pid);
 
 #ifdef CRANE_ENABLE_BPF
   inline static BpfRuntimeInfo bpf_runtime_info;
@@ -556,7 +559,7 @@ class CgroupManager {
   static std::string CgroupStrByTaskId_(job_id_t job_id, step_id_t step_id,
                                         task_id_t task_id);
 
-  static std::tuple<job_id_t, step_id_t, task_id_t> ParseIdsFromCgroupStr_(
+  static CgroupStrParsedIds ParseIdsFromCgroupStr_(
       const std::string &cgroup_str);
 
   static std::unique_ptr<CgroupInterface> CreateOrOpen_(

--- a/src/Craned/Core/CgroupManager.h
+++ b/src/Craned/Core/CgroupManager.h
@@ -94,7 +94,7 @@ inline constexpr bool kCgLimitDeviceRead = true;
 inline constexpr bool kCgLimitDeviceWrite = true;
 inline constexpr bool kCgLimitDeviceMknod = true;
 
-// For libcgroup use kRootCgPathPrefix as libcgroup operates in the system path
+// For libcgroup, use kRootCgPathPrefix as libcgroup operates in the system path
 // For manual cgroup operation, use kSystemCgPathPrefix / kRootCgPathPrefix
 inline const std::filesystem::path kSystemCgPathPrefix = "/sys/fs/cgroup";
 inline const std::filesystem::path kRootCgPathPrefix = "crane";
@@ -549,6 +549,7 @@ class CgroupManager {
   inline static BpfRuntimeInfo bpf_runtime_info;
 #endif
  private:
+  // NOTE: The caller should add prefix to the generated cgroup string.
   static std::string CgroupStrByJobId_(job_id_t job_id);
   static std::string CgroupStrByStepId_(job_id_t job_id, step_id_t step_id);
   static std::string CgroupStrByTaskId_(job_id_t job_id, step_id_t step_id,

--- a/src/Craned/Core/CgroupManager.h
+++ b/src/Craned/Core/CgroupManager.h
@@ -536,14 +536,15 @@ class CgroupManager {
   static EnvMap GetResourceEnvMapByResInNode(
       const crane::grpc::ResourceInNode &res_in_node);
 
-  static CraneExpected<task_id_t> GetJobIdFromPid(pid_t pid);
-
   static void SetCgroupVersion(CgConstant::CgroupVersion v) {
     m_cg_version_ = v;
   }
   [[nodiscard]] static CgConstant::CgroupVersion GetCgroupVersion() {
     return m_cg_version_;
   }
+
+  static CraneExpected<std::tuple<job_id_t, step_id_t, task_id_t>> GetIdsByPid(
+      pid_t pid);
 
 #ifdef CRANE_ENABLE_BPF
   inline static BpfRuntimeInfo bpf_runtime_info;
@@ -554,9 +555,6 @@ class CgroupManager {
   static std::string CgroupStrByStepId_(job_id_t job_id, step_id_t step_id);
   static std::string CgroupStrByTaskId_(job_id_t job_id, step_id_t step_id,
                                         task_id_t task_id);
-
-  [[deprecated]] static std::optional<task_id_t> GetJobIdFromCg_(
-      const std::string &path);
 
   static std::tuple<job_id_t, step_id_t, task_id_t> ParseIdsFromCgroupStr_(
       const std::string &cgroup_str);

--- a/src/Craned/Core/Craned.cpp
+++ b/src/Craned/Core/Craned.cpp
@@ -743,19 +743,19 @@ void GlobalVariableInit() {
   CgroupManager::Init();
   if (CgroupManager::GetCgroupVersion() ==
           Craned::CgConstant::CgroupVersion::CGROUP_V1 &&
-      (!CgroupManager::Mounted(Controller::CPU_CONTROLLER) ||
-       !CgroupManager::Mounted(Controller::MEMORY_CONTROLLER) ||
-       !CgroupManager::Mounted(Controller::DEVICES_CONTROLLER) ||
-       !CgroupManager::Mounted(Controller::BLOCK_CONTROLLER))) {
+      (!CgroupManager::IsMounted(Controller::CPU_CONTROLLER) ||
+       !CgroupManager::IsMounted(Controller::MEMORY_CONTROLLER) ||
+       !CgroupManager::IsMounted(Controller::DEVICES_CONTROLLER) ||
+       !CgroupManager::IsMounted(Controller::BLOCK_CONTROLLER))) {
     CRANE_ERROR(
         "Failed to initialize cpu,memory,devices,block cgroups controller.");
     std::exit(1);
   }
   if (CgroupManager::GetCgroupVersion() ==
           Craned::CgConstant::CgroupVersion::CGROUP_V2 &&
-      (!CgroupManager::Mounted(Controller::CPU_CONTROLLER_V2) ||
-       !CgroupManager::Mounted(Controller::MEMORY_CONTROLLER_V2) ||
-       !CgroupManager::Mounted(Controller::IO_CONTROLLER_V2))) {
+      (!CgroupManager::IsMounted(Controller::CPU_CONTROLLER_V2) ||
+       !CgroupManager::IsMounted(Controller::MEMORY_CONTROLLER_V2) ||
+       !CgroupManager::IsMounted(Controller::IO_CONTROLLER_V2))) {
     CRANE_ERROR("Failed to initialize cpu,memory,IO cgroups controller.");
     std::exit(1);
   }

--- a/src/Craned/Core/CranedServer.cpp
+++ b/src/Craned/Core/CranedServer.cpp
@@ -177,12 +177,14 @@ grpc::Status CranedServiceImpl::QueryStepFromPort(
   do {
     auto pid_to_ids_expt = CgroupManager::GetIdsByPid(pid_i);
     if (pid_to_ids_expt.has_value()) {
-      auto [job_id, step_id, task_id] = pid_to_ids_expt.value();
-      CRANE_TRACE("Find {} for pid {}", pid_to_ids_expt.value(), pid_i);
+      auto [job_id_opt, step_id_opt, task_id_opt] = pid_to_ids_expt.value();
 
-      // FIXME: Use step id instead of job id / step id.
+      // FIXME: Use step_id_opt after multi-step is supported.
+      CRANE_ASSERT_MSG(job_id_opt.has_value(),
+                       "Job ID always has value when RE2 matches.");
+
       response->set_ok(true);
-      response->set_task_id(job_id);
+      response->set_task_id(job_id_opt.value());
       return Status::OK;
     }
 

--- a/src/Craned/Core/SupervisorKeeper.h
+++ b/src/Craned/Core/SupervisorKeeper.h
@@ -47,7 +47,7 @@ class SupervisorStub {
 class SupervisorKeeper {
  public:
   SupervisorKeeper() = default;
-  ~SupervisorKeeper() { CRANE_DEBUG("Destroy SupervisorKeeper."); }
+  ~SupervisorKeeper() = default;
 
   SupervisorKeeper(const SupervisorKeeper&) = delete;
   SupervisorKeeper& operator=(const SupervisorKeeper&) = delete;

--- a/src/Misc/BPF/cgroup_dev_bpf.c
+++ b/src/Misc/BPF/cgroup_dev_bpf.c
@@ -1,6 +1,10 @@
+// DO NOT
 #include <linux/bpf.h>
+// REORDER
 #include <bpf/bpf_helpers.h>
+// THESE
 #include <bpf/bpf_core_read.h>
+// HEADERS
 #include <stdint.h>
 
 enum BPF_PERMISSION { ALLOW = 0, DENY };
@@ -18,8 +22,8 @@ struct BpfDeviceMeta {
   uint32_t major;
   uint32_t minor;
   int permission;
-  short access;
-  short type;
+  int16_t access;
+  int16_t type;
 };
 #pragma pack(pop)
 
@@ -104,8 +108,7 @@ int craned_device_access(struct bpf_cgroup_dev_ctx *ctx) {
   }
 
   if (enable_logging)
-    bpf_printk("Access allowed for device major=%d, minor=%d\n", major,
-               minor);
+    bpf_printk("Access allowed for device major=%d, minor=%d\n", major, minor);
   return 1;
 }
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Enhanced job/step/task identification using hierarchical cgroup names.
  - Added PID-to-IDs lookup for more precise mapping across process trees.
- Bug Fixes
  - Improved reliability of port-to-step queries by traversing parent processes when needed.
- Refactor
  - Migrated cgroup handling to a name-based, hierarchical model with clearer paths and messages.
  - Streamlined APIs and logs for cgroup creation, recovery, and cleanup.
- Chores
  - Updated static analysis configuration to reduce noisy warnings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->