### PR TITLE
fix: Reservation filed not set in task info.

### DIFF
--- a/src/CraneCtld/CtldPublicDefs.cpp
+++ b/src/CraneCtld/CtldPublicDefs.cpp
@@ -276,6 +276,7 @@ void TaskInCtld::SetFieldsOfTaskInfo(crane::grpc::TaskInfo* task_info) {
 
   task_info->set_container(container);
   task_info->set_extra_attr(extra_attr);
+  task_info->set_reservation(reservation);
 
   task_info->set_held(held);
   task_info->mutable_execution_node()->Assign(executing_craned_ids.begin(),


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Task/job details now include a reservation field, visible wherever task information is displayed or retrieved (CLI, UI, and API).
  * API responses for task info return an additional "reservation" field, enabling clients to identify a task's associated reservation.
  * Additive change—existing behavior unchanged aside from exposing reservation data.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->