### PR TITLE
fix: Reservation db not closed

### DIFF
--- a/src/CraneCtld/EmbeddedDbClient.cpp
+++ b/src/CraneCtld/EmbeddedDbClient.cpp
@@ -493,10 +493,10 @@ EmbeddedDbClient::~EmbeddedDbClient() {
   }
 
   if (m_resv_db_) {
-  auto result = m_resv_db_->Close();
-  if (!result)
-    CRANE_ERROR(
-        "Error occurred when closing the embedded db of reservation data!");
+    auto result = m_resv_db_->Close();
+    if (!result)
+      CRANE_ERROR(
+          "Error occurred when closing the embedded db of reservation data!");
   }
 }
 

--- a/src/CraneCtld/EmbeddedDbClient.cpp
+++ b/src/CraneCtld/EmbeddedDbClient.cpp
@@ -491,6 +491,13 @@ EmbeddedDbClient::~EmbeddedDbClient() {
     if (!result)
       CRANE_ERROR("Error occurred when closing the embedded db of fixed data!");
   }
+
+  if (m_resv_db_) {
+  auto result = m_resv_db_->Close();
+  if (!result)
+    CRANE_ERROR(
+        "Error occurred when closing the embedded db of reservation data!");
+  }
 }
 
 bool EmbeddedDbClient::Init(const std::string& db_path) {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Ensures the embedded reservation database is closed properly during shutdown to prevent resource leaks.
  * Adds an error log when closing the reservation database fails, improving visibility into shutdown issues.
  * Aligns reservation DB shutdown behavior with other embedded databases for more consistent cleanup and error reporting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->