### PR TITLE
fix: config qos

### DIFF
--- a/etc/config.yaml
+++ b/etc/config.yaml
@@ -84,7 +84,7 @@ PriorityWeightFairShare: 10000
 PriorityWeightJobSize: 0
 
 PriorityWeightPartition: 1000
-PriorityWeightQOS: 1000000
+PriorityWeightQoS: 1000000
 
 # list of configuration information of the computing machine
 # Nodes and partitions settings

--- a/src/CraneCtld/CraneCtld.cpp
+++ b/src/CraneCtld/CraneCtld.cpp
@@ -326,11 +326,11 @@ void ParseConfig(int argc, char** argv) {
       else
         g_config.PriorityConfig.WeightPartition = 0;
 
-      if (config["PriorityWeightQOS"])
-        g_config.PriorityConfig.WeightQOS =
-            config["PriorityWeightQOS"].as<uint32_t>();
+      if (config["PriorityWeightQoS"])
+        g_config.PriorityConfig.WeightQoS =
+            config["PriorityWeightQoS"].as<uint32_t>();
       else
-        g_config.PriorityConfig.WeightQOS = 0;
+        g_config.PriorityConfig.WeightQoS = 0;
 
       if (config["PendingQueueMaxSize"]) {
         g_config.PendingQueueMaxSize =

--- a/src/CraneCtld/CtldPublicDefs.h
+++ b/src/CraneCtld/CtldPublicDefs.h
@@ -144,7 +144,7 @@ struct Config {
     uint32_t WeightFairShare;
     uint32_t WeightJobSize;
     uint32_t WeightPartition;
-    uint32_t WeightQOS;
+    uint32_t WeightQoS;
   };
 
   struct PluginConfig {

--- a/src/CraneCtld/TaskScheduler.cpp
+++ b/src/CraneCtld/TaskScheduler.cpp
@@ -4115,7 +4115,7 @@ double MultiFactorPriority::CalculatePriority_(PdJobInScheduler* job,
       g_config.PriorityConfig.WeightPartition * partition_factor +
       g_config.PriorityConfig.WeightJobSize * job_size_factor +
       g_config.PriorityConfig.WeightFairShare * fair_share_factor +
-      g_config.PriorityConfig.WeightQOS * qos_factor;
+      g_config.PriorityConfig.WeightQoS * qos_factor;
 
   return priority;
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed a naming mismatch for the QoS priority weight in configuration and public settings. The QoS weight key and corresponding configuration field were aligned so the configured QoS weight is now read and applied consistently in priority calculations. No other functional behavior or control flow changed.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->