### PR TITLE
fix: add .pb.cc/.pb.h to protobuf custom command OUTPUT

### DIFF
--- a/CMakeModule/ProtobufGenerate.cmake
+++ b/CMakeModule/ProtobufGenerate.cmake
@@ -23,7 +23,8 @@ function(PROTOBUF_GENERATE_GRPC_CPP SRCS HDRS OUTDIR SYSTEM_PROTO_DIR)
                 "${OUTDIR}/${FIL_WE}.grpc.pb.h")
 
         add_custom_command(
-                OUTPUT "${OUTDIR}/${FIL_WE}.grpc.pb.cc" "${OUTDIR}/${FIL_WE}.grpc.pb.h"
+                OUTPUT "${OUTDIR}/${FIL_WE}.pb.cc" "${OUTDIR}/${FIL_WE}.pb.h"
+                       "${OUTDIR}/${FIL_WE}.grpc.pb.cc" "${OUTDIR}/${FIL_WE}.grpc.pb.h"
                 COMMAND ${CMAKE_COMMAND} -E env "LD_LIBRARY_PATH=${_PROTOBUF_LIBS_PATH}:$LD_LIBRARY_PATH"  ${_PROTOBUF_PROTOC}
                 ARGS --grpc_out "${OUTDIR}" --cpp_out "${OUTDIR}" -I ${CMAKE_CURRENT_SOURCE_DIR}
                 -I ${SYSTEM_PROTO_DIR}


### PR DESCRIPTION
The add_custom_command for protobuf generation only listed .grpc.pb.cc/.grpc.pb.h in OUTPUT, but the same command also generates .pb.cc/.pb.h via --cpp_out. CMake didn't track these files as outputs, so when .proto files changed, only the grpc files were regenerated while .pb.cc stayed stale. This caused undefined reference errors during incremental builds.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced build artifact dependency tracking to ensure all generated files are properly recognized during compilation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->