### PR TITLE
fix: Job keep running when some to supervisor rpc failed.

### DIFF
--- a/src/Craned/Core/JobManager.cpp
+++ b/src/Craned/Core/JobManager.cpp
@@ -355,7 +355,9 @@ bool JobManager::EvCheckSupervisorRunning_() {
             .job_id = job_id,
             .step_id = step_id,
             .new_status = StepStatus::Failed,
-            .reason = "Supervisor not responding during step completion"});
+            .exit_code = ExitCode::EC_RPC_ERR,
+            .reason = "Supervisor not responding during step completion",
+            .timestamp = google::protobuf::util::TimeUtil::GetCurrentTime()});
       } else {
         if (exists) continue;
       }
@@ -1212,7 +1214,9 @@ void JobManager::CleanUpJobAndStepsAsync(std::vector<JobInD>&& jobs,
               .job_id = step->job_id,
               .step_id = step->step_id,
               .new_status = StepStatus::Failed,
-              .reason = "Supervisor not responding during step completion"});
+              .exit_code = ExitCode::EC_RPC_ERR,
+              .reason = "Supervisor not responding during step completion",
+              .timestamp = google::protobuf::util::TimeUtil::GetCurrentTime()});
         }
       }
       g_supervisor_keeper->RemoveSupervisor(step->job_id, step->step_id);


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling when the supervisor becomes unresponsive: affected steps are now explicitly marked as Failed and detailed failure reasons are reported asynchronously to the control system, improving visibility and consistency of job failure status.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->