### PR TITLE
Revert "fix: Job keep running when some to supervisor rpc failed."

### DIFF
--- a/src/Craned/Core/JobManager.cpp
+++ b/src/Craned/Core/JobManager.cpp
@@ -351,13 +351,7 @@ bool JobManager::EvCheckSupervisorRunning_() {
             "[Step #{}.{}] Supervisor is still running after {} checks, will "
             "clean up now!",
             job_id, step_id, kMaxSupervisorCheckRetryCount);
-        g_ctld_client->StepStatusChangeAsync(StepStatusChangeQueueElem{
-            .job_id = job_id,
-            .step_id = step_id,
-            .new_status = StepStatus::Failed,
-            .exit_code = ExitCode::EC_RPC_ERR,
-            .reason = "Supervisor not responding during step completion",
-            .timestamp = google::protobuf::util::TimeUtil::GetCurrentTime()});
+        // TODO: Send status change for dead step
       } else {
         if (exists) continue;
       }
@@ -1206,17 +1200,8 @@ void JobManager::CleanUpJobAndStepsAsync(std::vector<JobInD>&& jobs,
                     step->step_id);
         auto err = stub->ShutdownSupervisor();
         if (err != CraneErrCode::SUCCESS) {
-          CRANE_ERROR(
-              "[Step #{}.{}] Failed to shutdown supervisor sending a status "
-              "change with FAILED status.",
-              step->job_id, step->step_id);
-          g_ctld_client->StepStatusChangeAsync(StepStatusChangeQueueElem{
-              .job_id = step->job_id,
-              .step_id = step->step_id,
-              .new_status = StepStatus::Failed,
-              .exit_code = ExitCode::EC_RPC_ERR,
-              .reason = "Supervisor not responding during step completion",
-              .timestamp = google::protobuf::util::TimeUtil::GetCurrentTime()});
+          CRANE_ERROR("[Step #{}.{}] Failed to shutdown supervisor.",
+                      step->job_id, step->step_id);
         }
       }
       g_supervisor_keeper->RemoveSupervisor(step->job_id, step->step_id);


### PR DESCRIPTION
Reverts PKUHPC/CraneSched#729

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* Improved error handling for unresponsive supervisors by streamlining status update notifications and enhancing error logging when supervisor shutdown operations fail.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->