### PR TITLE
doc: update deployment and uninstall scripts for csupervisor handling

### DIFF
--- a/docs/deployment/backend/Rocky9.md
+++ b/docs/deployment/backend/Rocky9.md
@@ -166,8 +166,7 @@ cmake --build .
 2. Install the built binaries:
 
 !!! tip
-    If you prefer to use RPM packages, please see the [Packaging Guide](packaging.md) for instructions.
-
+    We recommend deploying CraneSched using RPM packages. See the [Packaging Guide](packaging.md) for installation instructions.
 ```bash
 cmake --install .
 ```

--- a/docs/deployment/backend/packaging.md
+++ b/docs/deployment/backend/packaging.md
@@ -156,6 +156,7 @@ Contains files for compute nodes:
 
 ```
 /usr/local/bin/craned                       # Execution daemon binary
+/usr/libexec/csupervisor                    # Per-step execution supervisor
 /etc/systemd/system/craned.service          # Systemd service file
 /etc/crane/config.yaml.sample               # Cluster configuration template
 /usr/lib64/security/pam_crane.so            # PAM authentication module

--- a/docs/deployment/configuration/multi-node.md
+++ b/docs/deployment/configuration/multi-node.md
@@ -97,6 +97,7 @@ scp /etc/systemd/system/cranectld.service cranectl:/etc/systemd/system/
 
 # Compute nodes
 pdcp -w crane[01-04] /usr/local/bin/craned /usr/local/bin/
+pdcp -w crane[01-04] /usr/libexec/csupervisor /usr/libexec/
 pdcp -w crane[01-04] /etc/systemd/system/craned.service /etc/systemd/system/
 ```
 

--- a/scripts/uninstall_craned.sh
+++ b/scripts/uninstall_craned.sh
@@ -2,6 +2,7 @@
 
 rm -f /usr/lib/libcraned.so
 rm -f /usr/local/bin/craned
+rm -f /usr/libexec/csupervisor
 rm -rf /usr/include/craned
 systemctl disable craned
 rm -f /etc/systemd/system/craned.service
@@ -9,6 +10,6 @@ rm -f /etc/systemd/system/craned.service
 rm -f /usr/lib64/security/pam_crane.so
 if grep -q "pam_crane.so" /etc/pam.d/sshd; then
    sed -i '/account    required     pam_crane.so/d' /etc/pam.d/sshd
-   sed -i '/session    optional     pam_crane.so/d' /etc/pam.d/sshd
+   sed -i '/session    required     pam_crane.so/d' /etc/pam.d/sshd
 fi
-systemctl deamon-reload
+systemctl daemon-reload


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Documentation
  - Strengthened guidance to deploy via RPM packages and linked installation instructions.
  - Documented inclusion of the supervisor component in the compute node package.
  - Updated multi-node setup steps to copy the supervisor to compute nodes.

- Bug Fixes
  - Corrected a misspelled system service reload command.
  - Fixed SSH PAM cleanup to correctly handle lines marked as required.

- Chores
  - Uninstall process now removes the supervisor component for a more complete cleanup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->