### PR TITLE
fix: Fix systemd unit file and update documentation

### DIFF
--- a/docs/deployment/backend/packaging.md
+++ b/docs/deployment/backend/packaging.md
@@ -144,23 +144,49 @@ sudo dpkg -i CraneSched-*-craned.deb
 Contains files for the control node:
 
 ```
-/usr/local/bin/cranectld                    # Control daemon binary
-/etc/systemd/system/cranectld.service       # Systemd service file
+/usr/bin/cranectld                          # Control daemon binary
+/usr/lib/systemd/system/cranectld.service   # Systemd service file
 /etc/crane/config.yaml.sample               # Cluster configuration template
 /etc/crane/database.yaml.sample             # Database configuration template
 ```
+
+!!! warning "Installation Path Differences"
+    The file paths differ depending on the installation method:
+
+    **When using RPM/DEB packages (`cpack`):**
+    - Binaries are installed to `/usr/bin/` (following FHS standard)
+    - Example: `/usr/bin/cranectld`
+
+    **When using direct installation (`cmake --install`):**
+    - Binaries are installed to `/usr/local/bin/` (default `CMAKE_INSTALL_PREFIX`)
+    - Example: `/usr/local/bin/cranectld`
+    - You can customize this with `cmake --install --prefix=/custom/path`
 
 ### craned Package
 
 Contains files for compute nodes:
 
 ```
-/usr/local/bin/craned                       # Execution daemon binary
+/usr/bin/craned                             # Execution daemon binary
 /usr/libexec/csupervisor                    # Per-step execution supervisor
-/etc/systemd/system/craned.service          # Systemd service file
+/usr/lib/systemd/system/craned.service      # Systemd service file
 /etc/crane/config.yaml.sample               # Cluster configuration template
 /usr/lib64/security/pam_crane.so            # PAM authentication module
 ```
+
+!!! warning "Installation Path Differences"
+    The file paths differ depending on the installation method:
+
+    **When using RPM/DEB packages (`cpack`):**
+    - Binaries are installed to `/usr/bin/` (following FHS standard)
+    - Supervisor is installed to `/usr/libexec/`
+    - Examples: `/usr/bin/craned`, `/usr/libexec/csupervisor`
+
+    **When using direct installation (`cmake --install`):**
+    - Binaries are installed to `/usr/local/bin/` (default `CMAKE_INSTALL_PREFIX`)
+    - Supervisor is installed to `/usr/local/libexec/`
+    - Examples: `/usr/local/bin/craned`, `/usr/local/libexec/csupervisor`
+    - You can customize this with `cmake --install --prefix=/custom/path`
 
 ### Post-Installation Actions
 

--- a/etc/cranectld.service.in
+++ b/etc/cranectld.service.in
@@ -5,7 +5,7 @@ After=network.target nss-lookup.target
 [Service]
 User=crane
 Group=crane
-ExecStart=@CMAKE_INSTALL_PREFIX@/bin/cranectld
+ExecStart=@CMAKE_INSTALL_FULL_BINDIR@/cranectld
 
 [Install]
 WantedBy=multi-user.target

--- a/etc/craned.service.in
+++ b/etc/craned.service.in
@@ -5,7 +5,7 @@ After=network.target nss-lookup.target
 [Service]
 User=root
 Group=root
-ExecStart=@CMAKE_INSTALL_PREFIX@/bin/craned
+ExecStart=@CMAKE_INSTALL_FULL_BINDIR@/craned
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
Correct the paths in the systemd unit files for the control and execution daemons, ensuring they align with the installation method. Update documentation to clarify installation path differences.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified installation path differences for deployments, covering both packaged installations and direct cmake-based deployments.

* **Chores**
  * Updated systemd service configurations to reference correct binary and service file locations across different installation methods.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->