### PR TITLE
fix: waitpid conflict

### DIFF
--- a/src/Craned/Core/JobManager.cpp
+++ b/src/Craned/Core/JobManager.cpp
@@ -451,6 +451,7 @@ bool JobManager::EvCheckSupervisorRunning_() {
 
 // NOLINTNEXTLINE(readability-convert-member-functions-to-static)
 void JobManager::EvSigchldCb_() {
+  absl::MutexLock lock(&m_fork_reap_mu_);
   int status;
   pid_t pid;
   while (true) {

--- a/src/Craned/Core/JobManager.cpp
+++ b/src/Craned/Core/JobManager.cpp
@@ -458,7 +458,9 @@ void JobManager::EvSigchldCb_() {
                   /* TODO(More status tracing): | WUNTRACED | WCONTINUED */);
 
     if (pid > 0) {
-      CRANE_TRACE("Child pid {} exit", pid);
+      if (!m_exit_watcher_.TryDeliver(pid, status)) {
+        CRANE_TRACE("Child pid {} exit", pid);
+      }
       // We do nothing now
     } else if (pid == 0) {
       // There's no child that needs reaping.
@@ -731,6 +733,15 @@ bool JobManager::RunPrologWhenAllocSteps_(job_id_t job_id, step_id_t step_id,
         .run_uid = 0,
         .run_gid = 0,
         .output_size = g_config.JobLifecycleHook.MaxOutputSize};
+
+    args.fork_and_watch_fn = [this](std::function<pid_t()> do_fork)
+        -> std::optional<std::pair<pid_t, std::future<int>>> {
+      absl::MutexLock lock(&m_fork_reap_mu_);
+      pid_t pid = do_fork();
+      if (pid < 0) return std::nullopt;
+      if (pid == 0) return std::make_pair(pid, std::future<int>{});
+      return std::make_pair(pid, m_exit_watcher_.Watch(pid));
+    };
 
     if (g_config.JobLifecycleHook.PrologFlags & PrologFlagEnum::Contain) {
       args.at_child_setup_cb = [this, job_id](pid_t pid) {
@@ -1238,6 +1249,16 @@ void JobManager::CleanUpJobAndStepsAsync(std::vector<JobInD>&& jobs,
             .run_uid = 0,
             .run_gid = 0,
             .output_size = g_config.JobLifecycleHook.MaxOutputSize};
+
+        run_epilog_args.fork_and_watch_fn = [this](std::function<pid_t()> do_fork)
+        -> std::optional<std::pair<pid_t, std::future<int>>> {
+          absl::MutexLock lock(&m_fork_reap_mu_);
+          pid_t pid = do_fork();
+          if (pid < 0) return std::nullopt;
+          if (pid == 0) return std::make_pair(pid, std::future<int>{});
+          return std::make_pair(pid, m_exit_watcher_.Watch(pid));
+        };
+
         if (g_config.JobLifecycleHook.PrologEpilogTimeout > 0)
           run_epilog_args.timeout_sec =
               g_config.JobLifecycleHook.PrologEpilogTimeout;

--- a/src/Craned/Core/JobManager.cpp
+++ b/src/Craned/Core/JobManager.cpp
@@ -1250,8 +1250,9 @@ void JobManager::CleanUpJobAndStepsAsync(std::vector<JobInD>&& jobs,
             .run_gid = 0,
             .output_size = g_config.JobLifecycleHook.MaxOutputSize};
 
-        run_epilog_args.fork_and_watch_fn = [this](std::function<pid_t()> do_fork)
-        -> std::optional<std::pair<pid_t, std::future<int>>> {
+        run_epilog_args.fork_and_watch_fn =
+            [this](std::function<pid_t()> do_fork)
+            -> std::optional<std::pair<pid_t, std::future<int>>> {
           absl::MutexLock lock(&m_fork_reap_mu_);
           pid_t pid = do_fork();
           if (pid < 0) return std::nullopt;

--- a/src/Craned/Core/JobManager.cpp
+++ b/src/Craned/Core/JobManager.cpp
@@ -451,7 +451,7 @@ bool JobManager::EvCheckSupervisorRunning_() {
 
 // NOLINTNEXTLINE(readability-convert-member-functions-to-static)
 void JobManager::EvSigchldCb_() {
-  absl::MutexLock lock(&m_fork_reap_mu_);
+  std::unique_lock<std::mutex> lock(m_fork_reap_mu_);
   int status;
   pid_t pid;
   while (true) {
@@ -737,7 +737,7 @@ bool JobManager::RunPrologWhenAllocSteps_(job_id_t job_id, step_id_t step_id,
 
     args.fork_and_watch_fn = [this](std::function<pid_t()> do_fork)
         -> std::optional<std::pair<pid_t, std::future<int>>> {
-      absl::MutexLock lock(&m_fork_reap_mu_);
+      std::unique_lock<std::mutex> lock(m_fork_reap_mu_);
       pid_t pid = do_fork();
       if (pid < 0) return std::nullopt;
       if (pid == 0) return std::make_pair(pid, std::future<int>{});
@@ -1254,7 +1254,7 @@ void JobManager::CleanUpJobAndStepsAsync(std::vector<JobInD>&& jobs,
         run_epilog_args.fork_and_watch_fn =
             [this](std::function<pid_t()> do_fork)
             -> std::optional<std::pair<pid_t, std::future<int>>> {
-          absl::MutexLock lock(&m_fork_reap_mu_);
+          std::unique_lock<std::mutex> lock(m_fork_reap_mu_);
           pid_t pid = do_fork();
           if (pid < 0) return std::nullopt;
           if (pid == 0) return std::make_pair(pid, std::future<int>{});

--- a/src/Craned/Core/JobManager.h
+++ b/src/Craned/Core/JobManager.h
@@ -285,7 +285,7 @@ class JobManager {
 
   std::thread m_uvw_thread_;
 
-  absl::Mutex m_fork_reap_mu_;
+  std::mutex m_fork_reap_mu_;
   ChildExitWatcher m_exit_watcher_;
 };
 }  // namespace Craned

--- a/src/Craned/Core/JobManager.h
+++ b/src/Craned/Core/JobManager.h
@@ -284,6 +284,9 @@ class JobManager {
   util::mutex m_prolog_serial_mutex_;  // when prolog flags set Serial
 
   std::thread m_uvw_thread_;
+
+  absl::Mutex m_fork_reap_mu_;
+  ChildExitWatcher m_exit_watcher_;
 };
 }  // namespace Craned
 

--- a/src/Craned/Supervisor/TaskManager.cpp
+++ b/src/Craned/Supervisor/TaskManager.cpp
@@ -2904,6 +2904,16 @@ void TaskManager::EvCleanTaskStopQueueCb_() {
           .run_uid = task->GetParentStep().uid(),
           .run_gid = task->GetParentStep().gid()[0],
           .output_size = g_config.JobLifecycleHook.MaxOutputSize};
+
+      run_epilog_args.fork_and_watch_fn =
+        [this](std::function<pid_t()> do_fork)
+          -> std::optional<std::pair<pid_t, std::future<int>>> {
+        absl::MutexLock lock(&m_fork_reap_mu_);
+        pid_t pid = do_fork();
+        if (pid < 0) return std::nullopt;
+        if (pid == 0) return std::make_pair(pid, std::future<int>{});
+        return std::make_pair(pid, m_exit_watcher_.Watch(pid));
+      };
       if (g_config.JobLifecycleHook.PrologEpilogTimeout > 0)
         run_epilog_args.timeout_sec =
             g_config.JobLifecycleHook.PrologEpilogTimeout;
@@ -2927,6 +2937,16 @@ void TaskManager::EvCleanTaskStopQueueCb_() {
           .run_uid = task->GetParentStep().uid(),
           .run_gid = task->GetParentStep().gid()[0],
           .output_size = g_config.JobLifecycleHook.MaxOutputSize};
+
+      run_epilog_args.fork_and_watch_fn =
+        [this](std::function<pid_t()> do_fork)
+          -> std::optional<std::pair<pid_t, std::future<int>>> {
+        absl::MutexLock lock(&m_fork_reap_mu_);
+        pid_t pid = do_fork();
+        if (pid < 0) return std::nullopt;
+        if (pid == 0) return std::make_pair(pid, std::future<int>{});
+        return std::make_pair(pid, m_exit_watcher_.Watch(pid));
+      };
       if (g_config.JobLifecycleHook.PrologEpilogTimeout > 0)
         run_epilog_args.timeout_sec =
             g_config.JobLifecycleHook.PrologEpilogTimeout;

--- a/src/Craned/Supervisor/TaskManager.cpp
+++ b/src/Craned/Supervisor/TaskManager.cpp
@@ -2904,16 +2904,6 @@ void TaskManager::EvCleanTaskStopQueueCb_() {
           .run_uid = task->GetParentStep().uid(),
           .run_gid = task->GetParentStep().gid()[0],
           .output_size = g_config.JobLifecycleHook.MaxOutputSize};
-
-      run_epilog_args.fork_and_watch_fn =
-        [this](std::function<pid_t()> do_fork)
-          -> std::optional<std::pair<pid_t, std::future<int>>> {
-        absl::MutexLock lock(&m_fork_reap_mu_);
-        pid_t pid = do_fork();
-        if (pid < 0) return std::nullopt;
-        if (pid == 0) return std::make_pair(pid, std::future<int>{});
-        return std::make_pair(pid, m_exit_watcher_.Watch(pid));
-      };
       if (g_config.JobLifecycleHook.PrologEpilogTimeout > 0)
         run_epilog_args.timeout_sec =
             g_config.JobLifecycleHook.PrologEpilogTimeout;
@@ -2938,15 +2928,6 @@ void TaskManager::EvCleanTaskStopQueueCb_() {
           .run_gid = task->GetParentStep().gid()[0],
           .output_size = g_config.JobLifecycleHook.MaxOutputSize};
 
-      run_epilog_args.fork_and_watch_fn =
-        [this](std::function<pid_t()> do_fork)
-          -> std::optional<std::pair<pid_t, std::future<int>>> {
-        absl::MutexLock lock(&m_fork_reap_mu_);
-        pid_t pid = do_fork();
-        if (pid < 0) return std::nullopt;
-        if (pid == 0) return std::make_pair(pid, std::future<int>{});
-        return std::make_pair(pid, m_exit_watcher_.Watch(pid));
-      };
       if (g_config.JobLifecycleHook.PrologEpilogTimeout > 0)
         run_epilog_args.timeout_sec =
             g_config.JobLifecycleHook.PrologEpilogTimeout;

--- a/src/Craned/Supervisor/TaskManager.h
+++ b/src/Craned/Supervisor/TaskManager.h
@@ -721,6 +721,9 @@ class TaskManager {
 
   StepInstance m_step_;
   std::unordered_map<TaskExecId, task_id_t> m_exec_id_task_id_map_;
+
+  absl::Mutex m_fork_reap_mu_;
+  ChildExitWatcher m_exit_watcher_;
 };
 
 }  // namespace Craned::Supervisor

--- a/src/Craned/Supervisor/TaskManager.h
+++ b/src/Craned/Supervisor/TaskManager.h
@@ -721,9 +721,6 @@ class TaskManager {
 
   StepInstance m_step_;
   std::unordered_map<TaskExecId, task_id_t> m_exec_id_task_id_map_;
-
-  absl::Mutex m_fork_reap_mu_;
-  ChildExitWatcher m_exit_watcher_;
 };
 
 }  // namespace Craned::Supervisor

--- a/src/Utilities/PublicHeader/OS.cpp
+++ b/src/Utilities/PublicHeader/OS.cpp
@@ -444,22 +444,49 @@ void KillPg(pid_t pid) {
   killpg(pid, SIGKILL);
 }
 
+/**
+ * @brief Execute a sequence of prolog or epilog scripts serially.
+ *
+ * Each script is forked as a child process whose stdout/stderr are captured
+ * via a pipe.  Scripts are run one-by-one: the next script starts only after
+ * the previous one exits successfully.  If any script fails or the aggregate
+ * wall-time budget is exhausted, execution stops and an error is returned.
+ *
+ * @param args  Configuration: script paths, timeout, uid/gid, environment
+ *              variables, optional fork-and-watch hook, etc.
+ * @return      The concatenated stdout/stderr of all scripts on success, or
+ *              a RunPrologEpilogStatus describing the first failure.
+ */
 std::expected<std::string, RunPrologEpilogStatus> RunPrologOrEpiLog(
     const RunPrologEpilogArgs& args) {
   using namespace std::chrono;
 
-  auto start_time = steady_clock::now();
-  auto timeout = duration_cast<milliseconds>(seconds(args.timeout_sec));
+  // Record the wall-clock start time so we can enforce an aggregate timeout
+  // across all scripts in the sequence.
+  const auto start_time = steady_clock::now();
+  const auto timeout    = duration_cast<milliseconds>(seconds(args.timeout_sec));
 
+  // Accumulated stdout/stderr from every successfully completed script.
   std::string output;
+
+  // Overall function result; initialised to a generic failure so that any
+  // early-return path without an explicit assignment still signals an error.
   std::expected<std::string, RunPrologEpilogStatus> result =
       std::unexpected(RunPrologEpilogStatus{.exit_code = 1, .signal_num = 0});
 
+  // Index into args.scripts – advanced by one each time a script succeeds.
   size_t script_idx = 0;
 
+  // run_next_script is a recursive lambda: it runs scripts[script_idx], and
+  // on success increments script_idx and calls itself again.  Using
+  // std::function allows the lambda to capture a reference to itself.
   std::function<void()> run_next_script;
 
   run_next_script = [&]() {
+
+    // -------------------------------------------------------------------------
+    // Base case: all scripts have finished successfully.
+    // -------------------------------------------------------------------------
     if (script_idx >= args.scripts.size()) {
       result = output;
       return;
@@ -467,94 +494,261 @@ std::expected<std::string, RunPrologEpilogStatus> RunPrologOrEpiLog(
 
     const auto& script = args.scripts[script_idx];
 
+    // Reject relative paths to prevent accidental execution of unintended
+    // binaries when the working directory changes.
     if (!IsAbsolutePath(script)) {
-      CRANE_ERROR("Script path {} is not absolute.", script);
+      CRANE_ERROR("Script path '{}' is not absolute.", script);
       result = std::unexpected(
           RunPrologEpilogStatus{.exit_code = 1, .signal_num = 0});
       return;
     }
 
+    // -------------------------------------------------------------------------
+    // Create a pipe to capture the child's stdout and stderr.
+    //   stdout_pipe[0] – read  end (parent reads script output)
+    //   stdout_pipe[1] – write end (child writes its output here)
+    // -------------------------------------------------------------------------
     int stdout_pipe[2];
     if (pipe(stdout_pipe) != 0) {
-      CRANE_ERROR("Failed to create pipe for script {}: {}", script,
-                  strerror(errno));
+      CRANE_ERROR("Failed to create pipe for script '{}': {}",
+                  script, strerror(errno));
       result = std::unexpected(
           RunPrologEpilogStatus{.exit_code = 1, .signal_num = 0});
       return;
     }
 
-    pid_t pid = fork();
-    if (pid == -1) {
-      CRANE_ERROR("Failed to fork for script {}: {}", script, strerror(errno));
-      result = std::unexpected(
-          RunPrologEpilogStatus{.exit_code = 1, .signal_num = 0});
-      close(stdout_pipe[0]);
-      close(stdout_pipe[1]);
-      return;
+    // -------------------------------------------------------------------------
+    // Fork the child process.
+    //
+    // Two modes depending on whether a fork_and_watch_fn hook is provided:
+    //
+    //  1. With hook (fork_and_watch_fn set):
+    //     The hook acquires a mutex BEFORE calling fork(), then immediately
+    //     registers the child PID in a ChildExitWatcher.  This eliminates the
+    //     TOCTOU race where SIGCHLD could arrive between fork() and Watch().
+    //     The hook returns:
+    //       nullopt          – fork() failed (pid < 0)
+    //       {0,  empty fut}  – we are the child process
+    //       {pid, future}    – we are the parent; future delivers waitpid status
+    //
+    //  2. Without hook:
+    //     Plain fork(); the caller is responsible for reaping via waitpid().
+    // -------------------------------------------------------------------------
+    pid_t pid        = -1;
+    std::future<int> exit_future;   // valid only in parent when use_watcher==true
+    bool use_watcher = false;
+
+    if (args.fork_and_watch_fn) {
+      auto fork_result = args.fork_and_watch_fn([]() { return fork(); });
+
+      if (!fork_result) {
+        // fork() itself failed (errno is already logged inside the hook).
+        close(stdout_pipe[0]);
+        close(stdout_pipe[1]);
+        result = std::unexpected(
+            RunPrologEpilogStatus{.exit_code = 1, .signal_num = 0});
+        return;
+      }
+
+      pid = fork_result->first;
+
+      // Only the parent process registers the watcher future.
+      // The child (pid == 0) receives an empty future but will exec shortly
+      // and never use it.
+      if (pid > 0) {
+        exit_future = std::move(fork_result->second);
+        use_watcher = true;
+      }
+    } else {
+      pid = fork();
+      if (pid == -1) {
+        CRANE_ERROR("Failed to fork for script '{}': {}", script, strerror(errno));
+        result = std::unexpected(
+            RunPrologEpilogStatus{.exit_code = 1, .signal_num = 0});
+        close(stdout_pipe[0]);
+        close(stdout_pipe[1]);
+        return;
+      }
     }
 
-    if (pid == 0) {  // child
+    // =========================================================================
+    // Child process
+    // =========================================================================
+    if (pid == 0) {
+      // The child only writes to the pipe; close the read end immediately.
       close(stdout_pipe[0]);
+
+      // Redirect both stdout and stderr to the write end of the pipe so the
+      // parent can capture all script output through a single fd.
       if (dup2(stdout_pipe[1], STDOUT_FILENO) == -1 ||
           dup2(stdout_pipe[1], STDERR_FILENO) == -1) {
         close(stdout_pipe[1]);
-        fmt::print(stderr, "[Subprocess] Error: dup2 failed: {} ({})\n",
+        fmt::print(stderr, "[Subprocess] dup2 failed: {} ({})\n",
                    strerror(errno), errno);
         _exit(EXIT_FAILURE);
       }
-      close(stdout_pipe[1]);
+      close(stdout_pipe[1]);  // original fd no longer needed after dup2
 
-      CloseFdFrom(3);  // close all other fds
-      setpgid(0, 0);   // set process group id to its own pid
+      // Close every fd >= 3 to avoid leaking parent file descriptors into
+      // the script (e.g. sockets, log files, gRPC channels).
+      CloseFdFrom(3);
 
+      // Place the child in its own process group so KillPg() can send
+      // signals to the entire group (child + any grandchildren it spawns).
+      setpgid(0, 0);
+
+      // Optional caller-supplied callback executed in the child context
+      // (e.g., to move the child into a cgroup before exec).
       if (args.at_child_setup_cb) {
-        bool setup_ok = args.at_child_setup_cb(getpid());
-        if (!setup_ok) {
-          fmt::print(stderr,
-                     "[Subprocess] Error: subprocess callback failed\n");
+        if (!args.at_child_setup_cb(getpid())) {
+          fmt::print(stderr, "[Subprocess] child setup callback failed\n");
           _exit(EXIT_FAILURE);
         }
       }
 
+      // Drop to the requested group and user credentials before executing
+      // the script.  Group must be dropped first (setgid fails after setuid
+      // on most Linux configurations).
       if (setgid(args.run_gid) != 0) {
-        fmt::print(stderr, "[Subprocess] Error: setgid({}) failed: {} ({})\n",
+        fmt::print(stderr, "[Subprocess] setgid(%u) failed: {} ({})\n",
                    args.run_gid, strerror(errno), errno);
         _exit(EXIT_FAILURE);
       }
-
       if (setuid(args.run_uid) != 0) {
-        fmt::print(stderr, "[Subprocess] Error: setuid({}) failed: {} ({})\n",
+        fmt::print(stderr, "[Subprocess] setuid(%u) failed: {} ({})\n",
                    args.run_uid, strerror(errno), errno);
         _exit(EXIT_FAILURE);
       }
 
+      // Populate the environment for the script.
       for (const auto& [name, value] : args.envs) {
         if (setenv(name.c_str(), value.c_str(), 1) != 0) {
-          fmt::print(stderr,
-                     "[Subprocess] Error: setenv({}, {}) failed: {} ({})\n",
+          fmt::print(stderr, "[Subprocess] setenv({}={}) failed: {} ({})\n",
                      name, value, strerror(errno), errno);
           _exit(EXIT_FAILURE);
         }
       }
 
+      // Replace the child image with the script.  execvp searches PATH, but
+      // since the script path is absolute, PATH is irrelevant here.
       std::vector<const char*> argv = {script.c_str(), nullptr};
       execvp(argv[0], const_cast<char* const*>(argv.data()));
-      fmt::print(stderr, "[Subprocess] execvp() failed: {}\n", strerror(errno));
+
+      // If execvp() returns, it has failed.
+      fmt::print(stderr, "[Subprocess] execvp('{}') failed: {}\n",
+                 script, strerror(errno));
       _exit(EXIT_FAILURE);
 
-    } else {  // parent
+    } else {
+      // =======================================================================
+      // Parent process
+      // =======================================================================
+
+      // The parent only reads from the pipe; close the write end so that
+      // EOF (end_event) is triggered when the child closes its write end.
       close(stdout_pipe[1]);
 
-      auto loop = uvw::loop::create();
-      auto pipe_handle = loop->uninitialized_resource<uvw::pipe_handle>(false);
-      auto timer_handle = loop->resource<uvw::timer_handle>();
-      auto idle_handle = loop->resource<uvw::idle_handle>();
+      // Create a dedicated libuv event loop for this script.
+      // Using a fresh loop per script keeps state isolated and avoids
+      // cross-contamination between sequential script executions.
+      auto loop          = uvw::loop::create();
+      auto pipe_handle   = loop->uninitialized_resource<uvw::pipe_handle>(false);
+      auto timeout_timer = loop->resource<uvw::timer_handle>();
+
+      // poll_timer replaces the previous idle_handle + sleep_for(50ms) design.
+      // A repeating 50ms timer is far less invasive than sleeping inside an
+      // idle callback, which would block the entire event loop and delay both
+      // pipe reads and the timeout timer.
+      // CPU overhead: ~20 lightweight syscalls per second (waitpid/wait_for),
+      // which is negligible even on the busiest node.
+      auto poll_timer = loop->resource<uvw::timer_handle>();
 
       std::string script_output;
-      int err = 0;
-      err = pipe_handle->init();
+
+      // -----------------------------------------------------------------------
+      // Completion state
+      //
+      // We need TWO independent events before it is safe to inspect results:
+      //
+      //   child_exited  – poll_timer detected the child has terminated and
+      //                   stored the raw waitpid() status in exit_status.
+      //
+      //   pipe_ended    – end_event fired, meaning the kernel has flushed all
+      //                   buffered pipe data to us via data_event callbacks.
+      //
+      // Checking child_exited alone would risk processing a truncated
+      // script_output if pipe data was still in flight.  Checking pipe_ended
+      // alone would miss the exit status.  try_finish() gates on both.
+      // -----------------------------------------------------------------------
+      bool child_exited  = false;
+      bool pipe_ended    = false;
+      bool has_error     = false;    // fatal error; suppress normal completion
+      int  exit_status   = 0;       // raw waitpid() status (not just exit code)
+      bool loop_stopping = false;   // guard against double-closing handles
+
+      // --- stop_loop -----------------------------------------------------------
+      // Close all active handles.  Once every handle is closed, libuv exits
+      // loop->run() automatically.  Idempotent via loop_stopping guard.
+      // -------------------------------------------------------------------------
+      auto stop_loop = [&]() {
+        if (loop_stopping) return;
+        loop_stopping = true;
+        pipe_handle->close();
+        timeout_timer->close();
+        poll_timer->close();
+      };
+
+      // --- try_finish ----------------------------------------------------------
+      // Called from both poll_timer and end_event callbacks.  Proceeds only
+      // when both events have fired so that script_output is complete and
+      // exit_status is valid.
+      //
+      // On success, appends output and tail-calls run_next_script(), which
+      // creates a NEW event loop internally.  This is safe because stop_loop()
+      // has already closed all handles on the current loop before we call
+      // run_next_script(); the outer loop->run() therefore returns as soon as
+      // the current callback completes.  Stack depth grows by one frame per
+      // script, which is acceptable for the small number of prolog/epilog
+      // scripts typically configured (< 10).
+      // -------------------------------------------------------------------------
+      auto try_finish = [&]() {
+        if (!child_exited || !pipe_ended) return;
+
+        // Shut down the current event loop before (possibly) entering a new one.
+        stop_loop();
+        if (has_error) return;
+
+        // Decode the raw waitpid() status using standard POSIX macros.
+        int exit_code  = 0;
+        int signal_num = 0;
+        if (WIFEXITED(exit_status)) {
+          exit_code = WEXITSTATUS(exit_status);
+        } else if (WIFSIGNALED(exit_status)) {
+          signal_num = WTERMSIG(exit_status);
+        } else {
+          // Unexpected status (e.g., stopped process); treat as error.
+          exit_code = exit_status;
+        }
+
+        if (exit_code != 0 || signal_num != 0) {
+          CRANE_TRACE("Script '{}' failed (exit_code={}, signal={}), output: {}.",
+                      script, exit_code, signal_num, script_output);
+          result = std::unexpected(RunPrologEpilogStatus{
+              .exit_code = exit_code, .signal_num = signal_num});
+        } else {
+          // Script succeeded; queue the next one.
+          output += script_output;
+          script_idx++;
+          run_next_script();
+        }
+      };
+
+      // -----------------------------------------------------------------------
+      // Initialise the pipe handle and associate it with the OS pipe fd.
+      // -----------------------------------------------------------------------
+      int err = pipe_handle->init();
       if (err) {
-        CRANE_ERROR("Failed to initialize pipe_handle for script {}: {}",
+        CRANE_ERROR("Failed to init pipe_handle for '{}': {}",
                     script, uv_strerror(err));
         result = std::unexpected(
             RunPrologEpilogStatus{.exit_code = 1, .signal_num = 0});
@@ -564,107 +758,166 @@ std::expected<std::string, RunPrologEpilogStatus> RunPrologOrEpiLog(
 
       err = pipe_handle->open(stdout_pipe[0]);
       if (err) {
-        CRANE_ERROR("Failed to open pipe_handle for script {}: {}", script,
-                    uv_strerror(err));
+        CRANE_ERROR("Failed to open pipe_handle for '{}': {}",
+                    script, uv_strerror(err));
         result = std::unexpected(
             RunPrologEpilogStatus{.exit_code = 1, .signal_num = 0});
         close(stdout_pipe[0]);
         return;
       }
 
+      // -----------------------------------------------------------------------
+      // Pipe: data event
+      // Append incoming bytes to script_output, honouring the caller-supplied
+      // size cap.  Excess bytes are silently discarded to bound memory use.
+      // -----------------------------------------------------------------------
       pipe_handle->on<uvw::data_event>(
           [&](const uvw::data_event& event, uvw::pipe_handle&) {
             if (event.length > 0) {
-              size_t remain = args.output_size > script_output.size()
-                                  ? args.output_size - script_output.size()
-                                  : 0;
+              const size_t remain =
+                  args.output_size > script_output.size()
+                      ? args.output_size - script_output.size()
+                      : 0;
               if (remain > 0)
                 script_output.append(event.data.get(),
                                      std::min<size_t>(event.length, remain));
             }
           });
 
+      // -----------------------------------------------------------------------
+      // Pipe: end event (EOF)
+      // The kernel delivers this only after the child has closed its write end
+      // (i.e., after it has exited or explicitly closed stdout/stderr).
+      // All data_event callbacks for this pipe have already been delivered by
+      // the time end_event fires, so script_output is complete here.
+      // -----------------------------------------------------------------------
       pipe_handle->on<uvw::end_event>(
-          [&](const uvw::end_event&, uvw::pipe_handle& h) { h.close(); });
+          [&](const uvw::end_event&, uvw::pipe_handle& h) {
+            h.close();           // release the handle
+            pipe_ended = true;
+            try_finish();        // proceed if child has also exited
+          });
 
+      // -----------------------------------------------------------------------
+      // Pipe: error event
+      // Any I/O error on the read end is treated as a fatal failure.
+      // All handles are closed so the event loop terminates promptly.
+      // -----------------------------------------------------------------------
       pipe_handle->on<uvw::error_event>(
-          [&](uvw::error_event& e, uvw::pipe_handle& h) {
-            CRANE_WARN("{} output pipe error: {}. Closing.", script, e.what());
-            h.close();
+          [&](uvw::error_event& e, uvw::pipe_handle&) {
+            CRANE_WARN("Pipe error for script '{}': {}.", script, e.what());
+            has_error = true;
+            result    = std::unexpected(
+                RunPrologEpilogStatus{.exit_code = 1, .signal_num = 0});
+            stop_loop();   // also closes timeout_timer and poll_timer
           });
 
       pipe_handle->read();
 
-      timer_handle->on<uvw::timer_event>(
-          [&](const uvw::timer_event&, uvw::timer_handle&) {
-            CRANE_TRACE("{} Timeout.", script);
+      // -----------------------------------------------------------------------
+      // Timeout timer (one-shot)
+      // Fires once after the remaining time budget has elapsed.
+      // Sends SIGKILL to the child's entire process group, then closes
+      // itself.  The poll_timer is intentionally left running so we can
+      // still detect the child's eventual exit and drain the pipe cleanly.
+      // -----------------------------------------------------------------------
+      timeout_timer->on<uvw::timer_event>(
+          [&](const uvw::timer_event&, uvw::timer_handle& h) {
+            CRANE_TRACE("Script '{}' timed out; killing process group {}.",
+                        script, pid);
             KillPg(pid);
+            h.close();  // close only the timeout timer; poll_timer keeps running
           });
 
-      int status = 0;
-      idle_handle->on<uvw::idle_event>(
-          [&](const uvw::idle_event&, uvw::idle_handle& h) {
-            int rc = waitpid(pid, &status, WNOHANG);
-            if (rc == pid) {
-              timer_handle->close();
-              pipe_handle->close();
-              h.parent().walk([](auto&& h) { h.close(); });
-              h.parent().stop();
+      // -----------------------------------------------------------------------
+      // Poll timer (repeating, 50 ms interval)
+      // Periodically checks whether the child process has exited.
+      //
+      // Why a timer instead of idle + sleep?
+      //   idle + sleep_for(50ms) blocks the entire event loop thread, which
+      //   prevents libuv from processing pipe data or firing the timeout timer
+      //   during the sleep window.  A repeating timer is non-blocking: libuv
+      //   sleeps efficiently in epoll_wait() between timer ticks, and other
+      //   I/O events (pipe reads, timeout) are handled in between.
+      //
+      // CPU overhead estimation:
+      //   20 ticks/s × 1 waitpid (or wait_for) syscall × ~1 µs each ≈ 0.002%
+      //   of a single CPU core.  Negligible even under heavy load.
+      // -----------------------------------------------------------------------
+      poll_timer->on<uvw::timer_event>(
+          [&](const uvw::timer_event&, uvw::timer_handle& h) {
+            bool exited = false;
 
-              int exit_code = 0, signal_num = 0;
-              if (WIFEXITED(status)) {
-                exit_code = WEXITSTATUS(status);
-                signal_num = 0;
-              } else if (WIFSIGNALED(status)) {
-                exit_code = 0;
-                signal_num = WTERMSIG(status);
-              } else {
-                exit_code = status;
-                signal_num = 0;
+            if (use_watcher) {
+              // Non-blocking check of the shared future.
+              // TryDeliver() MUST call promise::set_value() with the raw
+              // waitpid() status (not a processed exit code), so that the
+              // WIFEXITED / WEXITSTATUS macros in try_finish() work correctly.
+              if (exit_future.wait_for(milliseconds(0)) ==
+                  std::future_status::ready) {
+                exit_status = exit_future.get();
+                exited      = true;
               }
-              if (exit_code != 0 || signal_num != 0) {
-                CRANE_TRACE("{} Failed (exit status {}:{}), output: {}.",
-                            script, exit_code, signal_num, script_output);
-                result = std::unexpected(
-                    RunPrologEpilogStatus{.exit_code = exit_code,
-                                          .signal_num = signal_num});
+            } else {
+              // WNOHANG: return immediately if no child has changed state.
+              //   rc == pid  → child exited; exit_status is valid
+              //   rc == 0    → child still running; try again next tick
+              //   rc == -1   → error (e.g., child already reaped elsewhere)
+              int rc = waitpid(pid, &exit_status, WNOHANG);
+              if (rc == pid) {
+                exited = true;
+              } else if (rc == -1) {
+                CRANE_ERROR("waitpid failed for script '{}' pid={}: {}",
+                            script, pid, strerror(errno));
+                has_error = true;
+                result    = std::unexpected(
+                    RunPrologEpilogStatus{.exit_code = 1, .signal_num = 0});
+                stop_loop();
                 return;
               }
-              output += script_output;
-              script_idx++;
-              run_next_script();
-            } else if (rc == -1) {
-              timer_handle->close();
-              pipe_handle->close();
-              h.parent().walk([](auto&& h) { h.close(); });
-              h.parent().stop();
-              CRANE_ERROR("waitpid failed for script {}, pid:{} : {}", script,
-                          pid, strerror(errno));
-              result = std::unexpected(
-                  RunPrologEpilogStatus{.exit_code = 1, .signal_num = 0});
-              return;
+              // rc == 0: child still running; do nothing and wait for next tick
             }
-            std::this_thread::sleep_for(std::chrono::milliseconds(50));
+
+            if (exited) {
+              // Stop polling; child will not exit again.
+              h.close();
+              child_exited = true;
+              // Attempt completion; deferred if the pipe has not yet signalled EOF.
+              try_finish();
+            }
           });
 
-      auto elapsed = std::chrono::duration_cast<std::chrono::milliseconds>(
-          std::chrono::steady_clock::now() - start_time);
+      // -----------------------------------------------------------------------
+      // Pre-flight timeout check
+      // If previous scripts consumed all of the time budget, skip even
+      // starting the event loop and kill the child we just forked.
+      // -----------------------------------------------------------------------
+      const auto elapsed = duration_cast<milliseconds>(
+          steady_clock::now() - start_time);
       if (elapsed >= timeout) {
-        idle_handle->stop();
+        CRANE_TRACE("Script '{}' timed out before its event loop started.",
+                    script);
+        KillPg(pid);
         pipe_handle->close();
-        CRANE_TRACE("{} Timeout.", script);
         result = std::unexpected(
             RunPrologEpilogStatus{.exit_code = 1, .signal_num = 0});
         return;
       }
 
-      timer_handle->start(timeout - elapsed, std::chrono::seconds(0));
-      idle_handle->start();
+      // Start the one-shot timeout timer for the remaining time budget.
+      timeout_timer->start(timeout - elapsed, milliseconds(0));
 
+      // Start the repeating poll timer.  First tick after 50 ms; repeats
+      // every 50 ms thereafter.
+      poll_timer->start(milliseconds(50), milliseconds(50));
+
+      // Block until all handles have been closed (i.e., stop_loop() was called
+      // or every handle reached its natural end state).
       loop->run();
     }
   };
 
+  // Kick off the recursive script execution chain.
   run_next_script();
 
   return result;

--- a/src/Utilities/PublicHeader/OS.cpp
+++ b/src/Utilities/PublicHeader/OS.cpp
@@ -573,6 +573,16 @@ std::expected<std::string, RunPrologEpilogStatus> RunPrologOrEpiLog(
       }
     }
 
+    std::vector<char*> envp;
+    envp.reserve(args.envs.size() + 1);
+    for (const auto& [name, value] : args.envs) {
+      std::string env_entry = name + "=" + value;
+      envp.emplace_back(const_cast<char*>(env_entry.c_str()));
+    }
+    envp.push_back(nullptr);
+
+    const char* exec_argv[] = {script.c_str(), nullptr};
+
     // =========================================================================
     // Child process
     // =========================================================================
@@ -585,15 +595,18 @@ std::expected<std::string, RunPrologEpilogStatus> RunPrologOrEpiLog(
       if (dup2(stdout_pipe[1], STDOUT_FILENO) == -1 ||
           dup2(stdout_pipe[1], STDERR_FILENO) == -1) {
         close(stdout_pipe[1]);
-        fmt::print(stderr, "[Subprocess] dup2 failed: {} ({})\n",
-                   strerror(errno), errno);
-        _exit(EXIT_FAILURE);
+        const char msg[] = "[Subprocess] dup2 failed\n";
+        write(STDERR_FILENO, msg, sizeof(msg) - 1);
       }
       close(stdout_pipe[1]);  // original fd no longer needed after dup2
 
       // Close every fd >= 3 to avoid leaking parent file descriptors into
       // the script (e.g. sockets, log files, gRPC channels).
-      CloseFdFrom(3);
+    #if defined(__linux__) && defined(SYS_close_range)
+      syscall(SYS_close_range, 3, UINT_MAX, 0);  // 单次系统调用
+    #else
+        CloseFdFrom(3);
+    #endif
 
       // Place the child in its own process group so KillPg() can send
       // signals to the entire group (child + any grandchildren it spawns).
@@ -603,7 +616,8 @@ std::expected<std::string, RunPrologEpilogStatus> RunPrologOrEpiLog(
       // (e.g., to move the child into a cgroup before exec).
       if (args.at_child_setup_cb) {
         if (!args.at_child_setup_cb(getpid())) {
-          fmt::print(stderr, "[Subprocess] child setup callback failed\n");
+          const char msg[] = "[Subprocess] child setup callback failed\n";
+          write(STDERR_FILENO, msg, sizeof(msg) - 1);
           _exit(EXIT_FAILURE);
         }
       }
@@ -612,33 +626,25 @@ std::expected<std::string, RunPrologEpilogStatus> RunPrologOrEpiLog(
       // the script.  Group must be dropped first (setgid fails after setuid
       // on most Linux configurations).
       if (setgid(args.run_gid) != 0) {
-        fmt::print(stderr, "[Subprocess] setgid(%u) failed: {} ({})\n",
-                   args.run_gid, strerror(errno), errno);
+        const char msg[] = "[Subprocess] setgid failed\n";
+        write(STDERR_FILENO, msg, sizeof(msg) - 1);
         _exit(EXIT_FAILURE);
       }
       if (setuid(args.run_uid) != 0) {
-        fmt::print(stderr, "[Subprocess] setuid(%u) failed: {} ({})\n",
-                   args.run_uid, strerror(errno), errno);
+        const char msg[] = "[Subprocess] setuid failed\n";
+        write(STDERR_FILENO, msg, sizeof(msg) - 1);
         _exit(EXIT_FAILURE);
-      }
-
-      // Populate the environment for the script.
-      for (const auto& [name, value] : args.envs) {
-        if (setenv(name.c_str(), value.c_str(), 1) != 0) {
-          fmt::print(stderr, "[Subprocess] setenv({}={}) failed: {} ({})\n",
-                     name, value, strerror(errno), errno);
-          _exit(EXIT_FAILURE);
-        }
       }
 
       // Replace the child image with the script.  execvp searches PATH, but
       // since the script path is absolute, PATH is irrelevant here.
-      std::vector<const char*> argv = {script.c_str(), nullptr};
-      execvp(argv[0], const_cast<char* const*>(argv.data()));
+      execvpe(exec_argv[0],
+            const_cast<char* const*>(exec_argv),
+            envp.data());
 
       // If execvp() returns, it has failed.
-      fmt::print(stderr, "[Subprocess] execvp('{}') failed: {}\n", script,
-                 strerror(errno));
+      const char msg[] = "[Subprocess] execvp failed\n";
+      write(STDERR_FILENO, msg, sizeof(msg) - 1);
       _exit(EXIT_FAILURE);
 
     } else {
@@ -811,7 +817,7 @@ std::expected<std::string, RunPrologEpilogStatus> RunPrologOrEpiLog(
       // -----------------------------------------------------------------------
       pipe_handle->on<uvw::error_event>(
           [&](uvw::error_event& e, uvw::pipe_handle&) {
-            CRANE_WARN("Pipe error for script '{}': {}.", script, e.what());
+            CRANE_WARN("Pipe error for script '{}'({}): {}.", script, pid, e.what());
             has_error = true;
             result = std::unexpected(
                 RunPrologEpilogStatus{.exit_code = 1, .signal_num = 0});
@@ -905,9 +911,37 @@ std::expected<std::string, RunPrologEpilogStatus> RunPrologOrEpiLog(
         CRANE_TRACE("Script '{}' timed out before its event loop started.",
                     script);
         KillPg(pid);
+
+        // Reap the child and capture its true exit status to avoid leaving
+        // a zombie process.
+        int raw_status = 0;
+        if (use_watcher) {
+          // The fork_and_watch_fn hook is responsible for calling waitpid();
+          // block on the future to ensure the child is fully reaped before
+          // we return.
+          raw_status = exit_future.get();
+        } else {
+          // Plain fork() path: we must reap the child ourselves.
+          waitpid(pid, &raw_status, 0);
+        }
+
+        // Decode the raw waitpid() status (same logic as try_finish()).
+        int exit_code = 0;
+        int signal_num = 0;
+        if (WIFEXITED(raw_status)) {
+          exit_code = WEXITSTATUS(raw_status);
+        } else if (WIFSIGNALED(raw_status)) {
+          signal_num = WTERMSIG(raw_status);
+        } else {
+          exit_code = raw_status;  // unexpected status, treat as error
+        }
+
+        CRANE_TRACE("Script '{}' timed out (exit_code={}, signal={}).",
+                    script, exit_code, signal_num);
         pipe_handle->close();
         result = std::unexpected(
-            RunPrologEpilogStatus{.exit_code = 1, .signal_num = 0});
+            RunPrologEpilogStatus{.exit_code = exit_code,
+                                  .signal_num = signal_num});
         return;
       }
 

--- a/src/Utilities/PublicHeader/OS.cpp
+++ b/src/Utilities/PublicHeader/OS.cpp
@@ -464,7 +464,7 @@ std::expected<std::string, RunPrologEpilogStatus> RunPrologOrEpiLog(
   // Record the wall-clock start time so we can enforce an aggregate timeout
   // across all scripts in the sequence.
   const auto start_time = steady_clock::now();
-  const auto timeout    = duration_cast<milliseconds>(seconds(args.timeout_sec));
+  const auto timeout = duration_cast<milliseconds>(seconds(args.timeout_sec));
 
   // Accumulated stdout/stderr from every successfully completed script.
   std::string output;
@@ -483,7 +483,6 @@ std::expected<std::string, RunPrologEpilogStatus> RunPrologOrEpiLog(
   std::function<void()> run_next_script;
 
   run_next_script = [&]() {
-
     // -------------------------------------------------------------------------
     // Base case: all scripts have finished successfully.
     // -------------------------------------------------------------------------
@@ -510,8 +509,8 @@ std::expected<std::string, RunPrologEpilogStatus> RunPrologOrEpiLog(
     // -------------------------------------------------------------------------
     int stdout_pipe[2];
     if (pipe(stdout_pipe) != 0) {
-      CRANE_ERROR("Failed to create pipe for script '{}': {}",
-                  script, strerror(errno));
+      CRANE_ERROR("Failed to create pipe for script '{}': {}", script,
+                  strerror(errno));
       result = std::unexpected(
           RunPrologEpilogStatus{.exit_code = 1, .signal_num = 0});
       return;
@@ -529,13 +528,15 @@ std::expected<std::string, RunPrologEpilogStatus> RunPrologOrEpiLog(
     //     The hook returns:
     //       nullopt          – fork() failed (pid < 0)
     //       {0,  empty fut}  – we are the child process
-    //       {pid, future}    – we are the parent; future delivers waitpid status
+    //       {pid, future}    – we are the parent; future delivers waitpid
+    //       status
     //
     //  2. Without hook:
     //     Plain fork(); the caller is responsible for reaping via waitpid().
     // -------------------------------------------------------------------------
-    pid_t pid        = -1;
-    std::future<int> exit_future;   // valid only in parent when use_watcher==true
+    pid_t pid = -1;
+    std::future<int>
+        exit_future;  // valid only in parent when use_watcher==true
     bool use_watcher = false;
 
     if (args.fork_and_watch_fn) {
@@ -562,7 +563,8 @@ std::expected<std::string, RunPrologEpilogStatus> RunPrologOrEpiLog(
     } else {
       pid = fork();
       if (pid == -1) {
-        CRANE_ERROR("Failed to fork for script '{}': {}", script, strerror(errno));
+        CRANE_ERROR("Failed to fork for script '{}': {}", script,
+                    strerror(errno));
         result = std::unexpected(
             RunPrologEpilogStatus{.exit_code = 1, .signal_num = 0});
         close(stdout_pipe[0]);
@@ -635,8 +637,8 @@ std::expected<std::string, RunPrologEpilogStatus> RunPrologOrEpiLog(
       execvp(argv[0], const_cast<char* const*>(argv.data()));
 
       // If execvp() returns, it has failed.
-      fmt::print(stderr, "[Subprocess] execvp('{}') failed: {}\n",
-                 script, strerror(errno));
+      fmt::print(stderr, "[Subprocess] execvp('{}') failed: {}\n", script,
+                 strerror(errno));
       _exit(EXIT_FAILURE);
 
     } else {
@@ -651,8 +653,8 @@ std::expected<std::string, RunPrologEpilogStatus> RunPrologOrEpiLog(
       // Create a dedicated libuv event loop for this script.
       // Using a fresh loop per script keeps state isolated and avoids
       // cross-contamination between sequential script executions.
-      auto loop          = uvw::loop::create();
-      auto pipe_handle   = loop->uninitialized_resource<uvw::pipe_handle>(false);
+      auto loop = uvw::loop::create();
+      auto pipe_handle = loop->uninitialized_resource<uvw::pipe_handle>(false);
       auto timeout_timer = loop->resource<uvw::timer_handle>();
 
       // poll_timer replaces the previous idle_handle + sleep_for(50ms) design.
@@ -680,15 +682,16 @@ std::expected<std::string, RunPrologEpilogStatus> RunPrologOrEpiLog(
       // script_output if pipe data was still in flight.  Checking pipe_ended
       // alone would miss the exit status.  try_finish() gates on both.
       // -----------------------------------------------------------------------
-      bool child_exited  = false;
-      bool pipe_ended    = false;
-      bool has_error     = false;    // fatal error; suppress normal completion
-      int  exit_status   = 0;       // raw waitpid() status (not just exit code)
-      bool loop_stopping = false;   // guard against double-closing handles
+      bool child_exited = false;
+      bool pipe_ended = false;
+      bool has_error = false;      // fatal error; suppress normal completion
+      int exit_status = 0;         // raw waitpid() status (not just exit code)
+      bool loop_stopping = false;  // guard against double-closing handles
 
-      // --- stop_loop -----------------------------------------------------------
-      // Close all active handles.  Once every handle is closed, libuv exits
-      // loop->run() automatically.  Idempotent via loop_stopping guard.
+      // --- stop_loop
+      // ----------------------------------------------------------- Close all
+      // active handles.  Once every handle is closed, libuv exits loop->run()
+      // automatically.  Idempotent via loop_stopping guard.
       // -------------------------------------------------------------------------
       auto stop_loop = [&]() {
         if (loop_stopping) return;
@@ -698,10 +701,11 @@ std::expected<std::string, RunPrologEpilogStatus> RunPrologOrEpiLog(
         poll_timer->close();
       };
 
-      // --- try_finish ----------------------------------------------------------
-      // Called from both poll_timer and end_event callbacks.  Proceeds only
-      // when both events have fired so that script_output is complete and
-      // exit_status is valid.
+      // --- try_finish
+      // ---------------------------------------------------------- Called from
+      // both poll_timer and end_event callbacks.  Proceeds only when both
+      // events have fired so that script_output is complete and exit_status is
+      // valid.
       //
       // On success, appends output and tail-calls run_next_script(), which
       // creates a NEW event loop internally.  This is safe because stop_loop()
@@ -714,12 +718,13 @@ std::expected<std::string, RunPrologEpilogStatus> RunPrologOrEpiLog(
       auto try_finish = [&]() {
         if (!child_exited || !pipe_ended) return;
 
-        // Shut down the current event loop before (possibly) entering a new one.
+        // Shut down the current event loop before (possibly) entering a new
+        // one.
         stop_loop();
         if (has_error) return;
 
         // Decode the raw waitpid() status using standard POSIX macros.
-        int exit_code  = 0;
+        int exit_code = 0;
         int signal_num = 0;
         if (WIFEXITED(exit_status)) {
           exit_code = WEXITSTATUS(exit_status);
@@ -731,10 +736,12 @@ std::expected<std::string, RunPrologEpilogStatus> RunPrologOrEpiLog(
         }
 
         if (exit_code != 0 || signal_num != 0) {
-          CRANE_TRACE("Script '{}' failed (exit_code={}, signal={}), output: {}.",
-                      script, exit_code, signal_num, script_output);
-          result = std::unexpected(RunPrologEpilogStatus{
-              .exit_code = exit_code, .signal_num = signal_num});
+          CRANE_TRACE(
+              "Script '{}' failed (exit_code={}, signal={}), output: {}.",
+              script, exit_code, signal_num, script_output);
+          result =
+              std::unexpected(RunPrologEpilogStatus{.exit_code = exit_code,
+                                                    .signal_num = signal_num});
         } else {
           // Script succeeded; queue the next one.
           output += script_output;
@@ -748,8 +755,8 @@ std::expected<std::string, RunPrologEpilogStatus> RunPrologOrEpiLog(
       // -----------------------------------------------------------------------
       int err = pipe_handle->init();
       if (err) {
-        CRANE_ERROR("Failed to init pipe_handle for '{}': {}",
-                    script, uv_strerror(err));
+        CRANE_ERROR("Failed to init pipe_handle for '{}': {}", script,
+                    uv_strerror(err));
         result = std::unexpected(
             RunPrologEpilogStatus{.exit_code = 1, .signal_num = 0});
         close(stdout_pipe[0]);
@@ -758,8 +765,8 @@ std::expected<std::string, RunPrologEpilogStatus> RunPrologOrEpiLog(
 
       err = pipe_handle->open(stdout_pipe[0]);
       if (err) {
-        CRANE_ERROR("Failed to open pipe_handle for '{}': {}",
-                    script, uv_strerror(err));
+        CRANE_ERROR("Failed to open pipe_handle for '{}': {}", script,
+                    uv_strerror(err));
         result = std::unexpected(
             RunPrologEpilogStatus{.exit_code = 1, .signal_num = 0});
         close(stdout_pipe[0]);
@@ -771,18 +778,17 @@ std::expected<std::string, RunPrologEpilogStatus> RunPrologOrEpiLog(
       // Append incoming bytes to script_output, honouring the caller-supplied
       // size cap.  Excess bytes are silently discarded to bound memory use.
       // -----------------------------------------------------------------------
-      pipe_handle->on<uvw::data_event>(
-          [&](const uvw::data_event& event, uvw::pipe_handle&) {
-            if (event.length > 0) {
-              const size_t remain =
-                  args.output_size > script_output.size()
-                      ? args.output_size - script_output.size()
-                      : 0;
-              if (remain > 0)
-                script_output.append(event.data.get(),
-                                     std::min<size_t>(event.length, remain));
-            }
-          });
+      pipe_handle->on<uvw::data_event>([&](const uvw::data_event& event,
+                                           uvw::pipe_handle&) {
+        if (event.length > 0) {
+          const size_t remain = args.output_size > script_output.size()
+                                    ? args.output_size - script_output.size()
+                                    : 0;
+          if (remain > 0)
+            script_output.append(event.data.get(),
+                                 std::min<size_t>(event.length, remain));
+        }
+      });
 
       // -----------------------------------------------------------------------
       // Pipe: end event (EOF)
@@ -793,9 +799,9 @@ std::expected<std::string, RunPrologEpilogStatus> RunPrologOrEpiLog(
       // -----------------------------------------------------------------------
       pipe_handle->on<uvw::end_event>(
           [&](const uvw::end_event&, uvw::pipe_handle& h) {
-            h.close();           // release the handle
+            h.close();  // release the handle
             pipe_ended = true;
-            try_finish();        // proceed if child has also exited
+            try_finish();  // proceed if child has also exited
           });
 
       // -----------------------------------------------------------------------
@@ -807,9 +813,9 @@ std::expected<std::string, RunPrologEpilogStatus> RunPrologOrEpiLog(
           [&](uvw::error_event& e, uvw::pipe_handle&) {
             CRANE_WARN("Pipe error for script '{}': {}.", script, e.what());
             has_error = true;
-            result    = std::unexpected(
+            result = std::unexpected(
                 RunPrologEpilogStatus{.exit_code = 1, .signal_num = 0});
-            stop_loop();   // also closes timeout_timer and poll_timer
+            stop_loop();  // also closes timeout_timer and poll_timer
           });
 
       pipe_handle->read();
@@ -821,13 +827,13 @@ std::expected<std::string, RunPrologEpilogStatus> RunPrologOrEpiLog(
       // itself.  The poll_timer is intentionally left running so we can
       // still detect the child's eventual exit and drain the pipe cleanly.
       // -----------------------------------------------------------------------
-      timeout_timer->on<uvw::timer_event>(
-          [&](const uvw::timer_event&, uvw::timer_handle& h) {
-            CRANE_TRACE("Script '{}' timed out; killing process group {}.",
-                        script, pid);
-            KillPg(pid);
-            h.close();  // close only the timeout timer; poll_timer keeps running
-          });
+      timeout_timer->on<uvw::timer_event>([&](const uvw::timer_event&,
+                                              uvw::timer_handle& h) {
+        CRANE_TRACE("Script '{}' timed out; killing process group {}.", script,
+                    pid);
+        KillPg(pid);
+        h.close();  // close only the timeout timer; poll_timer keeps running
+      });
 
       // -----------------------------------------------------------------------
       // Poll timer (repeating, 50 ms interval)
@@ -856,7 +862,7 @@ std::expected<std::string, RunPrologEpilogStatus> RunPrologOrEpiLog(
               if (exit_future.wait_for(milliseconds(0)) ==
                   std::future_status::ready) {
                 exit_status = exit_future.get();
-                exited      = true;
+                exited = true;
               }
             } else {
               // WNOHANG: return immediately if no child has changed state.
@@ -867,10 +873,10 @@ std::expected<std::string, RunPrologEpilogStatus> RunPrologOrEpiLog(
               if (rc == pid) {
                 exited = true;
               } else if (rc == -1) {
-                CRANE_ERROR("waitpid failed for script '{}' pid={}: {}",
-                            script, pid, strerror(errno));
+                CRANE_ERROR("waitpid failed for script '{}' pid={}: {}", script,
+                            pid, strerror(errno));
                 has_error = true;
-                result    = std::unexpected(
+                result = std::unexpected(
                     RunPrologEpilogStatus{.exit_code = 1, .signal_num = 0});
                 stop_loop();
                 return;
@@ -882,7 +888,8 @@ std::expected<std::string, RunPrologEpilogStatus> RunPrologOrEpiLog(
               // Stop polling; child will not exit again.
               h.close();
               child_exited = true;
-              // Attempt completion; deferred if the pipe has not yet signalled EOF.
+              // Attempt completion; deferred if the pipe has not yet signalled
+              // EOF.
               try_finish();
             }
           });
@@ -892,8 +899,8 @@ std::expected<std::string, RunPrologEpilogStatus> RunPrologOrEpiLog(
       // If previous scripts consumed all of the time budget, skip even
       // starting the event loop and kill the child we just forked.
       // -----------------------------------------------------------------------
-      const auto elapsed = duration_cast<milliseconds>(
-          steady_clock::now() - start_time);
+      const auto elapsed =
+          duration_cast<milliseconds>(steady_clock::now() - start_time);
       if (elapsed >= timeout) {
         CRANE_TRACE("Script '{}' timed out before its event loop started.",
                     script);

--- a/src/Utilities/PublicHeader/OS.cpp
+++ b/src/Utilities/PublicHeader/OS.cpp
@@ -603,11 +603,11 @@ std::expected<std::string, RunPrologEpilogStatus> RunPrologOrEpiLog(
 
       // Close every fd >= 3 to avoid leaking parent file descriptors into
       // the script (e.g. sockets, log files, gRPC channels).
-    #if defined(__linux__) && defined(SYS_close_range)
+#if defined(__linux__) && defined(SYS_close_range)
       syscall(SYS_close_range, 3, UINT_MAX, 0);  // 单次系统调用
-    #else
-        CloseFdFrom(3);
-    #endif
+#else
+      CloseFdFrom(3);
+#endif
 
       // Place the child in its own process group so KillPg() can send
       // signals to the entire group (child + any grandchildren it spawns).
@@ -640,9 +640,7 @@ std::expected<std::string, RunPrologEpilogStatus> RunPrologOrEpiLog(
 
       // Replace the child image with the script.  execvp searches PATH, but
       // since the script path is absolute, PATH is irrelevant here.
-      execvpe(exec_argv[0],
-            const_cast<char* const*>(exec_argv),
-            envp.data());
+      execvpe(exec_argv[0], const_cast<char* const*>(exec_argv), envp.data());
 
       // If execvp() returns, it has failed.
       const char msg[] = "[Subprocess] execvp failed\n";
@@ -819,7 +817,8 @@ std::expected<std::string, RunPrologEpilogStatus> RunPrologOrEpiLog(
       // -----------------------------------------------------------------------
       pipe_handle->on<uvw::error_event>(
           [&](uvw::error_event& e, uvw::pipe_handle&) {
-            CRANE_WARN("Pipe error for script '{}'({}): {}.", script, pid, e.what());
+            CRANE_WARN("Pipe error for script '{}'({}): {}.", script, pid,
+                       e.what());
             has_error = true;
             result = std::unexpected(
                 RunPrologEpilogStatus{.exit_code = 1, .signal_num = 0});
@@ -938,12 +937,12 @@ std::expected<std::string, RunPrologEpilogStatus> RunPrologOrEpiLog(
           exit_code = raw_status;  // unexpected status, treat as error
         }
 
-        CRANE_TRACE("Script '{}' timed out (exit_code={}, signal={}).",
-                    script, exit_code, signal_num);
+        CRANE_TRACE("Script '{}' timed out (exit_code={}, signal={}).", script,
+                    exit_code, signal_num);
         pipe_handle->close();
-        result = std::unexpected(
-            RunPrologEpilogStatus{.exit_code = exit_code,
-                                  .signal_num = signal_num});
+        result =
+            std::unexpected(RunPrologEpilogStatus{.exit_code = exit_code,
+                                                  .signal_num = signal_num});
         return;
       }
 

--- a/src/Utilities/PublicHeader/OS.cpp
+++ b/src/Utilities/PublicHeader/OS.cpp
@@ -539,6 +539,17 @@ std::expected<std::string, RunPrologEpilogStatus> RunPrologOrEpiLog(
         exit_future;  // valid only in parent when use_watcher==true
     bool use_watcher = false;
 
+    std::vector<char*> envp;
+    std::vector<std::string> env_storage;
+    envp.reserve(args.envs.size() + 1);
+    for (const auto& [name, value] : args.envs) {
+      env_storage.emplace_back(name + "=" + value);
+      envp.emplace_back(const_cast<char*>(env_storage.back().c_str()));
+    }
+    envp.emplace_back(nullptr);
+
+    const char* exec_argv[] = {script.c_str(), nullptr};
+
     if (args.fork_and_watch_fn) {
       auto fork_result = args.fork_and_watch_fn([]() { return fork(); });
 
@@ -573,16 +584,6 @@ std::expected<std::string, RunPrologEpilogStatus> RunPrologOrEpiLog(
       }
     }
 
-    std::vector<char*> envp;
-    envp.reserve(args.envs.size() + 1);
-    for (const auto& [name, value] : args.envs) {
-      std::string env_entry = name + "=" + value;
-      envp.emplace_back(const_cast<char*>(env_entry.c_str()));
-    }
-    envp.push_back(nullptr);
-
-    const char* exec_argv[] = {script.c_str(), nullptr};
-
     // =========================================================================
     // Child process
     // =========================================================================
@@ -614,6 +615,7 @@ std::expected<std::string, RunPrologEpilogStatus> RunPrologOrEpiLog(
 
       // Optional caller-supplied callback executed in the child context
       // (e.g., to move the child into a cgroup before exec).
+      // TODO: move to parent
       if (args.at_child_setup_cb) {
         if (!args.at_child_setup_cb(getpid())) {
           const char msg[] = "[Subprocess] child setup callback failed\n";

--- a/src/Utilities/PublicHeader/include/crane/OS.h
+++ b/src/Utilities/PublicHeader/include/crane/OS.h
@@ -25,9 +25,9 @@
 
 #include <expected>
 #include <filesystem>
+#include <future>
 #include <set>
 #include <string>
-#include <future>
 
 #include "crane/Logger.h"
 
@@ -52,8 +52,8 @@ struct RunPrologEpilogArgs {
   gid_t run_gid;
   uint64_t output_size;
   std::function<bool(pid_t)> at_child_setup_cb;
-  using ForkAndWatchFn = std::function<
-      std::optional<std::pair<pid_t, std::future<int>>>(
+  using ForkAndWatchFn =
+      std::function<std::optional<std::pair<pid_t, std::future<int>>>(
           std::function<pid_t()> do_fork)>;
   ForkAndWatchFn fork_and_watch_fn;
 };

--- a/src/Utilities/PublicHeader/include/crane/OS.h
+++ b/src/Utilities/PublicHeader/include/crane/OS.h
@@ -27,6 +27,7 @@
 #include <filesystem>
 #include <set>
 #include <string>
+#include <future>
 
 #include "crane/Logger.h"
 
@@ -51,11 +52,35 @@ struct RunPrologEpilogArgs {
   gid_t run_gid;
   uint64_t output_size;
   std::function<bool(pid_t)> at_child_setup_cb;
+  using ForkAndWatchFn = std::function<
+      std::optional<std::pair<pid_t, std::future<int>>>(
+          std::function<pid_t()> do_fork)>;
+  ForkAndWatchFn fork_and_watch_fn;
 };
 
 struct RunPrologEpilogStatus {
   int exit_code;
   int signal_num;
+};
+
+class ChildExitWatcher {
+ public:
+  std::future<int> Watch(pid_t pid) {
+    auto& p = waiters_[pid];
+    return p.get_future();
+  }
+
+  bool TryDeliver(pid_t pid, int status) {
+    if (auto it = waiters_.find(pid); it != waiters_.end()) {
+      it->second.set_value(status);
+      waiters_.erase(it);
+      return true;
+    }
+    return false;
+  }
+
+ private:
+  absl::flat_hash_map<pid_t, std::promise<int>> waiters_;
 };
 
 namespace util::os {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prolog/epilog scripts now run serially with a shared timeout budget, improving timeout enforcement and output capture across multi-script sequences.
  * More reliable child-process monitoring and SIGCHLD handling to ensure exits are observed and delivered for cleanup.
  * Improved process termination handling to better wait for output drains before finalizing status.
  * Nodes with empty IDs now consistently progress to the configured state instead of being skipped.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->