### PR TITLE
fix: Resend status change if rpc failure

### DIFF
--- a/src/Craned/Supervisor/CranedClient.cpp
+++ b/src/Craned/Supervisor/CranedClient.cpp
@@ -86,13 +86,12 @@ void CranedClient::AsyncSendThread_() {
             elem.task_id, int(elem.new_status), status.error_message(),
             context.debug_error_string(), int(status.error_code()));
 
-        if (status.error_code() == grpc::UNAVAILABLE) {
-          // If some messages are not sent due to channel failure,
-          // put them back into m_task_status_change_list_
-          m_task_status_change_queue_.enqueue(elem);
-          std::this_thread::sleep_for(std::chrono::seconds(1));
-          break;
-        }
+        // If some messages are not sent due to channel failure,
+        // put them back into m_task_status_change_list_
+        m_task_status_change_queue_.enqueue(elem);
+        std::this_thread::sleep_for(std::chrono::seconds(1));
+        break;
+
       } else {
         m_finished_tasks_++;
         CRANE_TRACE("TaskStatusChange for task #{} sent. reply.ok={}",


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability of status updates by uniformly retrying pending changes on any RPC failure, reducing the chance of lost updates.
  * Enhanced resilience during transient connectivity issues, leading to fewer intermittent errors and more consistent task state synchronization.
  * Smoother shutdown behavior under error conditions by avoiding partial processing of pending updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->