### PR TITLE
fix: Renames config flag for ignoring config inconsistency

### DIFF
--- a/etc/config.yaml
+++ b/etc/config.yaml
@@ -127,7 +127,7 @@ RejectJobsBeyondCapacity: false
 JobFileAppend: false
 
 # Set the flag to ignore warnings about config files mismatches.
-ConfigCrcWarnIgnoreFlag: false
+IgnoreConfigInconsistency: false
 
 Supervisor:
   Path: /usr/libexec/csupervisor

--- a/src/CraneCtld/CraneCtld.cpp
+++ b/src/CraneCtld/CraneCtld.cpp
@@ -569,10 +569,10 @@ void ParseConfig(int argc, char** argv) {
         }
       }
 
-      if (config["ConfigCrcWarnIgnoreFlag"] &&
-          !config["ConfigCrcWarnIgnoreFlag"].IsNull())
-        g_config.ConfigCrcWarnIgnoreFlag =
-            config["ConfigCrcWarnIgnoreFlag"].as<bool>();
+      if (config["IgnoreConfigInconsistency"] &&
+          !config["IgnoreConfigInconsistency"].IsNull())
+        g_config.IgnoreConfigInconsistency =
+            config["IgnoreConfigInconsistency"].as<bool>();
 
       if (config["Plugin"]) {
         const auto& plugin_config = config["Plugin"];

--- a/src/CraneCtld/CtldPublicDefs.h
+++ b/src/CraneCtld/CtldPublicDefs.h
@@ -167,7 +167,7 @@ struct Config {
   uint32_t ScheduledBatchSize;
   bool RejectTasksBeyondCapacity{false};
   bool JobFileOpenModeAppend{false};
-  bool ConfigCrcWarnIgnoreFlag{false};
+  bool IgnoreConfigInconsistency{false};
 };
 
 struct RunTimeStatus {

--- a/src/CraneCtld/RpcService/CtldForInternalServer.cpp
+++ b/src/CraneCtld/RpcService/CtldForInternalServer.cpp
@@ -88,7 +88,7 @@ grpc::Status CtldForInternalServiceImpl::CranedRegister(
     return grpc::Status::OK;
   }
 
-  if (!g_config.ConfigCrcWarnIgnoreFlag &&
+  if (!g_config.IgnoreConfigInconsistency &&
       (request->remote_meta().config_crc() != g_config.ConfigCrcVal)) {
     CRANE_ERROR(
         "CranedNode #{} appears to have a diffrent config.yaml than the "


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Renamed configuration flag from “ConfigCrcWarnIgnoreFlag” to “IgnoreConfigInconsistency.”
  - Default remains false; behavior is unchanged apart from the new key name.
  - Update your configuration files to use “IgnoreConfigInconsistency.”

<!-- end of auto-generated comment: release notes by coderabbit.ai -->