### PR TITLE
ci: 强制针对AVX2指令集编译

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -261,7 +261,10 @@ jobs:
               -v ./output:/Workspace/output \
               -v ./script:/Workspace/script \
               -v ./cache/ccache:/root/.ccache \
-              "${CI_IMAGE_TAG}" /bin/bash --login script/build.sh
+              -e CMAKE_CXX_FLAGS="-march=x86-64-v3" \
+              -e CMAKE_C_FLAGS="-march=x86-64-v3" \
+              -e CRANE_NATIVE_ARCH_OPT="OFF" \
+              "${CI_IMAGE_TAG}" /bin/bash --login -c 'export ADDITIONAL_CMAKE_ARGS="-DCRANE_NATIVE_ARCH_OPT=OFF -DCMAKE_CXX_FLAGS=\"-march=x86-64-v3\" -DCMAKE_C_FLAGS=\"-march=x86-64-v3\"" && script/build.sh'
 
       # Validate non-empty output
       - name: Validate non-empty output


### PR DESCRIPTION
CI编译二进制时没有显式指定目标指令集，故最终会支持到CI机器最新支持的指令集，也就是x86-64-v4，里面会使用AVX512的指令，这使得编译出来的二进制不可以在不支持AVX-512指令集的机器上运行。

我认为预提供的二进制应尽可能在更多的机器上运行，以便于更多用户试用产品。当用户真的在生产环境上运行时，再根据用户机器的情况单独编译来达到最佳的性能。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated container build configuration to optimize CPU architecture settings and apply additional compiler flags during the build process.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->