### PR TITLE
fix: use correct TLS volume for CI tests

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -491,7 +491,7 @@ jobs:
             -v "${AUTOTEST_REPO}/docker/scripts":/CraneSched-AutoTest/docker/scripts \
             -v ./output:/CraneSched-AutoTest/output \
             -v ./log:/CraneSched-AutoTest/log \
-            -v /tmp/crane/tls:/etc/crane/tls:Z \
+            -v docker_crane-tls:/etc/crane/tls:ro \
             $( [ -n "$NETWORK_ID" ] && echo "--network $NETWORK_ID" ) \
             localhost/autotest
           podman exec ci-test /bin/bash --login docker/scripts/run-test.sh || echo "TEST_FAILED=true" >> $GITHUB_ENV


### PR DESCRIPTION
## Summary
- Change CI test container TLS mount from `/tmp/crane/tls` (stale host dir) to `docker_crane-tls` named volume (Vault's actual cert output)
- Fixes `certificate verify failed: unable to get local issuer certificate` on all test cases

## Root cause
Vault writes certs to the `docker_crane-tls` named volume (compose creates it with `docker_` prefix). CI was mounting the old host directory `/tmp/crane/tls` which had stale/mismatched certificates.

## Test plan
- [ ] CI test cases pass TLS handshake
- [ ] `cinfo` returns cluster info instead of "Connection to CraneCtld is broken"

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated build configuration for improved container security and consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->