### PR TITLE
fix: Crun exit too fast

### DIFF
--- a/src/Craned/Supervisor/CforedClient.cpp
+++ b/src/Craned/Supervisor/CforedClient.cpp
@@ -447,7 +447,7 @@ void CforedClient::AsyncSendRecvThread_() {
     if (next_status == grpc::CompletionQueue::TIMEOUT) {
       if (m_stopped_) {
         CRANE_TRACE("TIMEOUT with m_stopped_=true.");
-        if (state <= State::Registering) {
+        if (state < State::Forwarding) {
           CRANE_TRACE("Waiting for register.");
           continue;
         }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved client shutdown behavior to avoid performing shutdown/drain actions before registration completes, reducing rare hangs or errors during startup/shutdown.
  - Enhanced timeout handling to defer operations while awaiting registration, minimizing unnecessary log noise.
  - Increased reliability of connection handling under intermittent network or service delays, yielding more stable runtime behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->