### PR TITLE
fix: Fix error code

### DIFF
--- a/src/Craned/Supervisor/TaskManager.cpp
+++ b/src/Craned/Supervisor/TaskManager.cpp
@@ -1738,9 +1738,13 @@ void TaskManager::EvCleanTaskStopQueueCb_() {
               task_id, crane::grpc::TaskStatus::Failed,
               exit_info.value + ExitCode::kTerminationSignalBase, std::nullopt);
         }
-      } else
+      } else if (exit_info.value == 0) {
         ActivateTaskStatusChange_(task_id, crane::grpc::TaskStatus::Completed,
+                                  0, std::nullopt);
+      } else {
+        ActivateTaskStatusChange_(task_id, crane::grpc::TaskStatus::Failed,
                                   exit_info.value, std::nullopt);
+      }
     } else /* Calloc */ {
       // For a COMPLETING Calloc task with a process running,
       // the end of this process means that this task is done.
@@ -1748,8 +1752,11 @@ void TaskManager::EvCleanTaskStopQueueCb_() {
         ActivateTaskStatusChange_(
             task_id, crane::grpc::TaskStatus::Completed,
             exit_info.value + ExitCode::kTerminationSignalBase, std::nullopt);
-      else
+      else if (exit_info.value == 0)
         ActivateTaskStatusChange_(task_id, crane::grpc::TaskStatus::Completed,
+                                  0, std::nullopt);
+      else
+        ActivateTaskStatusChange_(task_id, crane::grpc::TaskStatus::Failed,
                                   exit_info.value, std::nullopt);
     }
   }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Tasks that stop without a signal now correctly reflect outcome by exit code: 0 is marked Completed; any non-zero exit code is marked Failed. This applies to both batch and allocated tasks.
  * Previously, some non-signal exits with non-zero codes were shown as Completed; they now show Failed with the actual exit code, improving status accuracy for monitoring and automation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->