### PR TITLE
doc: Add permalink option to markdown table of contents

### DIFF
--- a/mkdocs.yaml
+++ b/mkdocs.yaml
@@ -39,6 +39,8 @@ markdown_extensions:
           class: mermaid
           format: !!python/name:pymdownx.superfences.fence_code_format
   - tables
+  - toc:
+      permalink: true
   - attr_list
   - admonition
   - md_in_html


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Enabled a table of contents with permalinks across the documentation site.
  * Section headers now include linkable anchors, making it easy to copy and share direct links to specific sections.
  * Improves navigation and deep-linking consistency without altering existing content or layout.
  * Applies across all docs pages for a more discoverable, mobile-friendly reading experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->