### PR TITLE
fix: cranectld prolog

### DIFF
--- a/src/CraneCtld/CraneCtld.cpp
+++ b/src/CraneCtld/CraneCtld.cpp
@@ -185,11 +185,11 @@ void ParseConfig(int argc, char** argv) {
             &g_config.JobLifecycleHook.CranectldEpilogs);
 
         g_config.JobLifecycleHook.PrologTimeout =
-            YamlValueOr<uint32_t>(hook_config["PrologTimeout"], 0);
+            YamlValueOr<uint32_t>(hook_config["PrologTimeout"], 60);
         g_config.JobLifecycleHook.EpilogTimeout =
-            YamlValueOr<uint32_t>(hook_config["EpilogTimeout"], 0);
+            YamlValueOr<uint32_t>(hook_config["EpilogTimeout"], 60);
         g_config.JobLifecycleHook.PrologEpilogTimeout =
-            YamlValueOr<uint32_t>(hook_config["PrologEpilogTimeout"], 0);
+            YamlValueOr<uint32_t>(hook_config["PrologEpilogTimeout"], 60);
         g_config.JobLifecycleHook.MaxOutputSize = YamlValueOr<uint64_t>(
             hook_config["MaxOutputSize"], kDefaultPrologOutputSize);
       }

--- a/src/CraneCtld/CraneCtld.cpp
+++ b/src/CraneCtld/CraneCtld.cpp
@@ -189,7 +189,7 @@ void ParseConfig(int argc, char** argv) {
         g_config.JobLifecycleHook.EpilogTimeout =
             YamlValueOr<uint32_t>(hook_config["EpilogTimeout"], 60);
         g_config.JobLifecycleHook.PrologEpilogTimeout =
-            YamlValueOr<uint32_t>(hook_config["PrologEpilogTimeout"], 60);
+            YamlValueOr<uint32_t>(hook_config["PrologEpilogTimeout"], 0);
         g_config.JobLifecycleHook.MaxOutputSize = YamlValueOr<uint64_t>(
             hook_config["MaxOutputSize"], kDefaultPrologOutputSize);
       }

--- a/src/CraneCtld/CtldPublicDefs.cpp
+++ b/src/CraneCtld/CtldPublicDefs.cpp
@@ -585,7 +585,7 @@ DaemonStepInCtld::StepStatusChange(crane::grpc::TaskStatus new_status,
                   util::StepStatusToString(new_status));
     }
 
-    if (this->AllNodesConfigured() && this->PrologComplete()) {
+    if (this->AllNodesConfigured()) {
       if (this->PrevErrorStatus()) {
         job_finished = true;
       } else if (job->CancelRequested()) {
@@ -638,6 +638,7 @@ DaemonStepInCtld::StepStatusChange(crane::grpc::TaskStatus new_status,
           context->craned_step_alloc_map[node_id].emplace_back(
               job->PrimaryStep()->GetStepToD(node_id));
         }
+        g_task_scheduler->StartCraneCtldPrologThread(job);
       }
     }
 
@@ -716,12 +717,6 @@ DaemonStepInCtld::StepStatusChange(crane::grpc::TaskStatus new_status,
   }
 
   return std::nullopt;
-}
-
-bool DaemonStepInCtld::PrologComplete() const {
-  if (g_config.JobLifecycleHook.CranectldPrologs.empty()) return true;
-
-  return !is_prolog_running;
 }
 
 void DaemonStepInCtld::RecoverFromDb(
@@ -1013,12 +1008,13 @@ void CommonStepInCtld::StepStatusChange(
 
   if (this->Status() == crane::grpc::TaskStatus::Configuring) {
     // Configuring -> Configured / Failed / Cancelled,
-    this->NodeConfigured(craned_id);
+    if (!craned_id.empty())
+      this->NodeConfigured(craned_id);
     if (new_status != crane::grpc::TaskStatus::Configured) {
       this->SetErrorStatus(new_status);
       this->SetErrorExitCode(exit_code);
     }
-    if (this->AllNodesConfigured()) {
+    if (this->AllNodesConfigured() && job->PrologComplete()) {
       if (this->PrevErrorStatus().has_value()) {
         // Configuring -> Failed
         step_configure_failed = true;
@@ -1253,6 +1249,12 @@ bool TaskInCtld::ShouldLaunchOnAllNodes() const {
   } else {
     std::unreachable();
   }
+}
+
+bool TaskInCtld::PrologComplete() const {
+  if (g_config.JobLifecycleHook.CranectldPrologs.empty()) return true;
+
+  return !is_prolog_running;
 }
 
 void TaskInCtld::SetTaskId(task_id_t id) {

--- a/src/CraneCtld/CtldPublicDefs.cpp
+++ b/src/CraneCtld/CtldPublicDefs.cpp
@@ -1007,8 +1007,7 @@ void CommonStepInCtld::StepStatusChange(
 
   if (this->Status() == crane::grpc::TaskStatus::Configuring) {
     // Configuring -> Configured / Failed / Cancelled,
-    if (!craned_id.empty())
-      this->NodeConfigured(craned_id);
+    if (!craned_id.empty()) this->NodeConfigured(craned_id);
     if (new_status != crane::grpc::TaskStatus::Configured) {
       this->SetErrorStatus(new_status);
       this->SetErrorExitCode(exit_code);

--- a/src/CraneCtld/CtldPublicDefs.cpp
+++ b/src/CraneCtld/CtldPublicDefs.cpp
@@ -567,7 +567,8 @@ DaemonStepInCtld::StepStatusChange(crane::grpc::TaskStatus new_status,
   switch (this->Status()) {
   case crane::grpc::TaskStatus::Configuring:
     // Configuring -> Failed / Running
-    this->NodeConfigured(craned_id);
+    if (!craned_id.empty())
+      this->NodeConfigured(craned_id);
 
     switch (new_status) {
     case crane::grpc::TaskStatus::Running:
@@ -584,7 +585,7 @@ DaemonStepInCtld::StepStatusChange(crane::grpc::TaskStatus new_status,
                   util::StepStatusToString(new_status));
     }
 
-    if (this->AllNodesConfigured()) {
+    if (this->AllNodesConfigured() && this->PrologComplete()) {
       if (this->PrevErrorStatus()) {
         job_finished = true;
       } else if (job->CancelRequested()) {
@@ -715,6 +716,12 @@ DaemonStepInCtld::StepStatusChange(crane::grpc::TaskStatus new_status,
   }
 
   return std::nullopt;
+}
+
+bool DaemonStepInCtld::PrologComplete() const {
+  if (g_config.JobLifecycleHook.CranectldPrologs.empty()) return true;
+
+  return !is_prolog_running;
 }
 
 void DaemonStepInCtld::RecoverFromDb(

--- a/src/CraneCtld/CtldPublicDefs.cpp
+++ b/src/CraneCtld/CtldPublicDefs.cpp
@@ -567,8 +567,7 @@ DaemonStepInCtld::StepStatusChange(crane::grpc::TaskStatus new_status,
   switch (this->Status()) {
   case crane::grpc::TaskStatus::Configuring:
     // Configuring -> Failed / Running
-    if (!craned_id.empty())
-      this->NodeConfigured(craned_id);
+    this->NodeConfigured(craned_id);
 
     switch (new_status) {
     case crane::grpc::TaskStatus::Running:

--- a/src/CraneCtld/CtldPublicDefs.h
+++ b/src/CraneCtld/CtldPublicDefs.h
@@ -730,6 +730,8 @@ struct DaemonStepInCtld : StepInCtld {
   std::string account;
   std::string qos;
 
+  bool is_prolog_running{false};
+
   ~DaemonStepInCtld() override = default;
 
   void InitFromJob(const TaskInCtld& job);
@@ -744,6 +746,8 @@ struct DaemonStepInCtld : StepInCtld {
                    const std::string& reason, const CranedId& craned_id,
                    const google::protobuf::Timestamp& timestamp,
                    StepStatusChangeContext* context);
+
+  bool PrologComplete() const;
 
   void RecoverFromDb(const TaskInCtld& job,
                      const crane::grpc::StepInEmbeddedDb& step_in_db) override;

--- a/src/CraneCtld/CtldPublicDefs.h
+++ b/src/CraneCtld/CtldPublicDefs.h
@@ -730,8 +730,6 @@ struct DaemonStepInCtld : StepInCtld {
   std::string account;
   std::string qos;
 
-  bool is_prolog_running{false};
-
   ~DaemonStepInCtld() override = default;
 
   void InitFromJob(const TaskInCtld& job);
@@ -746,8 +744,6 @@ struct DaemonStepInCtld : StepInCtld {
                    const std::string& reason, const CranedId& craned_id,
                    const google::protobuf::Timestamp& timestamp,
                    StepStatusChangeContext* context);
-
-  bool PrologComplete() const;
 
   void RecoverFromDb(const TaskInCtld& job,
                      const crane::grpc::StepInEmbeddedDb& step_in_db) override;
@@ -837,6 +833,8 @@ struct TaskInCtld {
   std::list<std::string> account_chain;
 
   std::string submit_hostname;
+
+  bool is_prolog_running{false};
 
  private:
   /* ------------- [2] -------------
@@ -938,6 +936,8 @@ struct TaskInCtld {
   bool IsX11() const;
   bool IsX11WithPty() const;
   bool ShouldLaunchOnAllNodes() const;
+
+  bool PrologComplete() const;
 
   crane::grpc::TaskToCtld const& TaskToCtld() const { return task_to_ctld; }
   crane::grpc::TaskToCtld* MutableTaskToCtld() { return &task_to_ctld; }

--- a/src/CraneCtld/TaskScheduler.cpp
+++ b/src/CraneCtld/TaskScheduler.cpp
@@ -1180,55 +1180,6 @@ void TaskScheduler::ScheduleThread_() {
       Mutex thread_pool_mtx;
       HashSet<task_id_t> failed_job_id_set;
 
-      if (!g_config.JobLifecycleHook.CranectldPrologs.empty()) {
-        // TODO: cbatch job must be requeue
-        begin = std::chrono::steady_clock::now();
-        absl::BlockingCounter prolog_bl(jobs_to_run.size());
-        for (auto& job : jobs_to_run) {
-          const task_id_t job_id = job->TaskId();
-          g_thread_pool->detach_task([&, job_id, env = job->env]() {
-            // run prolog ctld script
-            RunPrologEpilogArgs run_prolog_args{
-                .scripts = g_config.JobLifecycleHook.CranectldPrologs,
-                .envs = env,
-                .timeout_sec = g_config.JobLifecycleHook.PrologTimeout,
-                .run_uid = 0,
-                .run_gid = 0,
-                .output_size = g_config.JobLifecycleHook.MaxOutputSize};
-                run_prolog_args.timeout_sec =
-                  g_config.JobLifecycleHook.PrologTimeout;
-              if (g_config.JobLifecycleHook.PrologEpilogTimeout > 60) {
-                run_prolog_args.timeout_sec =
-                    g_config.JobLifecycleHook.PrologEpilogTimeout;
-              }
-            CRANE_TRACE(
-                "#{}: Running CraneCtldProlog as UID {} with timeout {}s",
-                job_id, run_prolog_args.run_uid, run_prolog_args.timeout_sec);
-            auto run_prolog_result =
-                util::os::RunPrologOrEpiLog(run_prolog_args);
-            if (!run_prolog_result) {
-              auto status = run_prolog_result.error();
-              CRANE_DEBUG("[Job #{}]: CraneCtldProlog failed status={}:{}",
-                          job_id, status.exit_code, status.signal_num);
-              thread_pool_mtx.Lock();
-              failed_job_id_set.emplace(job_id);
-              thread_pool_mtx.Unlock();
-            } else {
-              CRANE_DEBUG("[Job #{}]: CraneCtldProlog success", job_id);
-            }
-            prolog_bl.DecrementCount();
-          });
-        }
-        prolog_bl.Wait();
-        end = std::chrono::steady_clock::now();
-        CRANE_TRACE(
-            "CraneCtldProlog running costed {} ms",
-            std::chrono::duration_cast<std::chrono::milliseconds>(end - begin)
-                .count());
-      }
-
-      begin = std::chrono::steady_clock::now();
-
       // RPC is time-consuming. Clustering rpc to one craned for performance.
 
       // Map for AllocJobs rpc.
@@ -1251,7 +1202,6 @@ void TaskScheduler::ScheduleThread_() {
       }
 
       for (auto& job : jobs_to_run) {
-        if (failed_job_id_set.contains(job->TaskId())) continue;
         // IMPORTANT: job must be put into running_task_map before any
         // time-consuming operation, otherwise TaskStatusChange RPC will come
         // earlier before job is put into running_task_map.
@@ -1266,10 +1216,11 @@ void TaskScheduler::ScheduleThread_() {
       }
 
       for (auto& job : jobs_to_run) {
-        if (failed_job_id_set.contains(job->TaskId())) continue;
         job->SetPrimaryStepStatus(crane::grpc::TaskStatus::Invalid);
         std::unique_ptr daemon_step = std::make_unique<DaemonStepInCtld>();
         daemon_step->InitFromJob(*job);
+        if (!g_config.JobLifecycleHook.CranectldPrologs.empty())
+          daemon_step->is_prolog_running = true;
         step_in_ctld_vec.push_back(daemon_step.get());
         job->SetDaemonStep(std::move(daemon_step));
       }
@@ -1281,7 +1232,6 @@ void TaskScheduler::ScheduleThread_() {
         CRANE_ERROR("Failed to append steps to embedded database.");
       } else {
         for (auto& job : jobs_to_run) {
-          if (failed_job_id_set.contains(job->TaskId())) continue;
           auto* daemon_step = job->DaemonStep();
           for (CranedId const& craned_id : job->CranedIds()) {
             craned_alloc_job_map[craned_id].push_back(
@@ -1422,9 +1372,13 @@ void TaskScheduler::ScheduleThread_() {
       // queue.
 
       // Set succeed tasks status and do callbacks.
+      std::vector<job_id_t> to_run_prolog_job_ids;
+      to_run_prolog_job_ids.reserve(jobs_created.size());
       for (auto& job : jobs_created) {
         job->TriggerDependencyEvents(crane::grpc::DependencyType::AFTER,
                                      job->StartTime());
+        if (!g_config.JobLifecycleHook.CranectldPrologs.empty())
+          to_run_prolog_job_ids.emplace_back(job->TaskId());
         // The ownership of TaskInCtld is transferred to the running queue.
         m_running_task_map_.emplace(job->TaskId(), std::move(job));
       }
@@ -1451,6 +1405,63 @@ void TaskScheduler::ScheduleThread_() {
           std::chrono::duration_cast<std::chrono::milliseconds>(schedule_end -
                                                                 schedule_begin)
               .count());
+
+      // CraneCtldProlog must be executed prior to task execution, 
+      // specifically during the configure phase, and it requires the running map 
+      // for the task to be present. At present, the framework can only launch the 
+      // CraneCtldProlog thread after the step has started and before the task is executed.
+      if (!g_config.JobLifecycleHook.CranectldPrologs.empty()) {
+        // TODO: cbatch job must be requeue
+        for (auto& job_id : to_run_prolog_job_ids) {
+          auto& job = m_running_task_map_.at(job_id);
+          
+          g_thread_pool->detach_task([this, job_id, env = job->env]() {
+            // run prolog ctld script
+            RunPrologEpilogArgs run_prolog_args{
+                .scripts = g_config.JobLifecycleHook.CranectldPrologs,
+                .envs = env,
+                .timeout_sec = g_config.JobLifecycleHook.PrologTimeout,
+                .run_uid = 0,
+                .run_gid = 0,
+                .output_size = g_config.JobLifecycleHook.MaxOutputSize};
+                run_prolog_args.timeout_sec =
+                  g_config.JobLifecycleHook.PrologTimeout;
+              if (g_config.JobLifecycleHook.PrologEpilogTimeout > 60) {
+                run_prolog_args.timeout_sec =
+                    g_config.JobLifecycleHook.PrologEpilogTimeout;
+              }
+            CRANE_TRACE(
+                "[Job #{}]: Running CraneCtldProlog as UID {} with timeout {}s",
+                job_id, run_prolog_args.run_uid, run_prolog_args.timeout_sec);
+            auto run_prolog_result =
+                util::os::RunPrologOrEpiLog(run_prolog_args);
+            
+            absl::MutexLock running_lk(&m_running_task_map_mtx_);
+            auto iter = m_running_task_map_.find(job_id);
+            if (iter == m_running_task_map_.end()) {
+              CRANE_DEBUG("[Job #{}]: Job not found in m_running_task_map_ when running CraneCtldProlog," 
+                " may be canceled.", job_id);
+              return;
+            }
+            auto& job = iter->second;
+            auto now = google::protobuf::util::TimeUtil::GetCurrentTime();
+            job->DaemonStep()->is_prolog_running = false;
+            if (!run_prolog_result) {
+              auto status = run_prolog_result.error();
+              CRANE_DEBUG("[Job #{}]: CraneCtldProlog failed status={}:{}",
+                          job_id, status.exit_code, status.signal_num);
+              this->StepStatusChangeAsync(job_id, kDaemonStepId, "",
+                                  crane::grpc::TaskStatus::Failed, ExitCode::EC_PROLOG_ERR,
+                                  "CraneCtldPrologError", now);
+            } else {
+              CRANE_DEBUG("[Job #{}]: CraneCtldProlog success", job_id);
+              this->StepStatusChangeAsync(job_id, kDaemonStepId, "",
+                                  crane::grpc::TaskStatus::Running, 0,
+                                  "", now);
+            }
+          });
+        }
+      }
 
       // Note: If unlock pending_map here, jobs may be unable to be find
       // before transferring to DB.

--- a/src/CraneCtld/TaskScheduler.cpp
+++ b/src/CraneCtld/TaskScheduler.cpp
@@ -1370,13 +1370,9 @@ void TaskScheduler::ScheduleThread_() {
       // queue.
 
       // Set succeed tasks status and do callbacks.
-      std::vector<job_id_t> to_run_prolog_job_ids;
-      to_run_prolog_job_ids.reserve(jobs_created.size());
       for (auto& job : jobs_created) {
         job->TriggerDependencyEvents(crane::grpc::DependencyType::AFTER,
                                      job->StartTime());
-        if (!g_config.JobLifecycleHook.CranectldPrologs.empty())
-          to_run_prolog_job_ids.emplace_back(job->TaskId());
         // The ownership of TaskInCtld is transferred to the running queue.
         m_running_task_map_.emplace(job->TaskId(), std::move(job));
       }

--- a/src/CraneCtld/TaskScheduler.cpp
+++ b/src/CraneCtld/TaskScheduler.cpp
@@ -3298,59 +3298,62 @@ void TaskScheduler::CleanStepSubmitQueueCb_() {
 }
 
 void TaskScheduler::StartCraneCtldPrologThread(TaskInCtld* job) {
-  // CraneCtldProlog must be executed prior to task execution, 
-  // specifically during the configure phase, and it requires the running map 
-  // for the task to be present. At present, the framework can only launch the 
-  // CraneCtldProlog thread after the step has started and before the task is executed.
+  // CraneCtldProlog must be executed prior to task execution,
+  // specifically during the configure phase, and it requires the running map
+  // for the task to be present. At present, the framework can only launch the
+  // CraneCtldProlog thread after the step has started and before the task is
+  // executed.
   if (!g_config.JobLifecycleHook.CranectldPrologs.empty()) {
     // TODO: cbatch job must be requeue
     job->is_prolog_running = true;
-    g_thread_pool->detach_task([this, job_id = job->TaskId(), env = job->env]() {
-      // run prolog ctld script
-      RunPrologEpilogArgs run_prolog_args{
-        .scripts = g_config.JobLifecycleHook.CranectldPrologs,
-        .envs = env,
-        .timeout_sec = g_config.JobLifecycleHook.PrologTimeout,
-        .run_uid = 0,
-        .run_gid = 0,
-        .output_size = g_config.JobLifecycleHook.MaxOutputSize};
-        run_prolog_args.timeout_sec =
-          g_config.JobLifecycleHook.PrologTimeout;
-        if (g_config.JobLifecycleHook.PrologEpilogTimeout > 0) {
-          run_prolog_args.timeout_sec =
-                    g_config.JobLifecycleHook.PrologEpilogTimeout;
-        }
-        CRANE_TRACE(
-            "[Job #{}]: Running CraneCtldProlog as UID {} with timeout {}s",
-            job_id, run_prolog_args.run_uid, run_prolog_args.timeout_sec);
-        auto run_prolog_result =
-                util::os::RunPrologOrEpiLog(run_prolog_args);
-            
-        absl::MutexLock running_lk(&m_running_task_map_mtx_);
-        auto iter = m_running_task_map_.find(job_id);
-        if (iter == m_running_task_map_.end()) {
-          CRANE_DEBUG("[Job #{}]: Job not found in m_running_task_map_ when running CraneCtldProlog," 
-                " may be canceled.", job_id);
-              return;
-        }
-        auto& job = iter->second;
-        auto now = google::protobuf::util::TimeUtil::GetCurrentTime();
-        job->is_prolog_running = false;
-        if (!run_prolog_result) {
-              auto status = run_prolog_result.error();
-              CRANE_DEBUG("[Job #{}]: CraneCtldProlog failed status={}:{}",
-                          job_id, status.exit_code, status.signal_num);
-              this->StepStatusChangeAsync(job_id, kPrimaryStepId, "",
-                                  crane::grpc::TaskStatus::Cancelled, ExitCode::EC_PROLOG_ERR,
-                                  "CraneCtldPrologError", now);
-        } else {
-              CRANE_DEBUG("[Job #{}]: CraneCtldProlog success", job_id);
-              this->StepStatusChangeAsync(job_id, kPrimaryStepId, "",
-                                  crane::grpc::TaskStatus::Configured, 0,
-                                  "", now);
-            }
-      });
-    }
+    g_thread_pool->detach_task(
+        [this, job_id = job->TaskId(), env = job->env]() {
+          // run prolog ctld script
+          RunPrologEpilogArgs run_prolog_args{
+              .scripts = g_config.JobLifecycleHook.CranectldPrologs,
+              .envs = env,
+              .timeout_sec = g_config.JobLifecycleHook.PrologTimeout,
+              .run_uid = 0,
+              .run_gid = 0,
+              .output_size = g_config.JobLifecycleHook.MaxOutputSize};
+          run_prolog_args.timeout_sec = g_config.JobLifecycleHook.PrologTimeout;
+          if (g_config.JobLifecycleHook.PrologEpilogTimeout > 0) {
+            run_prolog_args.timeout_sec =
+                g_config.JobLifecycleHook.PrologEpilogTimeout;
+          }
+          CRANE_TRACE(
+              "[Job #{}]: Running CraneCtldProlog as UID {} with timeout {}s",
+              job_id, run_prolog_args.run_uid, run_prolog_args.timeout_sec);
+          auto run_prolog_result = util::os::RunPrologOrEpiLog(run_prolog_args);
+
+          absl::MutexLock running_lk(&m_running_task_map_mtx_);
+          auto iter = m_running_task_map_.find(job_id);
+          if (iter == m_running_task_map_.end()) {
+            CRANE_DEBUG(
+                "[Job #{}]: Job not found in m_running_task_map_ when running "
+                "CraneCtldProlog,"
+                " may be canceled.",
+                job_id);
+            return;
+          }
+          auto& job = iter->second;
+          auto now = google::protobuf::util::TimeUtil::GetCurrentTime();
+          job->is_prolog_running = false;
+          if (!run_prolog_result) {
+            auto status = run_prolog_result.error();
+            CRANE_DEBUG("[Job #{}]: CraneCtldProlog failed status={}:{}",
+                        job_id, status.exit_code, status.signal_num);
+            this->StepStatusChangeAsync(
+                job_id, kPrimaryStepId, "", crane::grpc::TaskStatus::Cancelled,
+                ExitCode::EC_PROLOG_ERR, "CraneCtldPrologError", now);
+          } else {
+            CRANE_DEBUG("[Job #{}]: CraneCtldProlog success", job_id);
+            this->StepStatusChangeAsync(job_id, kPrimaryStepId, "",
+                                        crane::grpc::TaskStatus::Configured, 0,
+                                        "", now);
+          }
+        });
+  }
 }
 
 void TaskScheduler::StepStatusChangeAsync(

--- a/src/CraneCtld/TaskScheduler.cpp
+++ b/src/CraneCtld/TaskScheduler.cpp
@@ -1191,16 +1191,16 @@ void TaskScheduler::ScheduleThread_() {
             RunPrologEpilogArgs run_prolog_args{
                 .scripts = g_config.JobLifecycleHook.CranectldPrologs,
                 .envs = env,
+                .timeout_sec = g_config.JobLifecycleHook.PrologTimeout,
                 .run_uid = 0,
                 .run_gid = 0,
                 .output_size = g_config.JobLifecycleHook.MaxOutputSize};
-            if (g_config.JobLifecycleHook.PrologTimeout) {
-              run_prolog_args.timeout_sec =
+                run_prolog_args.timeout_sec =
                   g_config.JobLifecycleHook.PrologTimeout;
-            } else {
-              run_prolog_args.timeout_sec =
-                  g_config.JobLifecycleHook.PrologEpilogTimeout;
-            }
+              if (g_config.JobLifecycleHook.PrologEpilogTimeout > 60) {
+                run_prolog_args.timeout_sec =
+                    g_config.JobLifecycleHook.PrologEpilogTimeout;
+              }
             CRANE_TRACE(
                 "#{}: Running CraneCtldProlog as UID {} with timeout {}s",
                 job_id, run_prolog_args.run_uid, run_prolog_args.timeout_sec);
@@ -3492,13 +3492,11 @@ void TaskScheduler::CleanTaskStatusChangeQueueCb_() {
               RunPrologEpilogArgs run_epilog_ctld_args{
                   .scripts = g_config.JobLifecycleHook.CranectldEpilogs,
                   .envs = env_copy,
+                  .timeout_sec = g_config.JobLifecycleHook.EpilogTimeout,
                   .run_uid = 0,
                   .run_gid = 0,
                   .output_size = g_config.JobLifecycleHook.MaxOutputSize};
-              if (g_config.JobLifecycleHook.EpilogTimeout) {
-                run_epilog_ctld_args.timeout_sec =
-                    g_config.JobLifecycleHook.EpilogTimeout;
-              } else {
+              if (g_config.JobLifecycleHook.PrologEpilogTimeout > 60) {
                 run_epilog_ctld_args.timeout_sec =
                     g_config.JobLifecycleHook.PrologEpilogTimeout;
               }

--- a/src/CraneCtld/TaskScheduler.cpp
+++ b/src/CraneCtld/TaskScheduler.cpp
@@ -1219,8 +1219,6 @@ void TaskScheduler::ScheduleThread_() {
         job->SetPrimaryStepStatus(crane::grpc::TaskStatus::Invalid);
         std::unique_ptr daemon_step = std::make_unique<DaemonStepInCtld>();
         daemon_step->InitFromJob(*job);
-        if (!g_config.JobLifecycleHook.CranectldPrologs.empty())
-          daemon_step->is_prolog_running = true;
         step_in_ctld_vec.push_back(daemon_step.get());
         job->SetDaemonStep(std::move(daemon_step));
       }
@@ -1405,63 +1403,6 @@ void TaskScheduler::ScheduleThread_() {
           std::chrono::duration_cast<std::chrono::milliseconds>(schedule_end -
                                                                 schedule_begin)
               .count());
-
-      // CraneCtldProlog must be executed prior to task execution, 
-      // specifically during the configure phase, and it requires the running map 
-      // for the task to be present. At present, the framework can only launch the 
-      // CraneCtldProlog thread after the step has started and before the task is executed.
-      if (!g_config.JobLifecycleHook.CranectldPrologs.empty()) {
-        // TODO: cbatch job must be requeue
-        for (auto& job_id : to_run_prolog_job_ids) {
-          auto& job = m_running_task_map_.at(job_id);
-          
-          g_thread_pool->detach_task([this, job_id, env = job->env]() {
-            // run prolog ctld script
-            RunPrologEpilogArgs run_prolog_args{
-                .scripts = g_config.JobLifecycleHook.CranectldPrologs,
-                .envs = env,
-                .timeout_sec = g_config.JobLifecycleHook.PrologTimeout,
-                .run_uid = 0,
-                .run_gid = 0,
-                .output_size = g_config.JobLifecycleHook.MaxOutputSize};
-                run_prolog_args.timeout_sec =
-                  g_config.JobLifecycleHook.PrologTimeout;
-              if (g_config.JobLifecycleHook.PrologEpilogTimeout > 60) {
-                run_prolog_args.timeout_sec =
-                    g_config.JobLifecycleHook.PrologEpilogTimeout;
-              }
-            CRANE_TRACE(
-                "[Job #{}]: Running CraneCtldProlog as UID {} with timeout {}s",
-                job_id, run_prolog_args.run_uid, run_prolog_args.timeout_sec);
-            auto run_prolog_result =
-                util::os::RunPrologOrEpiLog(run_prolog_args);
-            
-            absl::MutexLock running_lk(&m_running_task_map_mtx_);
-            auto iter = m_running_task_map_.find(job_id);
-            if (iter == m_running_task_map_.end()) {
-              CRANE_DEBUG("[Job #{}]: Job not found in m_running_task_map_ when running CraneCtldProlog," 
-                " may be canceled.", job_id);
-              return;
-            }
-            auto& job = iter->second;
-            auto now = google::protobuf::util::TimeUtil::GetCurrentTime();
-            job->DaemonStep()->is_prolog_running = false;
-            if (!run_prolog_result) {
-              auto status = run_prolog_result.error();
-              CRANE_DEBUG("[Job #{}]: CraneCtldProlog failed status={}:{}",
-                          job_id, status.exit_code, status.signal_num);
-              this->StepStatusChangeAsync(job_id, kDaemonStepId, "",
-                                  crane::grpc::TaskStatus::Failed, ExitCode::EC_PROLOG_ERR,
-                                  "CraneCtldPrologError", now);
-            } else {
-              CRANE_DEBUG("[Job #{}]: CraneCtldProlog success", job_id);
-              this->StepStatusChangeAsync(job_id, kDaemonStepId, "",
-                                  crane::grpc::TaskStatus::Running, 0,
-                                  "", now);
-            }
-          });
-        }
-      }
 
       // Note: If unlock pending_map here, jobs may be unable to be find
       // before transferring to DB.
@@ -3358,6 +3299,62 @@ void TaskScheduler::CleanStepSubmitQueueCb_() {
     }
     CRANE_ERROR("Failed to append a batch of steps to embedded db queue.");
   }
+}
+
+void TaskScheduler::StartCraneCtldPrologThread(TaskInCtld* job) {
+  // CraneCtldProlog must be executed prior to task execution, 
+  // specifically during the configure phase, and it requires the running map 
+  // for the task to be present. At present, the framework can only launch the 
+  // CraneCtldProlog thread after the step has started and before the task is executed.
+  if (!g_config.JobLifecycleHook.CranectldPrologs.empty()) {
+    // TODO: cbatch job must be requeue
+    job->is_prolog_running = true;
+    g_thread_pool->detach_task([this, job_id = job->TaskId(), env = job->env]() {
+      // run prolog ctld script
+      RunPrologEpilogArgs run_prolog_args{
+        .scripts = g_config.JobLifecycleHook.CranectldPrologs,
+        .envs = env,
+        .timeout_sec = g_config.JobLifecycleHook.PrologTimeout,
+        .run_uid = 0,
+        .run_gid = 0,
+        .output_size = g_config.JobLifecycleHook.MaxOutputSize};
+        run_prolog_args.timeout_sec =
+          g_config.JobLifecycleHook.PrologTimeout;
+        if (g_config.JobLifecycleHook.PrologEpilogTimeout > 60) {
+          run_prolog_args.timeout_sec =
+                    g_config.JobLifecycleHook.PrologEpilogTimeout;
+        }
+        CRANE_TRACE(
+            "[Job #{}]: Running CraneCtldProlog as UID {} with timeout {}s",
+            job_id, run_prolog_args.run_uid, run_prolog_args.timeout_sec);
+        auto run_prolog_result =
+                util::os::RunPrologOrEpiLog(run_prolog_args);
+            
+        absl::MutexLock running_lk(&m_running_task_map_mtx_);
+        auto iter = m_running_task_map_.find(job_id);
+        if (iter == m_running_task_map_.end()) {
+          CRANE_DEBUG("[Job #{}]: Job not found in m_running_task_map_ when running CraneCtldProlog," 
+                " may be canceled.", job_id);
+              return;
+        }
+        auto& job = iter->second;
+        auto now = google::protobuf::util::TimeUtil::GetCurrentTime();
+        job->is_prolog_running = false;
+        if (!run_prolog_result) {
+              auto status = run_prolog_result.error();
+              CRANE_DEBUG("[Job #{}]: CraneCtldProlog failed status={}:{}",
+                          job_id, status.exit_code, status.signal_num);
+              this->StepStatusChangeAsync(job_id, kPrimaryStepId, "",
+                                  crane::grpc::TaskStatus::Cancelled, ExitCode::EC_PROLOG_ERR,
+                                  "CraneCtldPrologError", now);
+        } else {
+              CRANE_DEBUG("[Job #{}]: CraneCtldProlog success", job_id);
+              this->StepStatusChangeAsync(job_id, kPrimaryStepId, "",
+                                  crane::grpc::TaskStatus::Configured, 0,
+                                  "", now);
+            }
+      });
+    }
 }
 
 void TaskScheduler::StepStatusChangeAsync(

--- a/src/CraneCtld/TaskScheduler.cpp
+++ b/src/CraneCtld/TaskScheduler.cpp
@@ -3320,7 +3320,7 @@ void TaskScheduler::StartCraneCtldPrologThread(TaskInCtld* job) {
         .output_size = g_config.JobLifecycleHook.MaxOutputSize};
         run_prolog_args.timeout_sec =
           g_config.JobLifecycleHook.PrologTimeout;
-        if (g_config.JobLifecycleHook.PrologEpilogTimeout > 60) {
+        if (g_config.JobLifecycleHook.PrologEpilogTimeout > 0) {
           run_prolog_args.timeout_sec =
                     g_config.JobLifecycleHook.PrologEpilogTimeout;
         }
@@ -3504,7 +3504,7 @@ void TaskScheduler::CleanTaskStatusChangeQueueCb_() {
                   .run_uid = 0,
                   .run_gid = 0,
                   .output_size = g_config.JobLifecycleHook.MaxOutputSize};
-              if (g_config.JobLifecycleHook.PrologEpilogTimeout > 60) {
+              if (g_config.JobLifecycleHook.PrologEpilogTimeout > 0) {
                 run_epilog_ctld_args.timeout_sec =
                     g_config.JobLifecycleHook.PrologEpilogTimeout;
               }

--- a/src/CraneCtld/TaskScheduler.h
+++ b/src/CraneCtld/TaskScheduler.h
@@ -805,6 +805,8 @@ class TaskScheduler {
                           reason.value_or(""), std::move(timestamp));
   }
 
+  void StartCraneCtldPrologThread(TaskInCtld* job);
+
   void StepStatusChangeAsync(job_id_t job_id, step_id_t step_id,
                              const CranedId& craned_index,
                              crane::grpc::TaskStatus new_status,

--- a/src/Craned/Core/Craned.cpp
+++ b/src/Craned/Core/Craned.cpp
@@ -863,11 +863,11 @@ void ParseConfig(int argc, char** argv) {
             &g_config.JobLifecycleHook.TaskEpilogs);
 
         g_config.JobLifecycleHook.PrologTimeout =
-            YamlValueOr<uint32_t>(job_log_hook_config["PrologTimeout"], 0);
+            YamlValueOr<uint32_t>(job_log_hook_config["PrologTimeout"], 60);
         g_config.JobLifecycleHook.EpilogTimeout =
-            YamlValueOr<uint32_t>(job_log_hook_config["EpilogTimeout"], 0);
+            YamlValueOr<uint32_t>(job_log_hook_config["EpilogTimeout"], 60);
         g_config.JobLifecycleHook.PrologEpilogTimeout = YamlValueOr<uint32_t>(
-            job_log_hook_config["PrologEpilogTimeout"], 0);
+            job_log_hook_config["PrologEpilogTimeout"], 60);
         g_config.JobLifecycleHook.MaxOutputSize = YamlValueOr<uint64_t>(
             job_log_hook_config["MaxOutputSize"], kDefaultPrologOutputSize);
 

--- a/src/Craned/Core/Craned.cpp
+++ b/src/Craned/Core/Craned.cpp
@@ -867,7 +867,7 @@ void ParseConfig(int argc, char** argv) {
         g_config.JobLifecycleHook.EpilogTimeout =
             YamlValueOr<uint32_t>(job_log_hook_config["EpilogTimeout"], 60);
         g_config.JobLifecycleHook.PrologEpilogTimeout = YamlValueOr<uint32_t>(
-            job_log_hook_config["PrologEpilogTimeout"], 60);
+            job_log_hook_config["PrologEpilogTimeout"], 0);
         g_config.JobLifecycleHook.MaxOutputSize = YamlValueOr<uint64_t>(
             job_log_hook_config["MaxOutputSize"], kDefaultPrologOutputSize);
 

--- a/src/Craned/Core/JobManager.cpp
+++ b/src/Craned/Core/JobManager.cpp
@@ -1015,7 +1015,7 @@ bool JobManager::RunPrologWhenAllocSteps_(job_id_t job_id, step_id_t step_id,
       };
     }
 
-    if (g_config.JobLifecycleHook.PrologEpilogTimeout > 60)
+    if (g_config.JobLifecycleHook.PrologEpilogTimeout > 0)
       args.timeout_sec = g_config.JobLifecycleHook.PrologEpilogTimeout;
 
     auto result = util::os::RunPrologOrEpiLog(args);
@@ -1446,7 +1446,7 @@ void JobManager::CleanUpJobAndStepsAsync(std::vector<JobInD>&& jobs,
             .run_uid = 0,
             .run_gid = 0,
             .output_size = g_config.JobLifecycleHook.MaxOutputSize};
-        if (g_config.JobLifecycleHook.PrologEpilogTimeout > 60)
+        if (g_config.JobLifecycleHook.PrologEpilogTimeout > 0)
           run_epilog_args.timeout_sec =
               g_config.JobLifecycleHook.PrologEpilogTimeout;
 

--- a/src/Craned/Core/JobManager.cpp
+++ b/src/Craned/Core/JobManager.cpp
@@ -1004,6 +1004,7 @@ bool JobManager::RunPrologWhenAllocSteps_(job_id_t job_id, step_id_t step_id,
     RunPrologEpilogArgs args{
         .scripts = g_config.JobLifecycleHook.Prologs,
         .envs = job_env,
+        .timeout_sec = g_config.JobLifecycleHook.PrologTimeout,
         .run_uid = 0,
         .run_gid = 0,
         .output_size = g_config.JobLifecycleHook.MaxOutputSize};
@@ -1014,10 +1015,9 @@ bool JobManager::RunPrologWhenAllocSteps_(job_id_t job_id, step_id_t step_id,
       };
     }
 
-    if (g_config.JobLifecycleHook.PrologTimeout > 0)
-      args.timeout_sec = g_config.JobLifecycleHook.PrologTimeout;
-    else if (g_config.JobLifecycleHook.PrologEpilogTimeout > 0)
+    if (g_config.JobLifecycleHook.PrologEpilogTimeout > 60)
       args.timeout_sec = g_config.JobLifecycleHook.PrologEpilogTimeout;
+
     auto result = util::os::RunPrologOrEpiLog(args);
     if (script_lock) m_prolog_serial_mutex_.Unlock();
     if (!result) {
@@ -1442,12 +1442,11 @@ void JobManager::CleanUpJobAndStepsAsync(std::vector<JobInD>&& jobs,
         RunPrologEpilogArgs run_epilog_args{
             .scripts = g_config.JobLifecycleHook.Epilogs,
             .envs = env_map,
+            .timeout_sec = g_config.JobLifecycleHook.EpilogTimeout,
             .run_uid = 0,
             .run_gid = 0,
             .output_size = g_config.JobLifecycleHook.MaxOutputSize};
-        if (g_config.JobLifecycleHook.EpilogTimeout > 0)
-          run_epilog_args.timeout_sec = g_config.JobLifecycleHook.EpilogTimeout;
-        else if (g_config.JobLifecycleHook.PrologEpilogTimeout > 0)
+        if (g_config.JobLifecycleHook.PrologEpilogTimeout > 60)
           run_epilog_args.timeout_sec =
               g_config.JobLifecycleHook.PrologEpilogTimeout;
 

--- a/src/Craned/Supervisor/Supervisor.cpp
+++ b/src/Craned/Supervisor/Supervisor.cpp
@@ -402,7 +402,7 @@ void StartServer(int grpc_output_fd) {
           .run_uid = 0,
           .run_gid = 0,
           .output_size = g_config.JobLifecycleHook.MaxOutputSize};
-      if (g_config.JobLifecycleHook.PrologEpilogTimeout > 60)
+      if (g_config.JobLifecycleHook.PrologEpilogTimeout > 0)
         run_prolog_args.timeout_sec =
             g_config.JobLifecycleHook.PrologEpilogTimeout;
 

--- a/src/Craned/Supervisor/Supervisor.cpp
+++ b/src/Craned/Supervisor/Supervisor.cpp
@@ -398,12 +398,11 @@ void StartServer(int grpc_output_fd) {
       RunPrologEpilogArgs run_prolog_args{
           .scripts = g_config.JobLifecycleHook.Prologs,
           .envs = g_config.JobEnv,
+          .timeout_sec = g_config.JobLifecycleHook.PrologTimeout,
           .run_uid = 0,
           .run_gid = 0,
           .output_size = g_config.JobLifecycleHook.MaxOutputSize};
-      if (g_config.JobLifecycleHook.PrologTimeout > 0)
-        run_prolog_args.timeout_sec = g_config.JobLifecycleHook.PrologTimeout;
-      else if (g_config.JobLifecycleHook.PrologEpilogTimeout > 0)
+      if (g_config.JobLifecycleHook.PrologEpilogTimeout > 60)
         run_prolog_args.timeout_sec =
             g_config.JobLifecycleHook.PrologEpilogTimeout;
 

--- a/src/Craned/Supervisor/TaskManager.cpp
+++ b/src/Craned/Supervisor/TaskManager.cpp
@@ -1780,7 +1780,7 @@ CraneErrCode ProcInstance::Spawn() {
           .run_uid = m_parent_step_inst_->uid,
           .run_gid = m_parent_step_inst_->gids[0],
           .output_size = g_config.JobLifecycleHook.MaxOutputSize};
-      
+
       if (g_config.JobLifecycleHook.PrologEpilogTimeout > 0)
         run_prolog_args.timeout_sec =
             g_config.JobLifecycleHook.PrologEpilogTimeout;

--- a/src/Craned/Supervisor/TaskManager.cpp
+++ b/src/Craned/Supervisor/TaskManager.cpp
@@ -1781,7 +1781,7 @@ CraneErrCode ProcInstance::Spawn() {
           .run_gid = m_parent_step_inst_->gids[0],
           .output_size = g_config.JobLifecycleHook.MaxOutputSize};
       
-      if (g_config.JobLifecycleHook.PrologEpilogTimeout > 60)
+      if (g_config.JobLifecycleHook.PrologEpilogTimeout > 0)
         run_prolog_args.timeout_sec =
             g_config.JobLifecycleHook.PrologEpilogTimeout;
       auto result = util::os::RunPrologOrEpiLog(run_prolog_args);
@@ -2020,7 +2020,7 @@ TaskManager::~TaskManager() {
         .run_uid = 0,
         .run_gid = 0,
         .output_size = g_config.JobLifecycleHook.MaxOutputSize};
-    if (g_config.JobLifecycleHook.PrologEpilogTimeout > 60)
+    if (g_config.JobLifecycleHook.PrologEpilogTimeout > 0)
       run_epilog_args.timeout_sec =
           g_config.JobLifecycleHook.PrologEpilogTimeout;
 
@@ -2364,7 +2364,7 @@ void TaskManager::EvCleanTaskStopQueueCb_() {
           .run_uid = task->GetParentStep().uid(),
           .run_gid = task->GetParentStep().gid()[0],
           .output_size = g_config.JobLifecycleHook.MaxOutputSize};
-      if (g_config.JobLifecycleHook.PrologEpilogTimeout > 60)
+      if (g_config.JobLifecycleHook.PrologEpilogTimeout > 0)
         run_epilog_args.timeout_sec =
             g_config.JobLifecycleHook.PrologEpilogTimeout;
       auto result = util::os::RunPrologOrEpiLog(run_epilog_args);
@@ -2387,7 +2387,7 @@ void TaskManager::EvCleanTaskStopQueueCb_() {
           .run_uid = task->GetParentStep().uid(),
           .run_gid = task->GetParentStep().gid()[0],
           .output_size = g_config.JobLifecycleHook.MaxOutputSize};
-      if (g_config.JobLifecycleHook.PrologEpilogTimeout > 60)
+      if (g_config.JobLifecycleHook.PrologEpilogTimeout > 0)
         run_epilog_args.timeout_sec =
             g_config.JobLifecycleHook.PrologEpilogTimeout;
       auto result = util::os::RunPrologOrEpiLog(run_epilog_args);

--- a/src/Craned/Supervisor/TaskManager.cpp
+++ b/src/Craned/Supervisor/TaskManager.cpp
@@ -1776,12 +1776,12 @@ CraneErrCode ProcInstance::Spawn() {
       RunPrologEpilogArgs run_prolog_args{
           .scripts = g_config.JobLifecycleHook.TaskPrologs,
           .envs = m_env_,
+          .timeout_sec = g_config.JobLifecycleHook.PrologTimeout,
           .run_uid = m_parent_step_inst_->uid,
           .run_gid = m_parent_step_inst_->gids[0],
           .output_size = g_config.JobLifecycleHook.MaxOutputSize};
-      if (g_config.JobLifecycleHook.PrologTimeout > 0)
-        run_prolog_args.timeout_sec = g_config.JobLifecycleHook.PrologTimeout;
-      else if (g_config.JobLifecycleHook.PrologEpilogTimeout > 0)
+      
+      if (g_config.JobLifecycleHook.PrologEpilogTimeout > 60)
         run_prolog_args.timeout_sec =
             g_config.JobLifecycleHook.PrologEpilogTimeout;
       auto result = util::os::RunPrologOrEpiLog(run_prolog_args);
@@ -2016,12 +2016,11 @@ TaskManager::~TaskManager() {
     RunPrologEpilogArgs run_epilog_args{
         .scripts = g_config.JobLifecycleHook.Epilogs,
         .envs = g_config.JobEnv,
+        .timeout_sec = g_config.JobLifecycleHook.EpilogTimeout,
         .run_uid = 0,
         .run_gid = 0,
         .output_size = g_config.JobLifecycleHook.MaxOutputSize};
-    if (g_config.JobLifecycleHook.EpilogTimeout > 0)
-      run_epilog_args.timeout_sec = g_config.JobLifecycleHook.EpilogTimeout;
-    else if (g_config.JobLifecycleHook.PrologEpilogTimeout > 0)
+    if (g_config.JobLifecycleHook.PrologEpilogTimeout > 60)
       run_epilog_args.timeout_sec =
           g_config.JobLifecycleHook.PrologEpilogTimeout;
 
@@ -2361,12 +2360,11 @@ void TaskManager::EvCleanTaskStopQueueCb_() {
           .scripts = std::vector<std::string>{m_step_.GetStep().task_epilog()},
           .envs = std::unordered_map{task->GetParentStep().env().begin(),
                                      task->GetParentStep().env().end()},
+          .timeout_sec = g_config.JobLifecycleHook.EpilogTimeout,
           .run_uid = task->GetParentStep().uid(),
           .run_gid = task->GetParentStep().gid()[0],
           .output_size = g_config.JobLifecycleHook.MaxOutputSize};
-      if (g_config.JobLifecycleHook.EpilogTimeout > 0)
-        run_epilog_args.timeout_sec = g_config.JobLifecycleHook.EpilogTimeout;
-      else if (g_config.JobLifecycleHook.PrologEpilogTimeout > 0)
+      if (g_config.JobLifecycleHook.PrologEpilogTimeout > 60)
         run_epilog_args.timeout_sec =
             g_config.JobLifecycleHook.PrologEpilogTimeout;
       auto result = util::os::RunPrologOrEpiLog(run_epilog_args);
@@ -2385,12 +2383,11 @@ void TaskManager::EvCleanTaskStopQueueCb_() {
           .scripts = g_config.JobLifecycleHook.TaskEpilogs,
           .envs = std::unordered_map{task->GetParentStep().env().begin(),
                                      task->GetParentStep().env().end()},
+          .timeout_sec = g_config.JobLifecycleHook.EpilogTimeout,
           .run_uid = task->GetParentStep().uid(),
           .run_gid = task->GetParentStep().gid()[0],
           .output_size = g_config.JobLifecycleHook.MaxOutputSize};
-      if (g_config.JobLifecycleHook.EpilogTimeout > 0)
-        run_epilog_args.timeout_sec = g_config.JobLifecycleHook.EpilogTimeout;
-      else if (g_config.JobLifecycleHook.PrologEpilogTimeout > 0)
+      if (g_config.JobLifecycleHook.PrologEpilogTimeout > 60)
         run_epilog_args.timeout_sec =
             g_config.JobLifecycleHook.PrologEpilogTimeout;
       auto result = util::os::RunPrologOrEpiLog(run_epilog_args);

--- a/src/Utilities/PublicHeader/CMakeLists.txt
+++ b/src/Utilities/PublicHeader/CMakeLists.txt
@@ -17,6 +17,7 @@ target_link_libraries(Utility_PublicHeader PUBLIC
         fpm
         yaml-cpp
         bs_thread_pool
+        uvw
 )
 
 # This trimmed version is used for PAM module

--- a/src/Utilities/PublicHeader/OS.cpp
+++ b/src/Utilities/PublicHeader/OS.cpp
@@ -438,6 +438,7 @@ std::expected<std::string, RunPrologEpilogStatus> RunPrologOrEpiLog(
   auto timeout = std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::seconds(args.timeout_sec));
 
   for (const auto& script : args.scripts) {
+    // TODO: 判断是否是绝对路径
     bool send_terminate = true;
     
     auto elapsed = std::chrono::duration_cast<std::chrono::milliseconds>(

--- a/src/Utilities/PublicHeader/OS.cpp
+++ b/src/Utilities/PublicHeader/OS.cpp
@@ -628,8 +628,7 @@ std::expected<std::string, RunPrologEpilogStatus> RunPrologOrEpiLog(
               pipe_handle->close();
               h.parent().walk([](auto&& h) { h.close(); });
               h.parent().stop();
-              CRANE_ERROR("waitpid failed for script {}: {}", script,
-                          strerror(errno));
+              CRANE_ERROR("waitpid failed for script {}, pid:{} : {}", script, pid, strerror(errno));
               result = std::unexpected(
                   RunPrologEpilogStatus{.exit_code = 1, .signal_num = 0});
               return;

--- a/src/Utilities/PublicHeader/OS.cpp
+++ b/src/Utilities/PublicHeader/OS.cpp
@@ -32,6 +32,8 @@
 #include <string>
 #include <vector>
 
+#include <uvw.hpp>
+
 #include "absl/strings/str_split.h"
 #include "crane/Logger.h"
 #include "re2/re2.h"
@@ -427,7 +429,7 @@ bool IsAbsolutePath(const std::string& path) {
   return std::filesystem::path(path).is_absolute();
 }
 
-void kill_pg(pid_t pid) {
+void KillPg(pid_t pid) {
   killpg(pid, SIGTERM);
   usleep(10000);
   killpg(pid, SIGKILL);
@@ -435,217 +437,204 @@ void kill_pg(pid_t pid) {
 
 std::expected<std::string, RunPrologEpilogStatus> RunPrologOrEpiLog(
     const RunPrologEpilogArgs& args) {
+  using namespace std::chrono;
+
+  auto start_time = steady_clock::now();
+  auto timeout = duration_cast<milliseconds>(seconds(args.timeout_sec));
+
   std::string output;
+  std::expected<std::string, RunPrologEpilogStatus> result = 
+    std::unexpected(RunPrologEpilogStatus{.exit_code=1, .signal_num=0});
 
-  auto start_time = std::chrono::steady_clock::now();
-  auto timeout = std::chrono::duration_cast<std::chrono::milliseconds>(
-      std::chrono::seconds(args.timeout_sec));
+  size_t script_idx = 0;
 
-  for (const auto& script : args.scripts) {
-    if (!IsAbsolutePath(script)) {
-      CRANE_ERROR("Script path {} is not absolute.", script);
-      return std::unexpected(
-          RunPrologEpilogStatus{.exit_code = 1, .signal_num = 0});
+  std::function<void()> run_next_script;
+
+  run_next_script = [&](){
+    if (script_idx >= args.scripts.size()) {
+      result = output;
+      return;
     }
 
-    bool send_terminate = true;
+    const auto& script = args.scripts[script_idx];
 
-    auto elapsed = std::chrono::duration_cast<std::chrono::milliseconds>(
-        std::chrono::steady_clock::now() - start_time);
-    if (elapsed >= timeout) {
-      CRANE_ERROR("Total timeout ({}s) reached before running {}.",
-                  args.timeout_sec, script);
-      return std::unexpected(
-          RunPrologEpilogStatus{.exit_code = 1, .signal_num = 0});
+    if (!IsAbsolutePath(script)) {
+      CRANE_ERROR("Script path {} is not absolute.", script);
+      result = std::unexpected(RunPrologEpilogStatus{.exit_code=1, .signal_num=0});
+      return;
     }
 
     int stdout_pipe[2];
-    if (pipe(stdout_pipe) == -1) {
-      CRANE_ERROR("{} pipe stdout creation failed: {}", script,
-                  strerror(errno));
-      return std::unexpected(
-          RunPrologEpilogStatus{.exit_code = 1, .signal_num = 0});
+    if (pipe(stdout_pipe) != 0) {
+      CRANE_ERROR("Failed to create pipe for script {}: {}", script, strerror(errno));
+      result = std::unexpected(RunPrologEpilogStatus{.exit_code=1, .signal_num=0});
+      return;
     }
 
     pid_t pid = fork();
-
     if (pid == -1) {
-      CRANE_ERROR("{} pid fork failed: {}.", script, strerror(errno));
+      CRANE_ERROR("Failed to fork for script {}: {}", script, strerror(errno));
+      result = std::unexpected(RunPrologEpilogStatus{.exit_code=1, .signal_num=0});
       close(stdout_pipe[0]);
       close(stdout_pipe[1]);
-      return std::unexpected(
-          RunPrologEpilogStatus{.exit_code = 1, .signal_num = 0});
+      return;
     }
 
-    if (pid > 0) {  // parent proc
-      close(stdout_pipe[1]);
-      if (!SetFdNonBlocking(stdout_pipe[0])) {
-        CRANE_ERROR("Failed to set non-blocking mode for stdout pipe.");
-        close(stdout_pipe[0]);
-        return std::unexpected(
-            RunPrologEpilogStatus{.exit_code = 1, .signal_num = 0});
-      }
-
-      int status = 0;
-      while (true) {
-        auto elapsed = std::chrono::duration_cast<std::chrono::milliseconds>(
-            std::chrono::steady_clock::now() - start_time);
-        if (elapsed >= timeout) {
-          CRANE_TRACE("{} Timeout.", script);
-          break;
-        }
-
-        uint64_t remaining_time = timeout.count() - elapsed.count();
-
-        struct pollfd fds;
-        fds.fd = stdout_pipe[0];
-        fds.events = POLLIN | POLLHUP | POLLRDHUP;
-        fds.revents = 0;
-        int max_poll_time_ms = 100;
-        int timeout_ms = static_cast<int>(
-            std::min<uint64_t>(remaining_time, max_poll_time_ms));
-
-        int pret = poll(
-            &fds, 1, timeout_ms);  // Poll with timeout based on remaining time
-        if (pret == 0) {
-          continue;
-        } else if (pret < 0) {
-          if (errno == EAGAIN || errno == EINTR) continue;
-          CRANE_ERROR("{} poll() failed: {}", script, strerror(errno));
-          break;
-        }
-        if ((fds.revents & POLLIN) == 0) {
-          send_terminate = false;
-          break;
-        }
-        char buf[512];
-        auto bytes_read = read(stdout_pipe[0], buf, sizeof(buf));
-        if (bytes_read == 0) {
-          send_terminate = false;
-          break;
-        } else if (bytes_read < 0) {
-          if (errno == EAGAIN || errno == EWOULDBLOCK) continue;
-          send_terminate = false;
-          CRANE_ERROR("{} read() failed: {}", script, strerror(errno));
-          break;
-        } else {
-          size_t remain = args.output_size > output.size()
-                              ? args.output_size - output.size()
-                              : 0;
-          if (remain > 0)
-            output.append(buf, std::min<size_t>(bytes_read, remain));
-        }
-      }
-
+    if (pid == 0) { // child
       close(stdout_pipe[0]);
-
-      if (send_terminate) {
-        CRANE_TRACE("{} Sending termination signal to process group {}.",
-                    script, pid);
-        kill_pg(pid);
-        waitpid(pid, &status, 0);
-      } else {
-        /*
-         * If the STDOUT is closed from the script we may reach
-         * this point without any input in read_fd, so just wait
-         * for the process here until max_wait.
-         */
-        int options = WNOHANG;
-        int rc;
-        int delay = 10;
-        int max_delay = 1000;
-        bool killed_pg = false;
-        while ((rc = waitpid(pid, &status, options)) <= 0) {
-          if (rc < 0) {
-            if (errno == EINTR) continue;
-            CRANE_ERROR("{} waitpid() failed: {}", script, strerror(errno));
-            break;
-          }
-
-          auto elapsed = std::chrono::duration_cast<std::chrono::milliseconds>(
-              std::chrono::steady_clock::now() - start_time);
-          if (elapsed >= timeout) {
-            CRANE_TRACE("{} Timeout while waiting for process to exit.",
-                        script);
-            kill_pg(pid);
-            options = 0;
-            killed_pg = true;
-            break;
-          }
-
-          uint64_t remaining_time = timeout.count() - elapsed.count();
-          poll(NULL, 0, delay);
-          delay = std::min<int>(
-              max_delay,
-              std::max<int>(1, std::min<int>(delay * 2, remaining_time)));
-        }
-        if (!killed_pg) kill_pg(pid);
-      }
-
-      int exit_code = 0;
-      int signal_num = 0;
-
-      if (WIFEXITED(status)) {
-        exit_code = WEXITSTATUS(status);
-        signal_num = 0;
-      } else if (WIFSIGNALED(status)) {
-        exit_code = 0;
-        signal_num = WTERMSIG(status);
-      } else {
-        exit_code = status;
-        signal_num = 0;
-      }
-
-      if (exit_code != 0 || signal_num != 0) {
-        CRANE_TRACE("{} Failed (exit status {}:{}), output: {}.", script,
-                    exit_code, signal_num, output);
-        return std::unexpected(RunPrologEpilogStatus{.exit_code = exit_code,
-                                                     .signal_num = signal_num});
-      }
-
-    } else {  // child proc
-      close(stdout_pipe[0]);
-      if (dup2(stdout_pipe[1], STDOUT_FILENO) == -1) _exit(EXIT_FAILURE);
-      if (dup2(stdout_pipe[1], STDERR_FILENO) == -1) _exit(EXIT_FAILURE);
+      dup2(stdout_pipe[1], STDOUT_FILENO);
+      dup2(stdout_pipe[1], STDERR_FILENO);
       close(stdout_pipe[1]);
 
-      CloseFdFrom(3);
-      setpgid(0, 0);
-
+      CloseFdFrom(3); // close all other fds
+      setpgid(0, 0); // set process group id to its own pid
+      
       if (args.at_child_setup_cb) {
-        bool result = args.at_child_setup_cb(getpid());
-        if (!result) {
-          fmt::print(stderr,
-                     "[Subprocess] Error: subprocess callback failed\n");
+        bool setup_ok = args.at_child_setup_cb(getpid());
+        if (!setup_ok) {
+          fmt::print(stderr, "[Subprocess] Error: subprocess callback failed\n");
           _exit(EXIT_FAILURE);
         }
       }
 
       if (setgid(args.run_gid) != 0) {
-        fmt::print(stderr, "[Subprocess] Error: setgid({}) failed: {}\n",
-                   args.run_gid, strerror(errno));
+        fmt::print(stderr, "[Subprocess] Error: setgid({}) failed: {} ({})\n", args.run_gid, strerror(errno), errno);
         _exit(EXIT_FAILURE);
       }
+
       if (setuid(args.run_uid) != 0) {
-        fmt::print(stderr, "[Subprocess] Error: setuid({}) failed: {}\n",
-                   args.run_uid, strerror(errno));
+        fmt::print(stderr, "[Subprocess] Error: setuid({}) failed: {} ({})\n", args.run_uid, strerror(errno), errno);
         _exit(EXIT_FAILURE);
       }
-      for (const auto& [name, value] : args.envs)
-        if (setenv(name.c_str(), value.c_str(), 1)) {
-          fmt::print(stderr, "[Subprocess] Error: setenv() for {}={} failed.\n",
-                     name, value);
+
+      for (const auto& [name, value] : args.envs) {
+        if (setenv(name.c_str(), value.c_str(), 1) != 0) {
+          fmt::print(stderr, "[Subprocess] Error: setenv({}, {}) failed: {} ({})\n", name, value, strerror(errno), errno);
           _exit(EXIT_FAILURE);
         }
+       }
 
       std::vector<const char*> argv = {script.c_str(), nullptr};
       execvp(argv[0], const_cast<char* const*>(argv.data()));
       fmt::print(stderr, "[Subprocess] execvp() failed: {}\n", strerror(errno));
       _exit(EXIT_FAILURE);
-    }
-  }
 
-  return output;
+    } else { // parent
+      close(stdout_pipe[1]);
+      if (!SetFdNonBlocking(stdout_pipe[0])) {
+        CRANE_ERROR("Failed to set non-blocking mode for stdout pipe.");
+        close(stdout_pipe[0]);
+        result = std::unexpected(RunPrologEpilogStatus{.exit_code=1, .signal_num=0});
+        return;
+      }
+
+      auto loop = uvw::loop::create();
+      auto pipe_handle = loop->uninitialized_resource<uvw::pipe_handle>(false);
+      auto timer_handle = loop->resource<uvw::timer_handle>();
+      auto idle_handle = loop->resource<uvw::idle_handle>();
+
+      std::string script_output;
+      int err = 0;
+      err = pipe_handle->init();
+      if (err) {
+        CRANE_ERROR("Failed to initialize pipe_handle for script {}: {}", script, uv_strerror(err));
+        result = std::unexpected(RunPrologEpilogStatus{.exit_code=1, .signal_num=0});
+        close(stdout_pipe[0]);
+        return;
+      }
+
+      err = pipe_handle->open(stdout_pipe[0]);
+      if (err) {
+        CRANE_ERROR("Failed to open pipe_handle for script {}: {}", script, uv_strerror(err));
+        result = std::unexpected(RunPrologEpilogStatus{.exit_code=1, .signal_num=0});
+        close(stdout_pipe[0]);
+        return;
+      }
+
+      pipe_handle->on<uvw::data_event>([&](const uvw::data_event& event, uvw::pipe_handle&) {
+        if (event.length > 0) {
+          size_t remain = args.output_size > script_output.size() ? args.output_size - script_output.size() : 0;
+          if (remain > 0)
+            script_output.append(event.data.get(), std::min<size_t>(event.length, remain));
+        }
+      });
+
+      pipe_handle->on<uvw::end_event>([&](const uvw::end_event&, uvw::pipe_handle& h) {
+        h.close();
+      });
+
+      pipe_handle->on<uvw::error_event>([&](
+                                   uvw::error_event& e, uvw::pipe_handle& h) {
+        CRANE_WARN("{} output pipe error: {}. Closing.", script, e.what());
+        h.close();
+      });
+
+      pipe_handle->read();
+
+      timer_handle->on<uvw::timer_event>([&](const uvw::timer_event&, uvw::timer_handle&) {
+        CRANE_TRACE("{} Timeout.", script);
+        KillPg(pid);
+      });
+
+      int status = 0;
+      idle_handle->on<uvw::idle_event>([&](const uvw::idle_event&, uvw::idle_handle& h) {
+        int rc = waitpid(pid, &status, WNOHANG);
+        if (rc == pid) {
+          timer_handle->close();
+          pipe_handle->close();
+          h.parent().walk([](auto&& h) { h.close(); });
+          h.parent().stop(); 
+
+          int exit_code = 0, signal_num = 0;
+          if (WIFEXITED(status)) {
+            exit_code = WEXITSTATUS(status);
+            signal_num = 0;
+          } else if (WIFSIGNALED(status)) {
+            exit_code = 0;
+            signal_num = WTERMSIG(status);
+          } else {
+            exit_code = status;
+            signal_num = 0;
+          }
+          if (exit_code != 0 || signal_num != 0) {
+            CRANE_TRACE("{} Failed (exit status {}:{}), output: {}.", script, exit_code, signal_num, script_output);
+            result = std::unexpected(RunPrologEpilogStatus{.exit_code=exit_code, .signal_num=signal_num});
+            return;
+          }
+          output += script_output;
+          script_idx++;
+          run_next_script();
+        } else if (rc == -1) {
+          timer_handle->close();
+          pipe_handle->close();
+          h.parent().walk([](auto&& h) { h.close(); });
+          h.parent().stop();
+          CRANE_ERROR("waitpid failed for script {}: {}", script, strerror(errno));
+          result = std::unexpected(RunPrologEpilogStatus{.exit_code=1, .signal_num=0});
+          return;
+        }
+      });
+
+      auto elapsed = std::chrono::duration_cast<std::chrono::milliseconds>(
+              std::chrono::steady_clock::now() - start_time);
+      if (elapsed >= timeout) {
+        idle_handle->stop();
+        pipe_handle->close();
+        CRANE_TRACE("{} Timeout.", script);
+        result = std::unexpected(RunPrologEpilogStatus{.exit_code=1, .signal_num=0});
+        return ;
+      }
+
+      timer_handle->start(timeout - elapsed, std::chrono::seconds(0));
+      idle_handle->start();
+
+      loop->run();
+    }
+  };
+
+  run_next_script();
+
+  return result;
 }
 
 void ApplyPrologOutputToEnvAndStdout(

--- a/src/Utilities/PublicHeader/OS.cpp
+++ b/src/Utilities/PublicHeader/OS.cpp
@@ -468,7 +468,6 @@ std::expected<std::string, RunPrologEpilogStatus> RunPrologOrEpiLog(
     }
 
     pid_t pid = fork();
-    setpgid(0, 0);
 
     if (pid == -1) {
       CRANE_ERROR("{} pid fork failed: {}.", script, strerror(errno));
@@ -607,6 +606,7 @@ std::expected<std::string, RunPrologEpilogStatus> RunPrologOrEpiLog(
       close(stdout_pipe[1]);
 
       CloseFdFrom(3);
+      setpgid(0, 0);
 
       if (args.at_child_setup_cb) {
         bool result = args.at_child_setup_cb(getpid());

--- a/src/Utilities/PublicHeader/OS.cpp
+++ b/src/Utilities/PublicHeader/OS.cpp
@@ -628,7 +628,8 @@ std::expected<std::string, RunPrologEpilogStatus> RunPrologOrEpiLog(
               pipe_handle->close();
               h.parent().walk([](auto&& h) { h.close(); });
               h.parent().stop();
-              CRANE_ERROR("waitpid failed for script {}, pid:{} : {}", script, pid, strerror(errno));
+              CRANE_ERROR("waitpid failed for script {}, pid:{} : {}", script,
+                          pid, strerror(errno));
               result = std::unexpected(
                   RunPrologEpilogStatus{.exit_code = 1, .signal_num = 0});
               return;

--- a/src/Utilities/PublicHeader/OS.cpp
+++ b/src/Utilities/PublicHeader/OS.cpp
@@ -479,8 +479,12 @@ std::expected<std::string, RunPrologEpilogStatus> RunPrologOrEpiLog(
 
     if (pid > 0) {  // parent proc
       close(stdout_pipe[1]);
-      int flags = fcntl(stdout_pipe[0], F_GETFL, 0);
-      fcntl(stdout_pipe[0], F_SETFL, flags | O_NONBLOCK);
+      if (!SetFdNonBlocking(stdout_pipe[0])) {
+        CRANE_ERROR("Failed to set non-blocking mode for stdout pipe.");
+        close(stdout_pipe[0]);
+        return std::unexpected(
+            RunPrologEpilogStatus{.exit_code = 1, .signal_num = 0});
+      }
 
       int status = 0;
       while (true) {

--- a/src/Utilities/PublicHeader/OS.cpp
+++ b/src/Utilities/PublicHeader/OS.cpp
@@ -30,9 +30,8 @@
 #include <cstring>
 #include <future>
 #include <string>
-#include <vector>
-
 #include <uvw.hpp>
+#include <vector>
 
 #include "absl/strings/str_split.h"
 #include "crane/Logger.h"
@@ -443,14 +442,14 @@ std::expected<std::string, RunPrologEpilogStatus> RunPrologOrEpiLog(
   auto timeout = duration_cast<milliseconds>(seconds(args.timeout_sec));
 
   std::string output;
-  std::expected<std::string, RunPrologEpilogStatus> result = 
-    std::unexpected(RunPrologEpilogStatus{.exit_code=1, .signal_num=0});
+  std::expected<std::string, RunPrologEpilogStatus> result =
+      std::unexpected(RunPrologEpilogStatus{.exit_code = 1, .signal_num = 0});
 
   size_t script_idx = 0;
 
   std::function<void()> run_next_script;
 
-  run_next_script = [&](){
+  run_next_script = [&]() {
     if (script_idx >= args.scripts.size()) {
       result = output;
       return;
@@ -460,71 +459,80 @@ std::expected<std::string, RunPrologEpilogStatus> RunPrologOrEpiLog(
 
     if (!IsAbsolutePath(script)) {
       CRANE_ERROR("Script path {} is not absolute.", script);
-      result = std::unexpected(RunPrologEpilogStatus{.exit_code=1, .signal_num=0});
+      result = std::unexpected(
+          RunPrologEpilogStatus{.exit_code = 1, .signal_num = 0});
       return;
     }
 
     int stdout_pipe[2];
     if (pipe(stdout_pipe) != 0) {
-      CRANE_ERROR("Failed to create pipe for script {}: {}", script, strerror(errno));
-      result = std::unexpected(RunPrologEpilogStatus{.exit_code=1, .signal_num=0});
+      CRANE_ERROR("Failed to create pipe for script {}: {}", script,
+                  strerror(errno));
+      result = std::unexpected(
+          RunPrologEpilogStatus{.exit_code = 1, .signal_num = 0});
       return;
     }
 
     pid_t pid = fork();
     if (pid == -1) {
       CRANE_ERROR("Failed to fork for script {}: {}", script, strerror(errno));
-      result = std::unexpected(RunPrologEpilogStatus{.exit_code=1, .signal_num=0});
+      result = std::unexpected(
+          RunPrologEpilogStatus{.exit_code = 1, .signal_num = 0});
       close(stdout_pipe[0]);
       close(stdout_pipe[1]);
       return;
     }
 
-    if (pid == 0) { // child
+    if (pid == 0) {  // child
       close(stdout_pipe[0]);
       if (dup2(stdout_pipe[1], STDOUT_FILENO) == -1 ||
           dup2(stdout_pipe[1], STDERR_FILENO) == -1) {
-       close(stdout_pipe[1]);
-       fmt::print(stderr, "[Subprocess] Error: dup2 failed: {} ({})\n",
-                  strerror(errno), errno);
-       _exit(EXIT_FAILURE);     
+        close(stdout_pipe[1]);
+        fmt::print(stderr, "[Subprocess] Error: dup2 failed: {} ({})\n",
+                   strerror(errno), errno);
+        _exit(EXIT_FAILURE);
       }
       close(stdout_pipe[1]);
 
-      CloseFdFrom(3); // close all other fds
-      setpgid(0, 0); // set process group id to its own pid
-      
+      CloseFdFrom(3);  // close all other fds
+      setpgid(0, 0);   // set process group id to its own pid
+
       if (args.at_child_setup_cb) {
         bool setup_ok = args.at_child_setup_cb(getpid());
         if (!setup_ok) {
-          fmt::print(stderr, "[Subprocess] Error: subprocess callback failed\n");
+          fmt::print(stderr,
+                     "[Subprocess] Error: subprocess callback failed\n");
           _exit(EXIT_FAILURE);
         }
       }
 
       if (setgid(args.run_gid) != 0) {
-        fmt::print(stderr, "[Subprocess] Error: setgid({}) failed: {} ({})\n", args.run_gid, strerror(errno), errno);
+        fmt::print(stderr, "[Subprocess] Error: setgid({}) failed: {} ({})\n",
+                   args.run_gid, strerror(errno), errno);
         _exit(EXIT_FAILURE);
       }
 
       if (setuid(args.run_uid) != 0) {
-        fmt::print(stderr, "[Subprocess] Error: setuid({}) failed: {} ({})\n", args.run_uid, strerror(errno), errno);
+        fmt::print(stderr, "[Subprocess] Error: setuid({}) failed: {} ({})\n",
+                   args.run_uid, strerror(errno), errno);
         _exit(EXIT_FAILURE);
       }
 
       for (const auto& [name, value] : args.envs) {
         if (setenv(name.c_str(), value.c_str(), 1) != 0) {
-          fmt::print(stderr, "[Subprocess] Error: setenv({}, {}) failed: {} ({})\n", name, value, strerror(errno), errno);
+          fmt::print(stderr,
+                     "[Subprocess] Error: setenv({}, {}) failed: {} ({})\n",
+                     name, value, strerror(errno), errno);
           _exit(EXIT_FAILURE);
         }
-       }
+      }
 
       std::vector<const char*> argv = {script.c_str(), nullptr};
       execvp(argv[0], const_cast<char* const*>(argv.data()));
       fmt::print(stderr, "[Subprocess] execvp() failed: {}\n", strerror(errno));
       _exit(EXIT_FAILURE);
 
-    } else { // parent
+    } else {  // parent
       close(stdout_pipe[1]);
 
       auto loop = uvw::loop::create();
@@ -536,92 +544,107 @@ std::expected<std::string, RunPrologEpilogStatus> RunPrologOrEpiLog(
       int err = 0;
       err = pipe_handle->init();
       if (err) {
-        CRANE_ERROR("Failed to initialize pipe_handle for script {}: {}", script, uv_strerror(err));
-        result = std::unexpected(RunPrologEpilogStatus{.exit_code=1, .signal_num=0});
+        CRANE_ERROR("Failed to initialize pipe_handle for script {}: {}",
+                    script, uv_strerror(err));
+        result = std::unexpected(
+            RunPrologEpilogStatus{.exit_code = 1, .signal_num = 0});
         close(stdout_pipe[0]);
         return;
       }
 
       err = pipe_handle->open(stdout_pipe[0]);
       if (err) {
-        CRANE_ERROR("Failed to open pipe_handle for script {}: {}", script, uv_strerror(err));
-        result = std::unexpected(RunPrologEpilogStatus{.exit_code=1, .signal_num=0});
+        CRANE_ERROR("Failed to open pipe_handle for script {}: {}", script,
+                    uv_strerror(err));
+        result = std::unexpected(
+            RunPrologEpilogStatus{.exit_code = 1, .signal_num = 0});
         close(stdout_pipe[0]);
         return;
       }
 
-      pipe_handle->on<uvw::data_event>([&](const uvw::data_event& event, uvw::pipe_handle&) {
-        if (event.length > 0) {
-          size_t remain = args.output_size > script_output.size() ? args.output_size - script_output.size() : 0;
-          if (remain > 0)
-            script_output.append(event.data.get(), std::min<size_t>(event.length, remain));
-        }
-      });
+      pipe_handle->on<uvw::data_event>(
+          [&](const uvw::data_event& event, uvw::pipe_handle&) {
+            if (event.length > 0) {
+              size_t remain = args.output_size > script_output.size()
+                                  ? args.output_size - script_output.size()
+                                  : 0;
+              if (remain > 0)
+                script_output.append(event.data.get(),
+                                     std::min<size_t>(event.length, remain));
+            }
+          });
 
-      pipe_handle->on<uvw::end_event>([&](const uvw::end_event&, uvw::pipe_handle& h) {
-        h.close();
-      });
+      pipe_handle->on<uvw::end_event>(
+          [&](const uvw::end_event&, uvw::pipe_handle& h) { h.close(); });
 
-      pipe_handle->on<uvw::error_event>([&](
-                                   uvw::error_event& e, uvw::pipe_handle& h) {
-        CRANE_WARN("{} output pipe error: {}. Closing.", script, e.what());
-        h.close();
-      });
+      pipe_handle->on<uvw::error_event>(
+          [&](uvw::error_event& e, uvw::pipe_handle& h) {
+            CRANE_WARN("{} output pipe error: {}. Closing.", script, e.what());
+            h.close();
+          });
 
       pipe_handle->read();
 
-      timer_handle->on<uvw::timer_event>([&](const uvw::timer_event&, uvw::timer_handle&) {
-        CRANE_TRACE("{} Timeout.", script);
-        KillPg(pid);
-      });
+      timer_handle->on<uvw::timer_event>(
+          [&](const uvw::timer_event&, uvw::timer_handle&) {
+            CRANE_TRACE("{} Timeout.", script);
+            KillPg(pid);
+          });
 
       int status = 0;
-      idle_handle->on<uvw::idle_event>([&](const uvw::idle_event&, uvw::idle_handle& h) {
-        int rc = waitpid(pid, &status, WNOHANG);
-        if (rc == pid) {
-          timer_handle->close();
-          pipe_handle->close();
-          h.parent().walk([](auto&& h) { h.close(); });
-          h.parent().stop(); 
+      idle_handle->on<uvw::idle_event>(
+          [&](const uvw::idle_event&, uvw::idle_handle& h) {
+            int rc = waitpid(pid, &status, WNOHANG);
+            if (rc == pid) {
+              timer_handle->close();
+              pipe_handle->close();
+              h.parent().walk([](auto&& h) { h.close(); });
+              h.parent().stop();
 
-          int exit_code = 0, signal_num = 0;
-          if (WIFEXITED(status)) {
-            exit_code = WEXITSTATUS(status);
-            signal_num = 0;
-          } else if (WIFSIGNALED(status)) {
-            exit_code = 0;
-            signal_num = WTERMSIG(status);
-          } else {
-            exit_code = status;
-            signal_num = 0;
-          }
-          if (exit_code != 0 || signal_num != 0) {
-            CRANE_TRACE("{} Failed (exit status {}:{}), output: {}.", script, exit_code, signal_num, script_output);
-            result = std::unexpected(RunPrologEpilogStatus{.exit_code=exit_code, .signal_num=signal_num});
-            return;
-          }
-          output += script_output;
-          script_idx++;
-          run_next_script();
-        } else if (rc == -1) {
-          timer_handle->close();
-          pipe_handle->close();
-          h.parent().walk([](auto&& h) { h.close(); });
-          h.parent().stop();
-          CRANE_ERROR("waitpid failed for script {}: {}", script, strerror(errno));
-          result = std::unexpected(RunPrologEpilogStatus{.exit_code=1, .signal_num=0});
-          return;
-        }
-      });
+              int exit_code = 0, signal_num = 0;
+              if (WIFEXITED(status)) {
+                exit_code = WEXITSTATUS(status);
+                signal_num = 0;
+              } else if (WIFSIGNALED(status)) {
+                exit_code = 0;
+                signal_num = WTERMSIG(status);
+              } else {
+                exit_code = status;
+                signal_num = 0;
+              }
+              if (exit_code != 0 || signal_num != 0) {
+                CRANE_TRACE("{} Failed (exit status {}:{}), output: {}.",
+                            script, exit_code, signal_num, script_output);
+                result = std::unexpected(
+                    RunPrologEpilogStatus{.exit_code = exit_code,
+                                          .signal_num = signal_num});
+                return;
+              }
+              output += script_output;
+              script_idx++;
+              run_next_script();
+            } else if (rc == -1) {
+              timer_handle->close();
+              pipe_handle->close();
+              h.parent().walk([](auto&& h) { h.close(); });
+              h.parent().stop();
+              CRANE_ERROR("waitpid failed for script {}: {}", script,
+                          strerror(errno));
+              result = std::unexpected(
+                  RunPrologEpilogStatus{.exit_code = 1, .signal_num = 0});
+              return;
+            }
+          });
 
       auto elapsed = std::chrono::duration_cast<std::chrono::milliseconds>(
-              std::chrono::steady_clock::now() - start_time);
+          std::chrono::steady_clock::now() - start_time);
       if (elapsed >= timeout) {
         idle_handle->stop();
         pipe_handle->close();
         CRANE_TRACE("{} Timeout.", script);
-        result = std::unexpected(RunPrologEpilogStatus{.exit_code=1, .signal_num=0});
-        return ;
+        result = std::unexpected(
+            RunPrologEpilogStatus{.exit_code = 1, .signal_num = 0});
+        return;
       }
 
       timer_handle->start(timeout - elapsed, std::chrono::seconds(0));

--- a/src/Utilities/PublicHeader/OS.cpp
+++ b/src/Utilities/PublicHeader/OS.cpp
@@ -634,6 +634,7 @@ std::expected<std::string, RunPrologEpilogStatus> RunPrologOrEpiLog(
                   RunPrologEpilogStatus{.exit_code = 1, .signal_num = 0});
               return;
             }
+            std::this_thread::sleep_for(std::chrono::milliseconds(50));
           });
 
       auto elapsed = std::chrono::duration_cast<std::chrono::milliseconds>(

--- a/src/Utilities/PublicHeader/OS.cpp
+++ b/src/Utilities/PublicHeader/OS.cpp
@@ -20,6 +20,7 @@
 
 #include <absl/cleanup/cleanup.h>
 #include <grp.h>
+#include <poll.h>
 #include <pwd.h>
 #include <sys/types.h>
 #include <sys/wait.h>
@@ -30,7 +31,6 @@
 #include <future>
 #include <string>
 #include <vector>
-#include <poll.h>
 
 #include "absl/strings/str_split.h"
 #include "crane/Logger.h"
@@ -424,35 +424,34 @@ absl::Time GetSystemBootTime() {
 }
 
 bool IsAbsolutePath(const std::string& path) {
-    return std::filesystem::path(path).is_absolute();
+  return std::filesystem::path(path).is_absolute();
 }
 
 void kill_pg(pid_t pid) {
   killpg(pid, SIGTERM);
-	usleep(10000);
-	killpg(pid, SIGKILL);
+  usleep(10000);
+  killpg(pid, SIGKILL);
 }
 
 std::expected<std::string, RunPrologEpilogStatus> RunPrologOrEpiLog(
     const RunPrologEpilogArgs& args) {
-
   std::string output;
-  
+
   auto start_time = std::chrono::steady_clock::now();
-  auto timeout = std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::seconds(args.timeout_sec));
+  auto timeout = std::chrono::duration_cast<std::chrono::milliseconds>(
+      std::chrono::seconds(args.timeout_sec));
 
   for (const auto& script : args.scripts) {
-    
     if (!IsAbsolutePath(script)) {
       CRANE_ERROR("Script path {} is not absolute.", script);
       return std::unexpected(
           RunPrologEpilogStatus{.exit_code = 1, .signal_num = 0});
     }
-    
+
     bool send_terminate = true;
-    
+
     auto elapsed = std::chrono::duration_cast<std::chrono::milliseconds>(
-    std::chrono::steady_clock::now() - start_time);
+        std::chrono::steady_clock::now() - start_time);
     if (elapsed >= timeout) {
       CRANE_ERROR("Total timeout ({}s) reached before running {}.",
                   args.timeout_sec, script);
@@ -479,35 +478,36 @@ std::expected<std::string, RunPrologEpilogStatus> RunPrologOrEpiLog(
           RunPrologEpilogStatus{.exit_code = 1, .signal_num = 0});
     }
 
-    if (pid > 0) { // parent proc
+    if (pid > 0) {  // parent proc
       close(stdout_pipe[1]);
       int flags = fcntl(stdout_pipe[0], F_GETFL, 0);
       fcntl(stdout_pipe[0], F_SETFL, flags | O_NONBLOCK);
 
       int status = 0;
-      while(true) {
+      while (true) {
         auto elapsed = std::chrono::duration_cast<std::chrono::milliseconds>(
-    std::chrono::steady_clock::now() - start_time);
+            std::chrono::steady_clock::now() - start_time);
         if (elapsed >= timeout) {
           CRANE_TRACE("{} Timeout.", script);
           break;
         }
 
         uint64_t remaining_time = timeout.count() - elapsed.count();
-  
+
         struct pollfd fds;
         fds.fd = stdout_pipe[0];
         fds.events = POLLIN | POLLHUP | POLLRDHUP;
         fds.revents = 0;
         int max_poll_time_ms = 100;
-        int timeout_ms = static_cast<int>(std::min<uint64_t>(remaining_time, max_poll_time_ms));
+        int timeout_ms = static_cast<int>(
+            std::min<uint64_t>(remaining_time, max_poll_time_ms));
 
-        int pret = poll(&fds, 1, timeout_ms); // Poll with timeout based on remaining time
+        int pret = poll(
+            &fds, 1, timeout_ms);  // Poll with timeout based on remaining time
         if (pret == 0) {
           continue;
         } else if (pret < 0) {
-          if (errno == EAGAIN || errno == EINTR)
-            continue;
+          if (errno == EAGAIN || errno == EINTR) continue;
           CRANE_ERROR("{} poll() failed: {}", script, strerror(errno));
           break;
         }
@@ -521,8 +521,7 @@ std::expected<std::string, RunPrologEpilogStatus> RunPrologOrEpiLog(
           send_terminate = false;
           break;
         } else if (bytes_read < 0) {
-          if (errno == EAGAIN || errno == EWOULDBLOCK)
-            continue;
+          if (errno == EAGAIN || errno == EWOULDBLOCK) continue;
           send_terminate = false;
           CRANE_ERROR("{} read() failed: {}", script, strerror(errno));
           break;
@@ -538,32 +537,33 @@ std::expected<std::string, RunPrologEpilogStatus> RunPrologOrEpiLog(
       close(stdout_pipe[0]);
 
       if (send_terminate) {
-        CRANE_TRACE("{} Sending termination signal to process group {}.", script, pid);
+        CRANE_TRACE("{} Sending termination signal to process group {}.",
+                    script, pid);
         kill_pg(pid);
         waitpid(pid, &status, 0);
       } else {
         /*
-		     * If the STDOUT is closed from the script we may reach
-		     * this point without any input in read_fd, so just wait
-		     * for the process here until max_wait.
-		     */
+         * If the STDOUT is closed from the script we may reach
+         * this point without any input in read_fd, so just wait
+         * for the process here until max_wait.
+         */
         int options = WNOHANG;
         int rc;
         int delay = 10;
         int max_delay = 1000;
         bool killed_pg = false;
-        while((rc = waitpid(pid, &status, options)) <= 0) {
+        while ((rc = waitpid(pid, &status, options)) <= 0) {
           if (rc < 0) {
-            if (errno == EINTR)
-              continue;
+            if (errno == EINTR) continue;
             CRANE_ERROR("{} waitpid() failed: {}", script, strerror(errno));
             break;
           }
 
           auto elapsed = std::chrono::duration_cast<std::chrono::milliseconds>(
-    std::chrono::steady_clock::now() - start_time);
+              std::chrono::steady_clock::now() - start_time);
           if (elapsed >= timeout) {
-            CRANE_TRACE("{} Timeout while waiting for process to exit.", script);
+            CRANE_TRACE("{} Timeout while waiting for process to exit.",
+                        script);
             kill_pg(pid);
             options = 0;
             killed_pg = true;
@@ -573,9 +573,8 @@ std::expected<std::string, RunPrologEpilogStatus> RunPrologOrEpiLog(
           uint64_t remaining_time = timeout.count() - elapsed.count();
           poll(NULL, 0, delay);
           delay = std::min<int>(
-            max_delay,
-            std::max<int>(1, std::min<int>(delay * 2, remaining_time))
-          );
+              max_delay,
+              std::max<int>(1, std::min<int>(delay * 2, remaining_time)));
         }
         if (!killed_pg) kill_pg(pid);
       }
@@ -593,7 +592,6 @@ std::expected<std::string, RunPrologEpilogStatus> RunPrologOrEpiLog(
         exit_code = status;
         signal_num = 0;
       }
-
 
       if (exit_code != 0 || signal_num != 0) {
         CRANE_TRACE("{} Failed (exit status {}:{}), output: {}.", script,

--- a/src/Utilities/PublicHeader/OS.cpp
+++ b/src/Utilities/PublicHeader/OS.cpp
@@ -482,8 +482,13 @@ std::expected<std::string, RunPrologEpilogStatus> RunPrologOrEpiLog(
 
     if (pid == 0) { // child
       close(stdout_pipe[0]);
-      dup2(stdout_pipe[1], STDOUT_FILENO);
-      dup2(stdout_pipe[1], STDERR_FILENO);
+      if (dup2(stdout_pipe[1], STDOUT_FILENO) == -1 ||
+          dup2(stdout_pipe[1], STDERR_FILENO) == -1) {
+       close(stdout_pipe[1]);
+       fmt::print(stderr, "[Subprocess] Error: dup2 failed: {} ({})\n",
+                  strerror(errno), errno);
+       _exit(EXIT_FAILURE);     
+      }
       close(stdout_pipe[1]);
 
       CloseFdFrom(3); // close all other fds
@@ -521,12 +526,6 @@ std::expected<std::string, RunPrologEpilogStatus> RunPrologOrEpiLog(
 
     } else { // parent
       close(stdout_pipe[1]);
-      if (!SetFdNonBlocking(stdout_pipe[0])) {
-        CRANE_ERROR("Failed to set non-blocking mode for stdout pipe.");
-        close(stdout_pipe[0]);
-        result = std::unexpected(RunPrologEpilogStatus{.exit_code=1, .signal_num=0});
-        return;
-      }
 
       auto loop = uvw::loop::create();
       auto pipe_handle = loop->uninitialized_resource<uvw::pipe_handle>(false);

--- a/src/Utilities/PublicHeader/include/crane/OS.h
+++ b/src/Utilities/PublicHeader/include/crane/OS.h
@@ -46,7 +46,7 @@ struct NodeSpecInfo {
 struct RunPrologEpilogArgs {
   std::vector<std::string> scripts;
   std::unordered_map<std::string, std::string> envs;
-  uint32_t timeout_sec{0};
+  uint32_t timeout_sec{60};
   uid_t run_uid;
   gid_t run_gid;
   uint64_t output_size;
@@ -105,6 +105,8 @@ bool CheckUserHasPermission(uid_t uid, gid_t gid,
                             std::filesystem::path const& p);
 
 absl::Time GetSystemBootTime();
+
+void kill_pg(pid_t pid);
 
 std::expected<std::string, RunPrologEpilogStatus> RunPrologOrEpiLog(
     const RunPrologEpilogArgs& args);

--- a/src/Utilities/PublicHeader/include/crane/OS.h
+++ b/src/Utilities/PublicHeader/include/crane/OS.h
@@ -106,6 +106,8 @@ bool CheckUserHasPermission(uid_t uid, gid_t gid,
 
 absl::Time GetSystemBootTime();
 
+bool IsAbsolutePath(const std::string& path);
+
 void kill_pg(pid_t pid);
 
 std::expected<std::string, RunPrologEpilogStatus> RunPrologOrEpiLog(

--- a/src/Utilities/PublicHeader/include/crane/OS.h
+++ b/src/Utilities/PublicHeader/include/crane/OS.h
@@ -108,7 +108,7 @@ absl::Time GetSystemBootTime();
 
 bool IsAbsolutePath(const std::string& path);
 
-void kill_pg(pid_t pid);
+void KillPg(pid_t pid);
 
 std::expected<std::string, RunPrologEpilogStatus> RunPrologOrEpiLog(
     const RunPrologEpilogArgs& args);


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Prolog execution now runs in a dedicated background thread when configured.
  * Steps wait for prolog completion before transitioning to running.
  * Lifecycle scripts run in a streaming, per-script model with incremental output and improved subprocess termination.
  * Added utilities for absolute-path checks and improved process-group termination.

* **Bug Fixes**
  * Prolog and epilog timeouts default to 60 seconds when unspecified.
  * Consistent timeout selection across lifecycle phases to reduce hangs and improve failure handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->