### PR TITLE
feat: Change TLS to use a single CA.

### DIFF
--- a/etc/config.yaml
+++ b/etc/config.yaml
@@ -15,10 +15,9 @@ TLS:
   Enabled: false
   InternalCertFilePath: /etc/crane/tls/internal.pem
   InternalKeyFilePath: /etc/crane/tls/internal.key
-  InternalCaFilePath: /etc/crane/tls/internal_ca.pem
   ExternalCertFilePath: /etc/crane/tls/external.pem
   ExternalKeyFilePath: /etc/crane/tls/external.key
-  ExternalCaFilePath: /etc/crane/tls/external_ca.pem
+  CaFilePath: /etc/crane/tls/ca.pem
   AllowedNodes: "cn[15-18]"
   DomainSuffix: crane.com
 

--- a/scripts/vault.sh
+++ b/scripts/vault.sh
@@ -1,0 +1,249 @@
+#!/bin/bash
+
+export VAULT_ADDR='http://127.0.0.1:8200'
+
+unseal_vault(){
+    VAULT_KEY_FILE="/etc/vault.d/vault_keys.txt"
+
+    if [ ! -f "$VAULT_KEY_FILE" ]; then
+        echo "Error: File $VAULT_KEY_FILE not found."
+        exit 1
+    fi
+
+    keys=$(cat "$VAULT_KEY_FILE" | jq -r '.[0:3][]')
+    if [ -z "$keys" ]; then
+        echo "Error: Failed to parse JSON array from $VAULT_KEY_FILE."
+        exit 1
+    fi
+
+    for key in $keys; do
+        vault operator unseal $key
+    done
+}
+
+login_vault() {
+    vault login -method=userpass username=admin
+}
+
+init_vault() {
+    output=$(vault operator init --format=json) # 该命令会得到5个Unseal Key以及1个root token，需要秘密保存后续使用
+    if [ $? -ne 0 ]; then
+        exit 1
+    fi
+    # 5个Unseal Key必须保存！！丢失可能导致后续无法使用
+
+    #vault使用前需要unseal解密，解析需要用到上述unseal key中的三个
+    key=$(echo "$output" | jq -r '.unseal_keys_b64[0]')
+    vault operator unseal $key
+    key=$(echo "$output" | jq -r '.unseal_keys_b64[1]')
+    vault operator unseal $key
+    key=$(echo "$output" | jq -r '.unseal_keys_b64[2]')
+    vault operator unseal $key
+
+    token=$(echo "$output" | jq -r '.root_token')
+    vault login $token #采用root token登录即可使用CLI命令进行操作
+    if [ $? -ne 0 ]; then
+        echo "登录失败"
+        exit 1
+    fi
+
+    mkdir /etc/vault.d
+    keys=$(echo "$output" | jq '.unseal_keys_b64')
+    echo $keys > /etc/vault.d/vault_keys.txt
+    chmod 600 /etc/vault.d/vault_keys.txt
+
+    echo -n $token > /etc/vault.d/vault_token.txt
+    chmod 600 /etc/vault.d/vault_token.txt
+
+    # 创建 admin-policy 策略文件
+    echo "Creating admin-policy file..."
+    cat <<EOF > /etc/vault.d/admin-policy.hcl
+path "*" {
+  capabilities = ["create", "read", "update", "delete", "list", "sudo"]
+}
+EOF
+
+    # 写入 admin-policy 策略
+    echo "Writing admin-policy to Vault..."
+    vault policy write admin-policy /etc/vault.d/admin-policy.hcl || {
+      echo "Failed to write admin-policy."
+      exit 1
+    }
+
+    vault auth enable userpass
+
+    # 创建 admin 用户并分配策略
+    echo "Creating admin user with admin-policy..."
+    vault write auth/userpass/users/admin password="123456" policies="admin-policy" || {
+      echo "Failed to create admin user."
+      exit 1
+    }
+
+    # 使用 admin 用户登录
+    echo "Logging in as admin user..."
+    vault login -method=userpass username=admin password=123456 || {
+      echo "Failed to log in as admin user."
+      exit 1
+    }
+
+   vault status
+}
+
+init_cert() {
+    if [ "$#" -eq 0 ]; then
+      domainSuffix="crane.local"
+    else
+      domainSuffix="$1"
+    fi
+
+    vault secrets enable pki
+
+    mkdir -p /etc/crane/tls
+
+    # 生成CA文件
+    vault write -field=certificate pki/root/generate/internal \
+    common_name="*.$domainSuffix"  issuer_name="CraneSched_root_CA" not_after="9999-12-31T23:59:59Z" > /etc/crane/CA_cert.crt
+    if [ $? -ne 0 ]; then
+        exit 1
+    fi
+
+    vault write pki/roles/CraneSched \
+        issuer_ref="$(vault read -field=default pki/config/issuers)" \
+        allowed_domains="$domainSuffix" \
+        allow_subdomains=true \
+        allow_glob_domains=true \
+        not_after="9999-12-31T23:59:59Z"
+    if [ $? -ne 0 ]; then
+        exit 1
+    fi
+
+    vault write pki/config/urls \
+          issuing_certificates="$VAULT_ADDR/v1/pki/ca" \
+          crl_distribution_points="$VAULT_ADDR/v1/pki/crl" \
+          ocsp_servers="$VAULT_ADDR/v1/pki/ocsp"
+    if [ $? -ne 0 ]; then
+        exit 1
+    fi
+
+    vault write -format=json pki/intermediate/generate/internal common_name="*.$domainSuffix" \
+          issuer_name="CraneSched_CA" not_after="9999-12-31T23:59:59Z" | jq -r '.data.csr' > /etc/crane/tls/ca.csr
+
+    vault write -format=json pki/root/sign-intermediate csr=@/etc/crane/tls/ca.csr \
+          format=pem_bundle not_after="9999-12-31T23:59:59Z" | jq -r '.data.certificate' > /etc/crane/tls/ca.pem
+
+    # Import the signed intermediate certificate into Vault.
+    vault write pki/intermediate/set-signed certificate=@/etc/crane/tls/ca.pem
+
+    issue_internal "$domainSuffix"
+    issue_external "$domainSuffix"
+}
+
+issue_internal (){
+    # 检查是否传递了 domainSuffix 参数
+    if [ -z "$1" ]; then
+        echo "Error: Please provide a domain suffix!"
+        echo "Usage: issure_internal <domainSuffix>"
+        return 1
+    fi
+
+    local domainSuffix="$1"  # 接收传递的 domainSuffix 参数
+
+    output=$(vault write -format=json pki/issue/CraneSched common_name="*.$domainSuffix" alt_names="localhost,*.$domainSuffix" not_after="9999-12-31T23:59:59Z" exclude_cn_from_sans=true)
+    certificate=$(echo "$output" | jq -r '.data.certificate')
+    echo "$certificate" > /etc/crane/tls/internal.pem
+
+    private_key=$(echo "$output" | jq -r '.data.private_key')
+    echo "$private_key" > /etc/crane/tls/internal.key
+    chmod 600 /etc/crane/tls/internal.key
+
+    ca=$(echo "$output" | jq -r '.data.issuing_ca')
+    echo "$ca" > /etc/crane/tls/ca.pem
+}
+
+issue_external() {
+    # 检查是否传递了 domainSuffix 参数
+    if [ -z "$1" ]; then
+        echo "Error: Please provide a domain suffix!"
+        echo "Usage: issure_internal <domainSuffix>"
+        return 1
+    fi
+
+    mkdir -p /etc/crane/tls
+
+    local domainSuffix="$1"  # 接收传递的 domainSuffix 参数
+
+    output=$(vault write -format=json pki/issue/CraneSched common_name="external.$domainSuffix" alt_names="localhost, *.$domainSuffix" not_after="9999-12-31T23:59:59Z"  exclude_cn_from_sans=true)
+    certificate=$(echo "$output" | jq -r '.data.certificate')
+    echo "$certificate" > /etc/crane/tls/external.pem
+
+    private_key=$(echo "$output" | jq -r '.data.private_key')
+    echo "$private_key" > /etc/crane/tls/external.key
+    chmod 600 /etc/crane/tls/external.key
+
+    ca=$(echo "$output" | jq -r '.data.issuing_ca')
+    echo "$ca" > /etc/crane/tls/ca.pem
+}
+
+
+init() {
+    if [ "$#" -eq 0 ]; then
+      domainSuffix="crane.local"
+    else
+      domainSuffix="$1"
+    fi
+
+    mkdir -p /etc/crane/tls
+
+    init_vault
+    init_cert "$domainSuffix"
+    echo "init 完成"
+}
+
+clean_vault(){
+  systemctl stop vault
+  rm -rf /etc/vault/data/
+  mkdir -p /etc/vault/data/
+  systemctl start vault
+  echo "clean vault 完成"
+}
+
+# 主逻辑：根据输入参数调用对应的函数
+if [ "$#" -lt 1 ]; then
+    echo "Usage: \$0 <function_name> [init, init_vault, init_cert, issue_internal, issue_external, login_vault, unseal_vault, clean_vault]"
+    exit 1
+fi
+
+function_name="$1"
+shift # 移除第一个参数，保留剩余参数
+
+case "$function_name" in
+    init)
+        init "$@"
+        ;;
+    init_vault)
+        init_vault
+        ;;
+     issue_internal)
+        issue_internal "$@"
+        ;;
+     issue_external)
+         issue_external "$@"
+         ;;
+     login_vault)
+         login_vault "$@"
+         ;;
+     unseal_vault)
+         unseal_vault "$@"
+         ;;
+     init_cert)
+         init_cert "$@"
+         ;;
+     clean_vault)
+         clean_vault "$@"
+         ;;
+    *)
+        echo "Error: Unknown function name '$function_name'."
+        echo "Available functions: init, init_vault, init_cert, issue_internal, issue_external, login_vault, unseal_vault, clean_vault"
+        exit 1
+        ;;
+esac

--- a/src/CraneCtld/CraneCtld.cpp
+++ b/src/CraneCtld/CraneCtld.cpp
@@ -171,6 +171,16 @@ void ParseConfig(int argc, char** argv) {
             // todo: localhost?
             g_tls_config.AllowedNodes.insert("localhost");
           }
+
+          if (auto result =
+                  util::ParseCertConfig("CaFilePath", tls_config,
+                                        &g_tls_config.CaFilePath,
+                                        &g_tls_config.CaContent);
+              result) {
+            CRANE_ERROR(result.value());
+            std::exit(1);
+              }
+
           // internal
           if (auto result = util::ParseCertConfig(
                   "InternalCertFilePath", tls_config,
@@ -190,15 +200,6 @@ void ParseConfig(int argc, char** argv) {
             std::exit(1);
           }
 
-          if (auto result =
-                  util::ParseCertConfig("InternalCaFilePath", tls_config,
-                                        &g_tls_config.InternalCerts.CaFilePath,
-                                        &g_tls_config.InternalCerts.CaContent);
-              result) {
-            CRANE_ERROR(result.value());
-            std::exit(1);
-          }
-
           // external
           if (auto result = util::ParseCertConfig(
                   "ExternalCertFilePath", tls_config,
@@ -212,14 +213,6 @@ void ParseConfig(int argc, char** argv) {
                   util::ParseCertConfig("ExternalKeyFilePath", tls_config,
                                         &g_tls_config.ExternalCerts.KeyFilePath,
                                         &g_tls_config.ExternalCerts.KeyContent);
-              result) {
-            CRANE_ERROR(result.value());
-            std::exit(1);
-          }
-          if (auto result =
-                  util::ParseCertConfig("ExternalCaFilePath", tls_config,
-                                        &g_tls_config.ExternalCerts.CaFilePath,
-                                        &g_tls_config.ExternalCerts.CaContent);
               result) {
             CRANE_ERROR(result.value());
             std::exit(1);

--- a/src/CraneCtld/CraneCtld.cpp
+++ b/src/CraneCtld/CraneCtld.cpp
@@ -172,14 +172,13 @@ void ParseConfig(int argc, char** argv) {
             g_tls_config.AllowedNodes.insert("localhost");
           }
 
-          if (auto result =
-                  util::ParseCertConfig("CaFilePath", tls_config,
-                                        &g_tls_config.CaFilePath,
-                                        &g_tls_config.CaContent);
+          if (auto result = util::ParseCertConfig("CaFilePath", tls_config,
+                                                  &g_tls_config.CaFilePath,
+                                                  &g_tls_config.CaContent);
               result) {
             CRANE_ERROR(result.value());
             std::exit(1);
-              }
+          }
 
           // internal
           if (auto result = util::ParseCertConfig(

--- a/src/CraneCtld/CtldPublicDefs.h
+++ b/src/CraneCtld/CtldPublicDefs.h
@@ -101,6 +101,8 @@ struct Config {
       TlsCertificates InternalCerts;
       TlsCertificates ExternalCerts;
       std::unordered_set<std::string> AllowedNodes;
+      std::string CaFilePath;
+      std::string CaContent;
       std::string DomainSuffix;
     };
     TlsCertsConfig TlsConfig;

--- a/src/CraneCtld/RpcService/CtldGrpcServer.cpp
+++ b/src/CraneCtld/RpcService/CtldGrpcServer.cpp
@@ -1910,7 +1910,7 @@ CtldServer::CtldServer(const Config::CraneCtldListenConf &listen_conf) {
     ServerBuilderAddTcpTlsListeningPort(
         &internal_builder, cranectld_listen_addr,
         listen_conf.CraneCtldForInternalListenPort,
-        listen_conf.TlsConfig.InternalCerts);
+        listen_conf.TlsConfig.InternalCerts, listen_conf.TlsConfig.CaContent);
   else
     ServerBuilderAddTcpInsecureListeningPort(
         &internal_builder, cranectld_listen_addr,
@@ -1934,7 +1934,7 @@ CtldServer::CtldServer(const Config::CraneCtldListenConf &listen_conf) {
   if (listen_conf.TlsConfig.Enabled) {
     ServerBuilderAddTcpTlsListeningPort(&builder, cranectld_listen_addr,
                                         listen_conf.CraneCtldListenPort,
-                                        listen_conf.TlsConfig.ExternalCerts);
+                                        listen_conf.TlsConfig.ExternalCerts, listen_conf.TlsConfig.CaContent);
   } else {
     ServerBuilderAddTcpInsecureListeningPort(&builder, cranectld_listen_addr,
                                              listen_conf.CraneCtldListenPort);

--- a/src/CraneCtld/RpcService/CtldGrpcServer.cpp
+++ b/src/CraneCtld/RpcService/CtldGrpcServer.cpp
@@ -1932,9 +1932,9 @@ CtldServer::CtldServer(const Config::CraneCtldListenConf &listen_conf) {
   if (g_config.CompressedRpc) ServerBuilderSetCompression(&builder);
 
   if (listen_conf.TlsConfig.Enabled) {
-    ServerBuilderAddTcpTlsListeningPort(&builder, cranectld_listen_addr,
-                                        listen_conf.CraneCtldListenPort,
-                                        listen_conf.TlsConfig.ExternalCerts, listen_conf.TlsConfig.CaContent);
+    ServerBuilderAddTcpTlsListeningPort(
+        &builder, cranectld_listen_addr, listen_conf.CraneCtldListenPort,
+        listen_conf.TlsConfig.ExternalCerts, listen_conf.TlsConfig.CaContent);
   } else {
     ServerBuilderAddTcpInsecureListeningPort(&builder, cranectld_listen_addr,
                                              listen_conf.CraneCtldListenPort);

--- a/src/CraneCtld/Security/VaultClient.cpp
+++ b/src/CraneCtld/Security/VaultClient.cpp
@@ -103,10 +103,10 @@ std::optional<SignResponse> VaultClient::Sign(const std::string& csr_content,
 
 bool VaultClient::RevokeCert(const std::string& serial_number) {
   try {
-    std::optional<std::string> resp = Post_(
-        *m_root_client_,
-        GetPkiUrl_(Vault::SecretMount{"pki"}, Vault::Path{"revoke"}),
-        Vault::Parameters{{"serial_number", serial_number}});
+    std::optional<std::string> resp =
+        Post_(*m_root_client_,
+              GetPkiUrl_(Vault::SecretMount{"pki"}, Vault::Path{"revoke"}),
+              Vault::Parameters{{"serial_number", serial_number}});
 
     if (!resp) return false;
 

--- a/src/CraneCtld/Security/VaultClient.cpp
+++ b/src/CraneCtld/Security/VaultClient.cpp
@@ -60,8 +60,6 @@ bool VaultClient::InitFromConfig(const Config::VaultConfig& vault_config) {
   // Init Pki
   m_pki_root_ = std::make_unique<Vault::Pki>(
       Vault::Pki{*m_root_client_, Vault::SecretMount{"pki"}});
-  m_pki_external_ = std::make_unique<Vault::Pki>(
-      Vault::Pki{*m_root_client_, Vault::SecretMount{"pki_external"}});
 
   CRANE_TRACE("Successfully connected to Vault, username: {}",
               vault_config.Username);
@@ -79,7 +77,7 @@ std::optional<SignResponse> VaultClient::Sign(const std::string& csr_content,
 
   try {
     std::optional<std::string> resp =
-        m_pki_external_->sign(Vault::Path{"external"}, parameters);
+        m_pki_root_->sign(Vault::Path{"CraneSched"}, parameters);
     if (!resp) return std::nullopt;
 
     nlohmann::json json = nlohmann::json::parse(resp.value());
@@ -107,7 +105,7 @@ bool VaultClient::RevokeCert(const std::string& serial_number) {
   try {
     std::optional<std::string> resp = Post_(
         *m_root_client_,
-        GetPkiUrl_(Vault::SecretMount{"pki_external"}, Vault::Path{"revoke"}),
+        GetPkiUrl_(Vault::SecretMount{"pki"}, Vault::Path{"revoke"}),
         Vault::Parameters{{"serial_number", serial_number}});
 
     if (!resp) return false;
@@ -131,7 +129,7 @@ bool VaultClient::IsCertAllowed(const std::string& serial_number) {
 
   try {
     std::optional<std::string> resp =
-        m_pki_external_->readCertificate(Vault::Path{serial_number});
+        m_pki_root_->readCertificate(Vault::Path{serial_number});
     if (!resp) return false;
 
     nlohmann::json json = nlohmann::json::parse(resp.value());

--- a/src/CraneCtld/Security/VaultClient.h
+++ b/src/CraneCtld/Security/VaultClient.h
@@ -58,7 +58,6 @@ class VaultClient {
 
   std::unique_ptr<Vault::Client> m_root_client_;
   std::unique_ptr<Vault::Pki> m_pki_root_;
-  std::unique_ptr<Vault::Pki> m_pki_external_;
 
   using ParallelHashMap = phmap::parallel_flat_hash_map<
       std::string, int64_t, phmap::priv::hash_default_hash<std::string>,

--- a/src/Craned/Core/Craned.cpp
+++ b/src/Craned/Core/Craned.cpp
@@ -351,8 +351,8 @@ void ParseConfig(int argc, char** argv) {
             std::exit(1);
           }
           if (auto result = util::ParseCertConfig(
-                  "InternalCaFilePath", tls_config, &tls_certs.CaFilePath,
-                  &tls_certs.CaContent);
+                  "CaFilePath", tls_config, &g_tls_config.CaFilePath,
+                  &g_tls_config.CaContent);
               result) {
             CRANE_ERROR(result.value());
             std::exit(1);

--- a/src/Craned/Core/Craned.cpp
+++ b/src/Craned/Core/Craned.cpp
@@ -350,9 +350,9 @@ void ParseConfig(int argc, char** argv) {
             CRANE_ERROR(result.value());
             std::exit(1);
           }
-          if (auto result = util::ParseCertConfig(
-                  "CaFilePath", tls_config, &g_tls_config.CaFilePath,
-                  &g_tls_config.CaContent);
+          if (auto result = util::ParseCertConfig("CaFilePath", tls_config,
+                                                  &g_tls_config.CaFilePath,
+                                                  &g_tls_config.CaContent);
               result) {
             CRANE_ERROR(result.value());
             std::exit(1);

--- a/src/Craned/Core/CranedPublicDefs.h
+++ b/src/Craned/Core/CranedPublicDefs.h
@@ -81,6 +81,8 @@ struct Config {
     struct TlsCertsConfig {
       bool Enabled{false};
       TlsCertificates TlsCerts;
+      std::string CaFilePath;
+      std::string CaContent;
       std::string DomainSuffix;
     };
 

--- a/src/Craned/Core/CranedServer.cpp
+++ b/src/Craned/Core/CranedServer.cpp
@@ -352,7 +352,7 @@ CranedServer::CranedServer(const Config::CranedListenConf &listen_conf) {
   if (listen_conf.TlsConfig.Enabled) {
     ServerBuilderAddTcpTlsListeningPortForInternal(
         &builder, craned_listen_addr, listen_conf.CranedListenPort,
-        listen_conf.TlsConfig.TlsCerts);
+        listen_conf.TlsConfig.TlsCerts, listen_conf.TlsConfig.CaContent);
   } else {
     ServerBuilderAddTcpInsecureListeningPort(&builder, craned_listen_addr,
                                              listen_conf.CranedListenPort);

--- a/src/Craned/Core/JobManager.cpp
+++ b/src/Craned/Core/JobManager.cpp
@@ -510,7 +510,7 @@ CraneErrCode JobManager::SpawnSupervisor_(JobInD* job, StepInstance* step) {
     auto* tls_certs = cfored_listen_conf->mutable_tls_certs();
     tls_certs->set_cert_content(
         g_config.ListenConf.TlsConfig.TlsCerts.CertContent);
-    tls_certs->set_ca_content(g_config.ListenConf.TlsConfig.TlsCerts.CaContent);
+    tls_certs->set_ca_content(g_config.ListenConf.TlsConfig.CaContent);
     tls_certs->set_key_content(
         g_config.ListenConf.TlsConfig.TlsCerts.KeyContent);
 

--- a/src/Craned/Supervisor/Supervisor.cpp
+++ b/src/Craned/Supervisor/Supervisor.cpp
@@ -82,7 +82,7 @@ void InitFromStdin(int argc, char** argv) {
       msg.cfored_listen_conf().use_tls();
   g_config.CforedListenConf.TlsConfig.TlsCerts.CertContent =
       msg.cfored_listen_conf().tls_certs().cert_content();
-  g_config.CforedListenConf.TlsConfig.TlsCerts.CaContent =
+  g_config.CforedListenConf.TlsConfig.CaContent =
       msg.cfored_listen_conf().tls_certs().ca_content();
   g_config.CforedListenConf.TlsConfig.TlsCerts.KeyContent =
       msg.cfored_listen_conf().tls_certs().key_content();

--- a/src/Craned/Supervisor/SupervisorPublicDefs.h
+++ b/src/Craned/Supervisor/SupervisorPublicDefs.h
@@ -43,6 +43,8 @@ struct Config {
     struct TlsCertConfig {
       bool Enabled{false};
       TlsCertificates TlsCerts;
+      std::string CaFilePath;
+      std::string CaContent;
       std::string DomainSuffix;
     };
     TlsCertConfig TlsConfig;

--- a/src/Utilities/PublicHeader/GrpcHelper.cpp
+++ b/src/Utilities/PublicHeader/GrpcHelper.cpp
@@ -94,7 +94,8 @@ void ServerBuilderAddTcpInsecureListeningPort(grpc::ServerBuilder* builder,
 // Internal enforced mutual TLS (mTLS) authentication
 void ServerBuilderAddTcpTlsListeningPortForInternal(
     grpc::ServerBuilder* builder, const std::string& address,
-    const std::string& port, const TlsCertificates& certs, const std::string& ca_content) {
+    const std::string& port, const TlsCertificates& certs,
+    const std::string& ca_content) {
   std::string listen_addr_port =
       fmt::format("{}:{}", GrpcFormatIpAddress(address), port);
 
@@ -115,7 +116,8 @@ void ServerBuilderAddTcpTlsListeningPortForInternal(
 void ServerBuilderAddTcpTlsListeningPort(grpc::ServerBuilder* builder,
                                          const std::string& address,
                                          const std::string& port,
-                                         const TlsCertificates& certs, const std::string& ca_content) {
+                                         const TlsCertificates& certs,
+                                         const std::string& ca_content) {
   std::string listen_addr_port =
       fmt::format("{}:{}", GrpcFormatIpAddress(address), port);
 

--- a/src/Utilities/PublicHeader/GrpcHelper.cpp
+++ b/src/Utilities/PublicHeader/GrpcHelper.cpp
@@ -94,7 +94,7 @@ void ServerBuilderAddTcpInsecureListeningPort(grpc::ServerBuilder* builder,
 // Internal enforced mutual TLS (mTLS) authentication
 void ServerBuilderAddTcpTlsListeningPortForInternal(
     grpc::ServerBuilder* builder, const std::string& address,
-    const std::string& port, const TlsCertificates& certs) {
+    const std::string& port, const TlsCertificates& certs, const std::string& ca_content) {
   std::string listen_addr_port =
       fmt::format("{}:{}", GrpcFormatIpAddress(address), port);
 
@@ -103,7 +103,7 @@ void ServerBuilderAddTcpTlsListeningPortForInternal(
   pem_key_cert_pair.private_key = certs.KeyContent;
 
   grpc::SslServerCredentialsOptions ssl_opts;
-  ssl_opts.pem_root_certs = certs.CaContent;
+  ssl_opts.pem_root_certs = ca_content;
   ssl_opts.pem_key_cert_pairs.emplace_back(std::move(pem_key_cert_pair));
   ssl_opts.client_certificate_request =
       GRPC_SSL_REQUEST_AND_REQUIRE_CLIENT_CERTIFICATE_AND_VERIFY;
@@ -115,7 +115,7 @@ void ServerBuilderAddTcpTlsListeningPortForInternal(
 void ServerBuilderAddTcpTlsListeningPort(grpc::ServerBuilder* builder,
                                          const std::string& address,
                                          const std::string& port,
-                                         const TlsCertificates& certs) {
+                                         const TlsCertificates& certs, const std::string& ca_content) {
   std::string listen_addr_port =
       fmt::format("{}:{}", GrpcFormatIpAddress(address), port);
 
@@ -124,7 +124,7 @@ void ServerBuilderAddTcpTlsListeningPort(grpc::ServerBuilder* builder,
   pem_key_cert_pair.private_key = certs.KeyContent;
 
   grpc::SslServerCredentialsOptions ssl_opts;
-  ssl_opts.pem_root_certs = certs.CaContent;
+  ssl_opts.pem_root_certs = ca_content;
   ssl_opts.pem_key_cert_pairs.emplace_back(std::move(pem_key_cert_pair));
   ssl_opts.client_certificate_request =
       GRPC_SSL_REQUEST_CLIENT_CERTIFICATE_AND_VERIFY;

--- a/src/Utilities/PublicHeader/include/crane/GrpcHelper.h
+++ b/src/Utilities/PublicHeader/include/crane/GrpcHelper.h
@@ -27,8 +27,6 @@ struct TlsCertificates {
   std::string CertContent;
   std::string KeyFilePath;
   std::string KeyContent;
-  std::string CaFilePath;
-  std::string CaContent;
 };
 
 std::string_view GrpcConnStateStr(grpc_connectivity_state state);
@@ -66,12 +64,12 @@ void ServerBuilderAddTcpInsecureListeningPort(grpc::ServerBuilder* builder,
 
 void ServerBuilderAddTcpTlsListeningPortForInternal(
     grpc::ServerBuilder* builder, const std::string& address,
-    const std::string& port, const TlsCertificates& certs);
+    const std::string& port, const TlsCertificates& certs, const std::string& ca_content);
 
 void ServerBuilderAddTcpTlsListeningPort(grpc::ServerBuilder* builder,
                                          const std::string& address,
                                          const std::string& port,
-                                         const TlsCertificates& certs);
+                                         const TlsCertificates& certs, const std::string& ca_content);
 
 void SetGrpcClientKeepAliveChannelArgs(grpc::ChannelArguments* args);
 

--- a/src/Utilities/PublicHeader/include/crane/GrpcHelper.h
+++ b/src/Utilities/PublicHeader/include/crane/GrpcHelper.h
@@ -64,12 +64,14 @@ void ServerBuilderAddTcpInsecureListeningPort(grpc::ServerBuilder* builder,
 
 void ServerBuilderAddTcpTlsListeningPortForInternal(
     grpc::ServerBuilder* builder, const std::string& address,
-    const std::string& port, const TlsCertificates& certs, const std::string& ca_content);
+    const std::string& port, const TlsCertificates& certs,
+    const std::string& ca_content);
 
 void ServerBuilderAddTcpTlsListeningPort(grpc::ServerBuilder* builder,
                                          const std::string& address,
                                          const std::string& port,
-                                         const TlsCertificates& certs, const std::string& ca_content);
+                                         const TlsCertificates& certs,
+                                         const std::string& ca_content);
 
 void SetGrpcClientKeepAliveChannelArgs(grpc::ChannelArguments* args);
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Added a helper script to automate Vault setup and TLS certificate issuance.

- Refactor
  - Consolidated TLS CA configuration into a single TLS.CaFilePath/CaContent field; remove previous separate internal/external CA fields.
  - Components now consistently load CA content from the top-level TLS setting.

- Chores
  - TLS handling streamlined to pass CA content explicitly, simplifying configuration and interoperability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->