### PR TITLE
fix: set BUILD_CACHE_DIR before Compute fingerprint

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -135,6 +135,12 @@ jobs:
           path: CraneSched-FrontEnd
           ref: ${{ env.FRONTEND_REF }}
 
+      # Pull latest AutoTest scripts and set up derived paths
+      - name: Update AutoTest repo
+        run: |
+          git -C "$AUTOTEST_REPO" pull --ff-only origin master || echo "WARN: AutoTest pull failed, using existing version"
+          echo "BUILD_CACHE_DIR=${RUNNER_DIR}/cache/builds" >> "$GITHUB_ENV"
+
       # Resolve CI image digest (kept for metadata/fingerprint; not pinning run)
       - name: Resolve CI image digest
         id: imagedigest
@@ -201,12 +207,6 @@ jobs:
           echo "KEY_SHA256=${KEY_SHA256}"   >> "$GITHUB_ENV"
           echo "CACHE_TGZ=${CACHE_TGZ}"     >> "$GITHUB_ENV"
           echo "CACHE_META=${CACHE_META}"   >> "$GITHUB_ENV"
-
-      # Pull latest AutoTest scripts and set up derived paths
-      - name: Update AutoTest repo
-        run: |
-          git -C "$AUTOTEST_REPO" pull --ff-only origin master || echo "WARN: AutoTest pull failed, using existing version"
-          echo "BUILD_CACHE_DIR=${RUNNER_DIR}/cache/builds" >> "$GITHUB_ENV"
 
       # Prepare workspace & local cache dir
       - name: Prepare workspace & local cache


### PR DESCRIPTION
## Summary
- Move "Update AutoTest repo" step before "Compute fingerprint" so `BUILD_CACHE_DIR` is defined when referenced
- Fixes `BUILD_CACHE_DIR: unbound variable` error from #822

## Test plan
- [ ] CI build job passes the "Compute fingerprint" step without unbound variable error

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Optimized build pipeline sequencing to improve efficiency and prevent redundant processing steps.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->