### PR TITLE
fix: Craned free invalid job when register

### DIFF
--- a/src/CraneCtld/TaskScheduler.cpp
+++ b/src/CraneCtld/TaskScheduler.cpp
@@ -2062,9 +2062,10 @@ void TaskScheduler::CleanTaskStatusChangeQueueCb_() {
     task->SetExitCode(exit_code);
     task->SetEndTime(absl::Now());
 
-    for (CranedId const& craned_id : task->CranedIds()) {
+    for (CranedId const& craned_id : task->executing_craned_ids) {
       craned_cgroups_map[craned_id].emplace_back(task_id, task->uid);
-
+    }
+    for (CranedId const& craned_id : task->CranedIds()) {
       auto node_to_task_map_it = m_node_to_tasks_map_.find(craned_id);
       if (node_to_task_map_it == m_node_to_tasks_map_.end()) [[unlikely]] {
         CRANE_ERROR("Failed to find craned_id {} in m_node_to_tasks_map_",

--- a/src/Craned/Core/JobManager.cpp
+++ b/src/Craned/Core/JobManager.cpp
@@ -261,6 +261,10 @@ bool JobManager::EvCheckSupervisorRunning_() {
         missing_jobs.emplace_back(job_id);
         continue;
       }
+      if (job_ptr->step_map.empty()) {
+        CRANE_DEBUG("[Job #{}] has no step, just clean up.", job_id);
+        job_ids.push_back(job_id);
+      }
       for (const auto& [step_id, step] : job_ptr->step_map) {
         bool exists = false;
         if (kill(step->supv_pid, 0) == 0) {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevents duplicate release attempts for the same job.
  * Skips missing jobs and reduces false positives when detecting running supervisors.
  * Ensures stuck jobs are released after a retry threshold.
  * Limits cgroup release to currently executing workers to avoid incorrect cleanup.

* **Refactor**
  * Replaces filesystem-based supervisor checks with live PID checks for improved accuracy.
  * Adds more granular logging to aid troubleshooting.
  * Triggers deferred cleanup tasks when release candidates are confirmed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->