### PR TITLE
perf: reduce supervisor check interval to 200ms

### DIFF
--- a/src/Craned/Core/JobManager.cpp
+++ b/src/Craned/Core/JobManager.cpp
@@ -145,7 +145,7 @@ JobManager::JobManager() {
         EvCheckSupervisorRunning_();
       });
   m_check_supervisor_timer_handle_->start(std::chrono::milliseconds{0ms},
-                                          std::chrono::milliseconds{1000ms});
+                                          std::chrono::milliseconds{200ms});
 
   // gRPC Alloc step Event
   m_grpc_alloc_step_async_handle_ = m_uvw_loop_->resource<uvw::async_handle>();


### PR DESCRIPTION
Reduce EvCheckSupervisorRunning_ polling from 1000ms to 200ms. Eliminates zombie detection delay.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance**
  * Increased supervisor status check frequency, reducing latency in job status monitoring.
  * Faster detection and reporting of state changes and potential failures.
  * Improves overall responsiveness of job management feedback in UI/CLI.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->