### PR TITLE
fix: crun input

### DIFF
--- a/src/Craned/Core/JobManager.cpp
+++ b/src/Craned/Core/JobManager.cpp
@@ -236,7 +236,9 @@ void JobManager::EvCleanCheckSupervisorQueueCb_() {
   std::vector<task_id_t> job_ids;
   absl::MutexLock lk(&m_release_cg_mtx_);
   while (m_check_supervisor_queue_.try_dequeue(job_ids)) {
-    m_release_job_req_set_.insert(job_ids.begin(), job_ids.end());
+    for (task_id_t job_id : job_ids) {
+      m_release_job_retry_map_.emplace(job_id, 0);
+    }
     if (!m_check_supervisor_timer_handle_->active())
       m_check_supervisor_timer_handle_->start(uvw::timer_handle::time{1000},
                                               uvw::timer_handle::time{1000});
@@ -248,7 +250,7 @@ bool JobManager::EvCheckSupervisorRunning_() {
   {
     std::error_code ec;
     absl::MutexLock lk(&m_release_cg_mtx_);
-    for (task_id_t job_id : m_release_job_req_set_) {
+    for (auto& [job_id, retry_count] : m_release_job_retry_map_) {
       // TODO: replace following with step_id
       auto job_ptr = m_job_map_.GetValueExclusivePtr(job_id);
       for (const auto& step : job_ptr->step_map | std::views::values) {
@@ -261,11 +263,16 @@ bool JobManager::EvCheckSupervisorRunning_() {
         }
         if (!exists) {
           job_ids.emplace_back(job_id);
+        } else {
+          retry_count++;
+        }
+        if (retry_count > kMaxSupervisorCheckRetryCount) {
+          job_ids.emplace_back(job_id);
         }
       }
     }
     for (task_id_t job_id : job_ids) {
-      m_release_job_req_set_.erase(job_id);
+      m_release_job_retry_map_.erase(job_id);
     }
   }
 
@@ -277,7 +284,7 @@ bool JobManager::EvCheckSupervisorRunning_() {
         [this, jobs = std::move(job_ids)] { FreeJobAllocation_(jobs); });
   }
 
-  return m_release_job_req_set_.empty();
+  return m_release_job_retry_map_.empty();
 }
 
 // NOLINTNEXTLINE(readability-convert-member-functions-to-static)
@@ -929,6 +936,10 @@ void JobManager::EvCleanTerminateTaskQueueCb_() {
         stub->TerminateTask(elem.mark_as_orphaned, elem.terminated_by_user);
     if (err != CraneErrCode::SUCCESS) {
       CRANE_ERROR("Failed to terminate task #{}", elem.step_id);
+    } else {
+      StepStopAndDoStatusChangeAsync(
+          elem.step_id, crane::grpc::TaskStatus::Cancelled,
+          ExitCode::kExitCodeTerminated, "Terminated failed.");
     }
   }
 }

--- a/src/Craned/Core/JobManager.h
+++ b/src/Craned/Core/JobManager.h
@@ -30,6 +30,7 @@
 
 namespace Craned {
 
+constexpr int kMaxSupervisorCheckRetryCount = 10;
 // TODO: Replace this with tak execution info.
 using StepToD = crane::grpc::TaskToD;
 
@@ -224,7 +225,7 @@ class JobManager {
   std::shared_ptr<uvw::signal_handle> m_sigterm_handle_;
 
   absl::Mutex m_release_cg_mtx_;
-  std::unordered_set<task_id_t> m_release_job_req_set_
+  std::unordered_map<task_id_t, int /*retry count*/> m_release_job_retry_map_
       ABSL_GUARDED_BY(m_release_cg_mtx_);
   ConcurrentQueue<std::vector<task_id_t>> m_check_supervisor_queue_;
   std::shared_ptr<uvw::async_handle> m_check_supervisor_async_handle_;

--- a/src/Craned/Supervisor/CforedClient.cpp
+++ b/src/Craned/Supervisor/CforedClient.cpp
@@ -566,12 +566,12 @@ void CforedClient::AsyncSendRecvThread_() {
                 !WriteStringToFd_(*msg, fwd_meta.x11_fd_info->fd, false);
         }
       } else {
-        const bool eof = reply.payload_task_input_req().eof();
+        bool eof = reply.payload_task_input_req().eof();
         // CRANED_TASK_INPUT
         for (auto& fwd_meta : m_fwd_meta_map | std::ranges::views::values) {
           if (!fwd_meta.input_stopped)
-            fwd_meta.input_stopped =
-                !WriteStringToFd_(*msg, fwd_meta.stdin_write, eof);
+            fwd_meta.input_stopped = !WriteStringToFd_(
+                *msg, fwd_meta.stdin_write, !fwd_meta.pty && eof);
         }
       }
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Bug Fixes
  - Prevents hangs by closing non-PTY standard input on EOF; PTY inputs remain open as expected.
  - Terminated tasks now promptly reflect a Cancelled status with a Terminated exit code.
  - More reliable job cleanup when supervisors stop responding, with bounded retries to avoid stalled releases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->