### PR TITLE
fix: Specify package versions in doc requirements.txt and remove deprecated default language settings in mkdocs.yaml

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,5 +1,5 @@
-mkdocs
-mkdocs-material
-pymdown-extensions
-mkdocs-material-extensions
-mkdocs-static-i18n
+mkdocs==1.6.1
+mkdocs-material==9.6.22
+pymdown-extensions==10.16.1
+mkdocs-material-extensions==1.3.1
+mkdocs-static-i18n==1.3.0

--- a/mkdocs.yaml
+++ b/mkdocs.yaml
@@ -38,8 +38,6 @@ plugins:
       fallback_to_default: true
       reconfigure_material: true
       reconfigure_search: true
-      default_language: en
-      default_language_only: false
       languages:
         - locale: en
           name: English


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Locked Python package versions for documentation dependencies
  * Updated internationalization plugin configuration by removing global default language settings

<!-- end of auto-generated comment: release notes by coderabbit.ai -->