### PR TITLE
 Add job env 

### DIFF
--- a/protos/PublicDefs.proto
+++ b/protos/PublicDefs.proto
@@ -168,6 +168,7 @@ message TaskToCtld {
   bool exclusive = 37;
 
   bool hold = 38;
+  string submit_hostname = 39;
 }
 
 message TaskInEmbeddedDb {
@@ -242,7 +243,8 @@ message TaskToD {
 
   bool get_user_env = 24;
   string container = 25;
-
+  string submit_hostname = 26;
+  uint32 total_gpus = 27;
   // Not used now.
   string extra_attr = 29;
 }

--- a/protos/Supervisor.proto
+++ b/protos/Supervisor.proto
@@ -73,7 +73,6 @@ message InitSupervisorRequest {
   }
 
   CforedListenConf cfored_listen_conf = 13;
-
 }
 
 message SupervisorReady {

--- a/protos/Supervisor.proto
+++ b/protos/Supervisor.proto
@@ -59,7 +59,7 @@ message InitSupervisorRequest {
   map<string, string> env = 10;
 
   string log_dir = 11;
-
+  string crane_cluster_name = 12;
   message CforedListenConf {
     message TlsCertificates {
       string cert_content = 1;
@@ -73,6 +73,7 @@ message InitSupervisorRequest {
   }
 
   CforedListenConf cfored_listen_conf = 13;
+
 }
 
 message SupervisorReady {

--- a/src/CraneCtld/CraneCtld.cpp
+++ b/src/CraneCtld/CraneCtld.cpp
@@ -123,6 +123,17 @@ void ParseConfig(int argc, char** argv) {
         db_config_path = config["DbConfigPath"].as<std::string>();
       }
 
+      if (config["ClusterName"]) {
+        g_config.CraneClusterName = config["ClusterName"].as<std::string>();
+        if (g_config.CraneClusterName.empty()) {
+          CRANE_ERROR("ClusterName is empty.");
+          std::exit(1);
+        }
+      } else {
+        CRANE_ERROR("ClusterName is empty.");
+        std::exit(1);
+      }
+
       g_config.CraneCtldMutexFilePath =
           g_config.CraneBaseDir / YamlValueOr(config["CraneCtldMutexFilePath"],
                                               kDefaultCraneCtldMutexFile);

--- a/src/CraneCtld/CtldPublicDefs.cpp
+++ b/src/CraneCtld/CtldPublicDefs.cpp
@@ -355,6 +355,8 @@ crane::grpc::TaskToD TaskInCtld::GetTaskToD(const CranedId& craned_id) const {
     auto* mutable_meta = task_to_d.mutable_interactive_meta();
     mutable_meta->CopyFrom(proto_ia_meta);
   }
+  task_to_d.set_submit_hostname(this->task_to_ctld.submit_hostname());
+  task_to_d.set_total_gpus(this->allocated_res_view.GpuCount());
   return task_to_d;
 }
 

--- a/src/CraneCtld/RpcService/CranedKeeper.cpp
+++ b/src/CraneCtld/RpcService/CranedKeeper.cpp
@@ -334,6 +334,8 @@ crane::grpc::ExecuteStepsRequest CranedStub::NewExecuteTasksRequests(
       auto *mutable_meta = mutable_task->mutable_interactive_meta();
       mutable_meta->CopyFrom(task->TaskToCtld().interactive_meta());
     }
+    mutable_task->set_submit_hostname(task->TaskToCtld().submit_hostname());
+    mutable_task->set_total_gpus(task->allocated_res_view.GpuCount());
   }
 
   return request;

--- a/src/Craned/Core/CgroupManager.cpp
+++ b/src/Craned/Core/CgroupManager.cpp
@@ -752,9 +752,9 @@ EnvMap CgroupManager::GetResourceEnvMapByResInNode(
 
   env_map.emplace(
       "CRANE_MEM_PER_NODE",
-      std::to_string(
-          res_in_node.allocatable_res_in_node().memory_limit_bytes() /
-          (1024 * 1024)));
+      std::format("{}M",
+                  res_in_node.allocatable_res_in_node().memory_limit_bytes() /
+                      (1024ULL * 1024ULL)));
 
   return env_map;
 }

--- a/src/Craned/Core/Craned.cpp
+++ b/src/Craned/Core/Craned.cpp
@@ -265,6 +265,16 @@ void ParseConfig(int argc, char** argv) {
       g_config.CraneCtldForInternalListenPort =
           YamlValueOr(config["CraneCtldForInternalListenPort"],
                       kCtldForInternalDefaultPort);
+      if (config["ClusterName"]) {
+        g_config.CraneClusterName = config["ClusterName"].as<std::string>();
+        if (g_config.CraneClusterName.empty()) {
+          CRANE_ERROR("Cluster name is empty.");
+          std::exit(1);
+        }
+      } else {
+        CRANE_ERROR("Cluster name is empty.");
+        std::exit(1);
+      }
 
       if (config["Nodes"]) {
         for (auto it = config["Nodes"].begin(); it != config["Nodes"].end();

--- a/src/Craned/Core/JobManager.cpp
+++ b/src/Craned/Core/JobManager.cpp
@@ -474,6 +474,7 @@ CraneErrCode JobManager::SpawnSupervisor_(JobInD* job, StepInstance* step) {
     init_req.set_crane_script_dir(g_config.CranedScriptDir);
     init_req.mutable_step_spec()->CopyFrom(step->step_to_d);
     init_req.set_log_dir(g_config.Supervisor.LogDir);
+    init_req.set_crane_cluster_name(g_config.CraneClusterName);
     auto* cfored_listen_conf = init_req.mutable_cfored_listen_conf();
     cfored_listen_conf->set_use_tls(g_config.ListenConf.TlsConfig.Enabled);
     cfored_listen_conf->set_domain_suffix(

--- a/src/Craned/Supervisor/Supervisor.cpp
+++ b/src/Craned/Supervisor/Supervisor.cpp
@@ -78,6 +78,7 @@ void InitFromStdin(int argc, char** argv) {
   g_config.CranedUnixSocketPath = msg.craned_unix_socket_path();
   g_config.CraneBaseDir = msg.crane_base_dir();
   g_config.CraneScriptDir = msg.crane_script_dir();
+  g_config.CraneClusterName = msg.crane_cluster_name();
   g_config.CforedListenConf.TlsConfig.Enabled =
       msg.cfored_listen_conf().use_tls();
   g_config.CforedListenConf.TlsConfig.TlsCerts.CertContent =

--- a/src/Craned/Supervisor/SupervisorPublicDefs.h
+++ b/src/Craned/Supervisor/SupervisorPublicDefs.h
@@ -83,6 +83,7 @@ struct Config {
   step_id_t StepId;
   StepToSupv StepSpec;
   std::atomic_int TaskCount;
+  std::string CraneClusterName;
 };
 
 inline Config g_config;

--- a/src/Craned/Supervisor/TaskManager.cpp
+++ b/src/Craned/Supervisor/TaskManager.cpp
@@ -154,6 +154,30 @@ ITaskInstance::~ITaskInstance() {
 EnvMap ITaskInstance::GetChildProcessEnv() const {
   std::unordered_map<std::string, std::string> env_map;
 
+  auto node_id_to_str = [this]() -> std::string {
+    uint32_t node_idx = 0;
+
+    std::array<char, HOST_NAME_MAX> host_name{};
+    if (gethostname(host_name.data(), host_name.size()) != 0) {
+      return std::to_string(-1);  // invalid
+    }
+    std::string_view host_name_view(host_name.data());
+    const auto& nodelist =
+        this->m_parent_step_inst_->GetStep().allocated_nodes();
+    for (const auto& node_name : nodelist) {
+      if (node_name == host_name_view) {
+        break;
+      }
+      node_idx++;
+    }
+
+    if (node_idx >= nodelist.size()) {
+      return std::to_string(-1);  // invalid
+    }
+
+    return std::to_string(node_idx);
+  };
+
   // Job env from CraneD
   for (auto& [name, value] : g_config.JobEnv) {
     env_map.emplace(name, value);
@@ -169,6 +193,67 @@ EnvMap ITaskInstance::GetChildProcessEnv() const {
   }
 
   // TODO: Move this to step instance.
+  // TODO CRANE_NTASKS_PER_CORE is not set
+  uint64_t gpus_per_node = 0;
+  auto alloc_node_num =
+      this->m_parent_step_inst_->GetStep().allocated_nodes().size();
+  if (alloc_node_num != 0) {
+    gpus_per_node =
+        this->m_parent_step_inst_->GetStep().total_gpus() / alloc_node_num;
+  }
+  auto mem_in_node = this->m_parent_step_inst_->GetStep()
+                         .resources()
+                         .allocatable_res_in_node()
+                         .memory_limit_bytes() /
+                     (static_cast<uint64_t>(1024 * 1024));
+
+  auto cpus_on_node = this->m_parent_step_inst_->GetStep()
+                          .resources()
+                          .allocatable_res_in_node()
+                          .cpu_core_limit();
+  auto mem_per_cpu = static_cast<double>(mem_in_node) / cpus_on_node;
+
+  env_map.emplace(
+      "CRANE_JOB_NODELIST",
+      absl::StrJoin(this->m_parent_step_inst_->GetStep().allocated_nodes(),
+                    ";"));
+  env_map.emplace(
+      "CRANE_EXCLUDES",
+      absl::StrJoin(this->m_parent_step_inst_->GetStep().excludes(), ";"));
+  env_map.emplace("CRANE_JOB_NAME",
+                  this->m_parent_step_inst_->GetStep().name());
+  env_map.emplace("CRANE_ACCOUNT",
+                  this->m_parent_step_inst_->GetStep().account());
+  env_map.emplace("CRANE_JOB_PARTITION",
+                  this->m_parent_step_inst_->GetStep().partition());
+  env_map.emplace("CRANE_QOS", this->m_parent_step_inst_->GetStep().qos());
+
+  env_map.emplace("CRANE_SUBMIT_DIR",
+                  this->m_parent_step_inst_->GetStep().cwd());
+  env_map.emplace(
+      "CRANE_CPUS_PER_TASK",
+      std::format("{:.2f}",
+                  this->m_parent_step_inst_->GetStep().cpus_per_task()));
+  env_map.emplace("CRANE_MEM_PER_NODE", std::to_string(mem_in_node));
+  env_map.emplace("CRANE_JOB_NUM_NODES", std::to_string(alloc_node_num));
+  env_map.emplace(
+      "CRANE_NTASKS_PER_NODE",
+      std::to_string(this->m_parent_step_inst_->GetStep().ntasks_per_node()));
+  env_map.emplace(
+      "CRANE_GPUS",
+      std::to_string(this->m_parent_step_inst_->GetStep().total_gpus()));
+  env_map.emplace("CRANE_GPUS_PER_NODE", std::to_string(gpus_per_node));
+  env_map.emplace("CRANE_MEM_PER_CPU", std::format("{:.2f}", mem_per_cpu));
+  env_map.emplace(
+      "CRANE_NTASKS",
+      std::to_string(alloc_node_num *
+                     this->m_parent_step_inst_->GetStep().ntasks_per_node()));
+  env_map.emplace("CRANE_CLUSTER_NAME", g_config.CraneClusterName);
+  env_map.emplace("CRANE_CPUS_ON_NODE", std::format("{:.2f}", cpus_on_node));
+  env_map.emplace("CRANE_NODEID", node_id_to_str());
+  env_map.emplace("CRANE_SUBMIT_HOST",
+                  this->m_parent_step_inst_->GetStep().submit_hostname());
+
   if (this->m_parent_step_inst_->IsCrun()) {
     auto const& ia_meta =
         this->m_parent_step_inst_->GetStep().interactive_meta();

--- a/src/Utilities/PublicHeader/PublicHeader.cpp
+++ b/src/Utilities/PublicHeader/PublicHeader.cpp
@@ -706,6 +706,19 @@ double ResourceView::CpuCount() const {
   return static_cast<double>(allocatable_res.cpu_count);
 }
 
+uint64_t ResourceView::GpuCount() const {
+  auto it = device_map.find(kResourceTypeGpu);
+  if (it == device_map.end()) return 0;
+
+  const auto& [untyped_count, type_map] = it->second;
+
+  uint64_t type_sum = std::accumulate(std::views::values(type_map).begin(),
+                                      std::views::values(type_map).end(),
+                                      static_cast<uint64_t>(0));
+
+  return untyped_count + type_sum;
+}
+
 uint64_t ResourceView::MemoryBytes() const {
   return allocatable_res.memory_bytes;
 }

--- a/src/Utilities/PublicHeader/include/crane/PublicHeader.h
+++ b/src/Utilities/PublicHeader/include/crane/PublicHeader.h
@@ -88,6 +88,8 @@ inline const char* const kDefaultSupervisorUnixSockDir = "/tmp/crane";
 
 inline const char* const kDefaultPlugindUnixSockPath = "cplugind/cplugind.sock";
 
+inline const char* const kResourceTypeGpu = "gpu";
+
 constexpr uint64_t kTaskMinTimeLimitSec = 11;
 constexpr int64_t kTaskMaxTimeLimitSec =
     google::protobuf::util::TimeUtil::kDurationMaxSeconds;
@@ -483,6 +485,7 @@ class ResourceView {
 
   double CpuCount() const;
   uint64_t MemoryBytes() const;
+  uint64_t GpuCount() const;
 
   AllocatableResource& GetAllocatableRes() { return allocatable_res; }
   const AllocatableResource& GetAllocatableRes() const {


### PR DESCRIPTION
This reverts commit 268d2602bdb7b0fa8665748036b493f5d5bb3edf.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Tasks now receive richer environment variables (e.g., CRANE_CLUSTER_NAME, CRANE_SUBMIT_HOST, CRANE_GPUS, CRANE_GPUS_PER_NODE, CRANE_MEM_PER_NODE, CRANE_MEM_PER_CPU, CRANE_JOB_NODELIST, CRANE_NTASKS).
  - Submitter hostname and total GPU count are included in task metadata and execution requests.
  - GPU resources are recognized and counted across untyped and typed allocations.
  - Configuration now requires a non-empty cluster name.
- Chores
  - Memory-per-node value is now formatted with an “M” suffix for clarity (e.g., “1024M”).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->