### PR TITLE
ci: cache FetchContent downloads for faster builds

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -259,8 +259,10 @@ jobs:
               -v ./output:/Workspace/output \
               -v "${AUTOTEST_REPO}/docker/scripts":/Workspace/scripts \
               -v ccache:/root/.cache/ccache \
+              -v "${RUNNER_DIR}/cache/fetchcontent":/cache/fetchcontent \
               -e CCACHE_DIR=/root/.cache/ccache \
               -e CCACHE_MAXSIZE=5G \
+              -e FETCHCONTENT_BASE_DIR=/cache/fetchcontent \
               "${CI_IMAGE_TAG}" /bin/bash --login scripts/build-crane.sh ci-debug
 
       # Validate non-empty output


### PR DESCRIPTION
## Summary
- Mount persistent `fetchcontent/` directory into build container via `FETCHCONTENT_BASE_DIR`
- CMake dependency sources cached across clean builds — no re-downloading on branch switches
- Combined with ccache + build cache, CI builds are now:
  - **No code change**: instant (build cache hit)
  - **Source change, same deps**: fast (ccache hit + deps cached)
  - **Dep version change**: only the changed dep re-downloads
  - **CMake structure change**: clean build but deps still cached

## Depends on
- PKUHPC/CraneSched-AutoTest#299 (build script change)

## Test plan
- [ ] Verify first build populates `fetchcontent/` directory
- [ ] Verify second build reuses cached deps (no download output)
- [ ] Verify branch switch with different dep version triggers re-fetch of that dep only

🤖 Generated with [Claude Code](https://claude.com/claude-code)