### PR TITLE
chore: Remove global FRONTEND_REF from build.yaml

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -41,9 +41,6 @@ env:
   # Local cache directory
   LOCAL_CACHE_DIR: /opt/actions-runner-external/runner_cache
 
-  # Unified frontend ref across all triggers
-  FRONTEND_REF: ${{ inputs.frontend_branch || 'master' }}
-
   # Cache buster for forcing rebuilds on workflow_dispatch
   CACHE_BUSTER: ${{ inputs.cache_buster || '' }}
 


### PR DESCRIPTION
Removed FRONTEND_REF variable from build workflow.