### PR TITLE
refactor: job/step/task misuse

### DIFF
--- a/protos/Crane.proto
+++ b/protos/Crane.proto
@@ -863,7 +863,7 @@ message StreamCrunRequest {
   enum CrunRequestType {
     JOB_REQUEST = 0;
     STEP_REQUEST = 4;
-    JOB_COMPLETION_REQUEST = 1;
+    STEP_COMPLETION_REQUEST = 1;
     TASK_IO_FORWARD = 2;
     STEP_X11_FORWARD = 3;
   }
@@ -878,7 +878,7 @@ message StreamCrunRequest {
     StepToCtld step = 2;
   }
 
-  message JobCompleteReq {
+  message StepCompleteReq {
     JobStatus status = 1;
   }
 
@@ -899,7 +899,7 @@ message StreamCrunRequest {
   oneof payload {
     JobReq payload_job_req = 2;
     StepReq payload_step_req = 6;
-    JobCompleteReq payload_job_complete_req = 3;
+    StepCompleteReq payload_step_complete_req = 3;
     TaskIOForwardReq payload_task_io_forward_req = 4;
     StepX11ForwardReq payload_step_x11_forward_req = 5;
   }
@@ -907,10 +907,10 @@ message StreamCrunRequest {
 
 message StreamCrunReply {
   enum CforedCrunReplyType {
-    JOB_ID_REPLY = 0;
-    JOB_RES_ALLOC_REPLY = 1;
-    JOB_CANCEL_REQUEST = 2;
-    JOB_COMPLETION_ACK_REPLY = 3;
+    STEP_ID_REPLY = 0;
+    STEP_RES_ALLOC_REPLY = 1;
+    STEP_CANCEL_REQUEST = 2;
+    STEP_COMPLETION_ACK_REPLY = 3;
     TASK_IO_FORWARD = 4;
     TASK_IO_FORWARD_READY = 5;
     STEP_X11_FORWARD = 6;
@@ -919,22 +919,22 @@ message StreamCrunReply {
     STEP_X11_EOF = 9;
   }
 
-  message JobIdReply {
+  message StepIdReply {
     bool ok = 1;
     uint32 job_id = 2;
     uint32 step_id = 3;
     string failure_reason = 4;
   }
 
-  message JobResAllocatedReply {
+  message StepResAllocatedReply {
     bool ok = 1;
     string allocated_craned_regex = 2;
     repeated string craned_ids = 3;
   }
 
-  message JobCancelRequest {}
+  message StepCancelRequest {}
 
-  message JobCompletionAckReply {
+  message StepCompletionAckReply {
     bool ok = 1;
   }
 
@@ -971,10 +971,10 @@ message StreamCrunReply {
   CforedCrunReplyType type = 1;
 
   oneof payload {
-    JobIdReply payload_job_id_reply = 2;
-    JobResAllocatedReply payload_job_alloc_reply = 3;
-    JobCancelRequest payload_job_cancel_request = 4;
-    JobCompletionAckReply payload_job_completion_ack_reply = 5;
+    StepIdReply payload_step_id_reply = 2;
+    StepResAllocatedReply payload_step_alloc_reply = 3;
+    StepCancelRequest payload_step_cancel_request = 4;
+    StepCompletionAckReply payload_step_completion_ack_reply = 5;
     TaskIOForwardReadyReply payload_task_io_forward_ready_reply = 6;
     TaskIOForwardReply payload_task_io_forward_reply = 7;
     StepX11ForwardReply payload_step_x11_forward_reply = 8;

--- a/protos/Crane.proto
+++ b/protos/Crane.proto
@@ -865,7 +865,7 @@ message StreamCrunRequest {
     STEP_REQUEST = 4;
     JOB_COMPLETION_REQUEST = 1;
     TASK_IO_FORWARD = 2;
-    TASK_X11_FORWARD = 3;
+    STEP_X11_FORWARD = 3;
   }
 
   message JobReq {
@@ -887,7 +887,7 @@ message StreamCrunRequest {
     bool eof = 2;
   }
 
-  message TaskX11ForwardReq {
+  message StepX11ForwardReq {
     bytes msg = 1;
     bool eof = 2;
     uint32 local_id = 3;
@@ -901,7 +901,7 @@ message StreamCrunRequest {
     StepReq payload_step_req = 6;
     JobCompleteReq payload_job_complete_req = 3;
     TaskIOForwardReq payload_task_io_forward_req = 4;
-    TaskX11ForwardReq payload_task_x11_forward_req = 5;
+    StepX11ForwardReq payload_step_x11_forward_req = 5;
   }
 }
 
@@ -913,10 +913,10 @@ message StreamCrunReply {
     JOB_COMPLETION_ACK_REPLY = 3;
     TASK_IO_FORWARD = 4;
     TASK_IO_FORWARD_READY = 5;
-    TASK_X11_FORWARD = 6;
+    STEP_X11_FORWARD = 6;
     TASK_EXIT_STATUS = 7;
-    TASK_X11_CONN = 8;
-    TASK_X11_EOF = 9;
+    STEP_X11_CONN = 8;
+    STEP_X11_EOF = 9;
   }
 
   message JobIdReply {
@@ -946,18 +946,18 @@ message StreamCrunReply {
     bytes msg = 1;
   }
 
-  message TaskX11ConnReply {
+  message StepX11ConnReply {
     string craned_id = 1;
     uint32 local_id = 2;
   }
 
-  message TaskX11ForwardReply {
+  message StepX11ForwardReply {
     bytes msg = 1;
     string craned_id = 2;
     uint32 local_id = 3;
   }
 
-  message TaskX11EofReply {
+  message StepX11EofReply {
     string craned_id = 1;
     uint32 local_id = 2;
   }
@@ -977,22 +977,22 @@ message StreamCrunReply {
     JobCompletionAckReply payload_job_completion_ack_reply = 5;
     TaskIOForwardReadyReply payload_task_io_forward_ready_reply = 6;
     TaskIOForwardReply payload_task_io_forward_reply = 7;
-    TaskX11ForwardReply payload_task_x11_forward_reply = 8;
+    StepX11ForwardReply payload_step_x11_forward_reply = 8;
     TaskExitStatusReply payload_task_exit_status_reply = 9;
-    TaskX11ConnReply payload_task_x11_conn_reply = 10;
-    TaskX11EofReply payload_task_x11_eof_reply = 11;
+    StepX11ConnReply payload_step_x11_conn_reply = 10;
+    StepX11EofReply payload_step_x11_eof_reply = 11;
   }
 }
 
-message StreamTaskIORequest {
+message StreamStepIORequest {
   enum SupervisorRequestType {
     SUPERVISOR_REGISTER = 0;
     TASK_OUTPUT = 1;
     SUPERVISOR_UNREGISTER = 2;
-    TASK_X11_OUTPUT = 3;
+    STEP_X11_OUTPUT = 3;
     TASK_EXIT_STATUS = 4;
-    TASK_X11_CONN = 5;
-    TASK_X11_EOF = 6;
+    STEP_X11_CONN = 5;
+    STEP_X11_EOF = 6;
   }
 
   message SupervisorRegisterReq {
@@ -1007,18 +1007,18 @@ message StreamTaskIORequest {
 
   message SupervisorUnRegisterReq {}
 
-  message TaskX11FwdConnReq {
+  message StepX11FwdConnReq {
     uint32 local_id = 1;
     string craned_id = 2;
   }
 
-  message TaskX11OutputReq {
+  message StepX11OutputReq {
     bytes msg = 1;
     uint32 local_id = 2;
     string craned_id = 3;
   }
 
-  message TaskX11OutputEofReq {
+  message StepX11OutputEofReq {
     uint32 local_id = 1;
     string craned_id = 2;
   }
@@ -1035,19 +1035,19 @@ message StreamTaskIORequest {
     SupervisorRegisterReq payload_register_req = 2;
     TaskOutputReq payload_task_output_req = 3;
     SupervisorUnRegisterReq payload_unregister_req = 4;
-    TaskX11OutputReq payload_task_x11_output_req = 5;
+    StepX11OutputReq payload_step_x11_output_req = 5;
     TaskExitStatus payload_task_exit_status_req = 6;
-    TaskX11FwdConnReq payload_task_x11_fwd_conn_req = 7;
-    TaskX11OutputEofReq payload_task_x11_eof_req = 8;
+    StepX11FwdConnReq payload_step_x11_fwd_conn_req = 7;
+    StepX11OutputEofReq payload_step_x11_eof_req = 8;
   }
 }
 
-message StreamTaskIOReply {
+message StreamStepIOReply {
   enum SupervisorReplyType {
     SUPERVISOR_REGISTER_REPLY = 0;
     TASK_INPUT = 1;
     SUPERVISOR_UNREGISTER_REPLY = 2;
-    TASK_X11_INPUT = 3;
+    STEP_X11_INPUT = 3;
   }
 
   message SupervisorRegisterReply {
@@ -1063,7 +1063,7 @@ message StreamTaskIOReply {
     bool ok = 1;
   }
 
-  message TaskX11InputReq {
+  message StepX11InputReq {
     bytes msg = 1;
     bool eof = 2;
     uint32 local_id = 3;
@@ -1075,7 +1075,7 @@ message StreamTaskIOReply {
     SupervisorRegisterReply payload_supervisor_register_reply = 2;
     TaskInputReq payload_task_input_req = 3;
     SupervisorUnregisterReply payload_supervisor_unregister_reply = 4;
-    TaskX11InputReq payload_task_x11_input_req = 5;
+    StepX11InputReq payload_step_x11_input_req = 5;
   }
 }
 
@@ -1421,6 +1421,6 @@ service CranedForPam {
 service CraneForeD {
   rpc CallocStream(stream StreamCallocRequest) returns (stream StreamCallocReply);
   rpc CrunStream(stream StreamCrunRequest) returns (stream StreamCrunReply);
-  rpc TaskIOStream(stream StreamTaskIORequest) returns (stream StreamTaskIOReply);
+  rpc StepIOStream(stream StreamStepIORequest) returns (stream StreamStepIOReply);
   rpc QueryStepFromPort(QueryStepFromPortRequest) returns (QueryStepFromPortReply);
 }

--- a/protos/Crane.proto
+++ b/protos/Crane.proto
@@ -29,7 +29,7 @@ message StepStatusChangeRequest {
   uint32 job_id = 1;
   uint32 step_id = 2;
   string craned_id = 3;
-  TaskStatus new_status = 4;
+  JobStatus new_status = 4;
   uint32 exit_code = 5;
   string reason = 6;
   google.protobuf.Timestamp timestamp = 7;
@@ -68,35 +68,35 @@ message CranedPingReply {
   bool ok = 1;
 }
 
-message QueryCranedListFromTaskIdRequest {
-  uint32 task_id = 1;
+message QueryCranedListFromJobIdRequest {
+  uint32 job_id = 1;
 }
 
-message QueryCranedListFromTaskIdReply {
+message QueryCranedListFromJobIdReply {
   bool ok = 1;
   string craned_list = 2;
 }
 
-message SubmitBatchTaskRequest {
-  TaskToCtld task = 1;
+message SubmitBatchJobRequest {
+  JobToCtld job = 1;
 }
 
-message SubmitBatchTaskReply {
+message SubmitBatchJobReply {
   bool ok = 1;
   oneof payload {
-    uint32 task_id = 2;
+    uint32 job_id = 2;
     ErrCode code = 3;
   }
   string reason = 4;
 }
 
-message SubmitBatchTasksRequest {
-  TaskToCtld task = 1;
+message SubmitBatchJobsRequest {
+  JobToCtld job = 1;
   uint32 count = 2;
 }
 
-message SubmitBatchTasksReply {
-  repeated uint32 task_id_list = 1;
+message SubmitBatchJobsReply {
+  repeated uint32 job_id_list = 1;
   repeated ErrCode code_list = 2;
 }
 
@@ -164,7 +164,7 @@ message TerminateOrphanedStepReply {
 }
 
 message ChangeJobTimeLimitRequest {
-  uint32 task_id = 1;
+  uint32 job_id = 1;
   int64 time_limit_seconds = 2;
 }
 
@@ -172,20 +172,20 @@ message ChangeJobTimeLimitReply {
   bool ok = 1;
 }
 
-message CancelTaskRequest {
+message CancelJobRequest {
   uint32 operator_uid = 1;
 
   // Filters
   map<uint32, JobStepIds> filter_ids = 2;
   string filter_partition = 3;
   string filter_account = 4;
-  TaskStatus filter_state = 5;
-  string filter_task_name = 6;
+  JobStatus filter_state = 5;
+  string filter_job_name = 6;
   repeated string filter_nodes = 7;
   string filter_username = 8;
 }
 
-message CancelTaskReply {
+message CancelJobReply {
   map<uint32, JobStepIds> cancelled_steps = 1;
   message NotCancelledJobSteps {
     string reason = 1;
@@ -253,7 +253,7 @@ message QueryLicensesInfoReply {
   repeated LicenseInfo license_info_list = 2;
 }
 
-message ModifyTaskRequest {
+message ModifyJobRequest {
   enum TargetAttributes {
     TimeLimit = 0;
     Priority = 1;
@@ -261,7 +261,7 @@ message ModifyTaskRequest {
   }
 
   uint32 uid = 1;
-  repeated uint32 task_ids = 2;
+  repeated uint32 job_ids = 2;
 
   TargetAttributes attribute = 3;
 
@@ -276,30 +276,30 @@ message ModifyTaskRequest {
   }
 }
 
-message ModifyTaskReply {
-  repeated uint32 modified_tasks = 2;
-  repeated uint32 not_modified_tasks = 3;
+message ModifyJobReply {
+  repeated uint32 modified_jobs = 2;
+  repeated uint32 not_modified_jobs = 3;
   repeated string not_modified_reasons = 4;
 }
 
-message ModifyTasksExtraAttrsRequest {
+message ModifyJobsExtraAttrsRequest {
   uint32 uid = 1;
-  map<uint32 /*taskid*/, string /*extraAttrs*/> extra_attrs_list = 2;
+  map<uint32 /*job_id*/, string /*extraAttrs*/> extra_attrs_list = 2;
 }
 
-message ModifyTasksExtraAttrsReply {
-  repeated uint32 modified_tasks = 1;
-  repeated uint32 not_modified_tasks = 2;
+message ModifyJobsExtraAttrsReply {
+  repeated uint32 modified_jobs = 1;
+  repeated uint32 not_modified_jobs = 2;
   repeated string not_modified_reasons = 3;
 }
 
-message ResetNextTaskIdRequest {
+message ResetNextJobIdRequest {
   uint32 uid = 1;
-  uint32 next_task_id = 2;    // Reset to this value (0 = default to 1)
-  int64 next_task_db_id = 3;  // Reset to this value (0 = default to 1)
+  uint32 next_job_id = 2;    // Reset to this value (0 = default to 1)
+  int64 next_job_db_id = 3;  // Reset to this value (0 = default to 1)
 }
 
-message ResetNextTaskIdReply {
+message ResetNextJobIdReply {
   bool ok = 1;
   string reason = 2;
 }
@@ -313,11 +313,11 @@ message ResetNextStepDbIdReply {
   string reason = 2;
 }
 
-message PurgeTaskHistoryRequest {
+message PurgeJobHistoryRequest {
   uint32 uid = 1;
 }
 
-message PurgeTaskHistoryReply {
+message PurgeJobHistoryReply {
   bool ok = 1;
   string reason = 2;
 }
@@ -547,7 +547,7 @@ message ModifyPartitionAclReply {
 
 message MigrateSshProcToCgroupRequest {
   int32 pid = 1;
-  uint32 task_id = 2;
+  uint32 job_id = 2;
 }
 
 message MigrateSshProcToCgroupReply {
@@ -555,7 +555,7 @@ message MigrateSshProcToCgroupReply {
 }
 
 message QuerySshStepEnvVariablesRequest {
-  uint32 task_id = 1;
+  uint32 job_id = 1;
 }
 
 message QuerySshStepEnvVariablesReply {
@@ -564,7 +564,7 @@ message QuerySshStepEnvVariablesReply {
 }
 
 message QuerySshStepEnvVariablesForwardRequest {
-  uint32 task_id = 1;
+  uint32 job_id = 1;
   string execution_node = 2 [deprecated = true];
 }
 
@@ -586,38 +586,38 @@ message QueryClusterInfoReply {
   repeated TrimmedPartitionInfo partitions = 2;
 }
 
-message QueryTasksInfoRequest {
+message QueryJobsInfoRequest {
   map<uint32 /*JobId*/, JobStepIds> filter_ids = 1;
   repeated string filter_partitions = 2;
   uint32 num_limit = 3;
-  repeated string filter_task_names = 4;
+  repeated string filter_job_names = 4;
   repeated string filter_qos = 5;
 
-  repeated TaskStatus filter_states = 6;
+  repeated JobStatus filter_states = 6;
   repeated string filter_users = 7;
   repeated string filter_accounts = 8;
   TimeInterval filter_submit_time_interval = 9;
   TimeInterval filter_start_time_interval = 10;
   TimeInterval filter_end_time_interval = 11;
-  repeated TaskType filter_task_types = 12;
+  repeated JobType filter_job_types = 12;
   repeated string filter_licenses = 13;
   repeated string filter_nodename_list = 14;
 
-  bool option_include_completed_tasks = 15;
+  bool option_include_completed_jobs = 15;
 }
 
-message QueryTasksInfoReply {
+message QueryJobsInfoReply {
   bool ok = 1;
-  repeated TaskInfo task_info_list = 2;
+  repeated JobInfo job_info_list = 2;
 }
 
-message QueryTaskEfficiencyRequest {
-  repeated uint32 task_ids = 1;
+message QueryJobEfficiencyRequest {
+  repeated uint32 job_ids = 1;
   uint32 uid = 2;  // User ID for authorization
 }
 
-message TaskEfficiencyInfo {
-  uint32 task_id = 1;
+message JobEfficiencyInfo {
+  uint32 job_id = 1;
   string hostname = 2;
   uint64 cpu_usage = 3;     // CPU usage in nanoseconds
   uint64 memory_usage = 4;  // Memory usage in bytes
@@ -625,10 +625,10 @@ message TaskEfficiencyInfo {
   google.protobuf.Timestamp timestamp = 6;
 }
 
-message QueryTaskEfficiencyReply {
+message QueryJobEfficiencyReply {
   bool ok = 1;
   string error_message = 2;
-  repeated TaskEfficiencyInfo efficiency_data = 3;
+  repeated JobEfficiencyInfo efficiency_data = 3;
 }
 
 message QueryNodeEventsRequest {
@@ -695,71 +695,71 @@ message ResetPartitionAclReply {
 
 message StreamCallocRequest {
   enum CallocRequestType {
-    TASK_REQUEST = 0;
-    TASK_COMPLETION_REQUEST = 1;
+    JOB_REQUEST = 0;
+    JOB_COMPLETION_REQUEST = 1;
   }
 
-  message TaskReq {
+  message JobReq {
     int32 calloc_pid = 1;
-    TaskToCtld task = 2;
+    JobToCtld job = 2;
   }
 
-  message TaskCompleteReq {
+  message JobCompleteReq {
     uint32 job_id = 1;
     uint32 step_id = 2;
-    TaskStatus status = 3;
+    JobStatus status = 3;
   }
 
   CallocRequestType type = 1;
 
   oneof payload {
-    TaskReq payload_task_req = 2;
-    TaskCompleteReq payload_task_complete_req = 3;
+    JobReq payload_job_req = 2;
+    JobCompleteReq payload_job_complete_req = 3;
   }
 }
 
 message StreamCallocReply {
   enum CforedReplyType {
-    TASK_ID_REPLY = 0;
-    TASK_RES_ALLOC_REPLY = 1;
-    TASK_CANCEL_REQUEST = 2;
-    TASK_COMPLETION_ACK_REPLY = 3;
+    JOB_ID_REPLY = 0;
+    JOB_RES_ALLOC_REPLY = 1;
+    JOB_CANCEL_REQUEST = 2;
+    JOB_COMPLETION_ACK_REPLY = 3;
   }
 
-  message TaskIdReply {
+  message JobIdReply {
     bool ok = 1;
     uint32 job_id = 2;
     uint32 step_id = 3;
     string failure_reason = 4;
   }
 
-  message TaskResAllocatedReply {
+  message JobResAllocatedReply {
     bool ok = 1;
     string allocated_craned_regex = 2;
   }
 
-  message TaskCancelRequest {}
+  message JobCancelRequest {}
 
-  message TaskCompletionAckReply {
+  message JobCompletionAckReply {
     bool ok = 1;
   }
 
   CforedReplyType type = 1;
 
   oneof payload {
-    TaskIdReply payload_task_id_reply = 2;
-    TaskResAllocatedReply payload_task_alloc_reply = 3;
-    TaskCancelRequest payload_task_cancel_request = 4;
-    TaskCompletionAckReply payload_task_completion_ack_reply = 5;
+    JobIdReply payload_job_id_reply = 2;
+    JobResAllocatedReply payload_job_alloc_reply = 3;
+    JobCancelRequest payload_job_cancel_request = 4;
+    JobCompletionAckReply payload_job_completion_ack_reply = 5;
   }
 }
 
 message StreamCforedRequest {
   enum CforedRequestType {
     CFORED_REGISTRATION = 0;
-    TASK_REQUEST = 1;
+    JOB_REQUEST = 1;
     STEP_REQUEST = 4;
-    TASK_COMPLETION_REQUEST = 2;
+    JOB_COMPLETION_REQUEST = 2;
     CFORED_GRACEFUL_EXIT = 3;
   }
   CforedRequestType type = 1;
@@ -768,10 +768,10 @@ message StreamCforedRequest {
     string cfored_name = 1;
   }
 
-  message TaskReq {
+  message JobReq {
     string cfored_name = 1;
     int32 pid = 2;
-    TaskToCtld task = 3;
+    JobToCtld job = 3;
   }
 
   message StepReq {
@@ -780,12 +780,12 @@ message StreamCforedRequest {
     StepToCtld step = 3;
   }
 
-  message TaskCompleteReq {
+  message JobCompleteReq {
     string cfored_name = 1;
     uint32 job_id = 2;
     uint32 step_id = 3;
-    TaskStatus status = 4;
-    InteractiveTaskType interactive_type = 5;
+    JobStatus status = 4;
+    InteractiveJobType interactive_type = 5;
   }
 
   message GracefulExitReq {
@@ -794,24 +794,24 @@ message StreamCforedRequest {
 
   oneof payload {
     CforedReg payload_cfored_reg = 2;
-    TaskReq payload_task_req = 3;
+    JobReq payload_job_req = 3;
     StepReq payload_step_req = 6;
-    TaskCompleteReq payload_task_complete_req = 4;
+    JobCompleteReq payload_job_complete_req = 4;
     GracefulExitReq payload_graceful_exit_req = 5;
   }
 }
 
 message StreamCtldReply {
   enum CtldReplyType {
-    TASK_ID_REPLY = 0;
-    TASK_RES_ALLOC_REPLY = 1;
-    TASK_CANCEL_REQUEST = 2;
-    TASK_COMPLETION_ACK_REPLY = 3;
+    JOB_ID_REPLY = 0;
+    JOB_RES_ALLOC_REPLY = 1;
+    JOB_CANCEL_REQUEST = 2;
+    JOB_COMPLETION_ACK_REPLY = 3;
     CFORED_REGISTRATION_ACK = 4;
     CFORED_GRACEFUL_EXIT_ACK = 5;
   }
 
-  message TaskIdReply {
+  message JobIdReply {
     int32 pid = 1;
     bool ok = 2;
     uint32 job_id = 3;
@@ -819,7 +819,7 @@ message StreamCtldReply {
     string failure_reason = 5;
   }
 
-  message TaskResAllocatedReply {
+  message JobResAllocatedReply {
     uint32 job_id = 1;
     uint32 step_id = 2;
     bool ok = 3;
@@ -828,12 +828,12 @@ message StreamCtldReply {
     repeated string craned_ids = 6;
   }
 
-  message TaskCancelRequest {
+  message JobCancelRequest {
     uint32 job_id = 1;
     uint32 step_id = 2;
   }
 
-  message TaskCompletionAckReply {
+  message JobCompletionAckReply {
     uint32 job_id = 1;
     uint32 step_id = 2;
   }
@@ -851,26 +851,26 @@ message StreamCtldReply {
 
   oneof payload {
     CforedRegistrationAck payload_cfored_reg_ack = 2;
-    TaskResAllocatedReply payload_task_res_alloc_reply = 3;
-    TaskCancelRequest payload_task_cancel_request = 4;
-    TaskCompletionAckReply payload_task_completion_ack = 5;
-    TaskIdReply payload_task_id_reply = 6;
+    JobResAllocatedReply payload_job_res_alloc_reply = 3;
+    JobCancelRequest payload_job_cancel_request = 4;
+    JobCompletionAckReply payload_job_completion_ack = 5;
+    JobIdReply payload_job_id_reply = 6;
     CforedGracefulExitAck payload_graceful_exit_ack = 7;
   }
 }
 
 message StreamCrunRequest {
   enum CrunRequestType {
-    TASK_REQUEST = 0;
+    JOB_REQUEST = 0;
     STEP_REQUEST = 4;
-    TASK_COMPLETION_REQUEST = 1;
+    JOB_COMPLETION_REQUEST = 1;
     TASK_IO_FORWARD = 2;
     TASK_X11_FORWARD = 3;
   }
 
-  message TaskReq {
+  message JobReq {
     int32 crun_pid = 1;
-    TaskToCtld task = 2;
+    JobToCtld job = 2;
   }
 
   message StepReq {
@@ -878,8 +878,8 @@ message StreamCrunRequest {
     StepToCtld step = 2;
   }
 
-  message TaskCompleteReq {
-    TaskStatus status = 1;
+  message JobCompleteReq {
+    JobStatus status = 1;
   }
 
   message TaskIOForwardReq {
@@ -897,9 +897,9 @@ message StreamCrunRequest {
   CrunRequestType type = 1;
 
   oneof payload {
-    TaskReq payload_task_req = 2;
+    JobReq payload_job_req = 2;
     StepReq payload_step_req = 6;
-    TaskCompleteReq payload_task_complete_req = 3;
+    JobCompleteReq payload_job_complete_req = 3;
     TaskIOForwardReq payload_task_io_forward_req = 4;
     TaskX11ForwardReq payload_task_x11_forward_req = 5;
   }
@@ -907,10 +907,10 @@ message StreamCrunRequest {
 
 message StreamCrunReply {
   enum CforedCrunReplyType {
-    TASK_ID_REPLY = 0;
-    TASK_RES_ALLOC_REPLY = 1;
-    TASK_CANCEL_REQUEST = 2;
-    TASK_COMPLETION_ACK_REPLY = 3;
+    JOB_ID_REPLY = 0;
+    JOB_RES_ALLOC_REPLY = 1;
+    JOB_CANCEL_REQUEST = 2;
+    JOB_COMPLETION_ACK_REPLY = 3;
     TASK_IO_FORWARD = 4;
     TASK_IO_FORWARD_READY = 5;
     TASK_X11_FORWARD = 6;
@@ -919,22 +919,22 @@ message StreamCrunReply {
     TASK_X11_EOF = 9;
   }
 
-  message TaskIdReply {
+  message JobIdReply {
     bool ok = 1;
     uint32 job_id = 2;
     uint32 step_id = 3;
     string failure_reason = 4;
   }
 
-  message TaskResAllocatedReply {
+  message JobResAllocatedReply {
     bool ok = 1;
     string allocated_craned_regex = 2;
     repeated string craned_ids = 3;
   }
 
-  message TaskCancelRequest {}
+  message JobCancelRequest {}
 
-  message TaskCompletionAckReply {
+  message JobCompletionAckReply {
     bool ok = 1;
   }
 
@@ -971,10 +971,10 @@ message StreamCrunReply {
   CforedCrunReplyType type = 1;
 
   oneof payload {
-    TaskIdReply payload_task_id_reply = 2;
-    TaskResAllocatedReply payload_task_alloc_reply = 3;
-    TaskCancelRequest payload_task_cancel_request = 4;
-    TaskCompletionAckReply payload_task_completion_ack_reply = 5;
+    JobIdReply payload_job_id_reply = 2;
+    JobResAllocatedReply payload_job_alloc_reply = 3;
+    JobCancelRequest payload_job_cancel_request = 4;
+    JobCompletionAckReply payload_job_completion_ack_reply = 5;
     TaskIOForwardReadyReply payload_task_io_forward_ready_reply = 6;
     TaskIOForwardReply payload_task_io_forward_reply = 7;
     TaskX11ForwardReply payload_task_x11_forward_reply = 8;
@@ -1284,11 +1284,11 @@ message QueryJobSizeSummaryReply {
 //  and have some kind of authentication
 service CraneCtld {
   /* RPCs called from ccancel */
-  rpc CancelTask(CancelTaskRequest) returns (CancelTaskReply);
+  rpc CancelJob(CancelJobRequest) returns (CancelJobReply);
 
   /* RPCs called from cbatch */
-  rpc SubmitBatchTask(SubmitBatchTaskRequest) returns (SubmitBatchTaskReply);
-  rpc SubmitBatchTasks(SubmitBatchTasksRequest) returns (SubmitBatchTasksReply);
+  rpc SubmitBatchJob(SubmitBatchJobRequest) returns (SubmitBatchJobReply);
+  rpc SubmitBatchJobs(SubmitBatchJobsRequest) returns (SubmitBatchJobsReply);
   rpc SubmitContainerStep(SubmitContainerStepRequest) returns (SubmitContainerStepReply);
 
   /* PRCs called from ccontrol */
@@ -1296,14 +1296,14 @@ service CraneCtld {
   rpc QueryPartitionInfo(QueryPartitionInfoRequest) returns (QueryPartitionInfoReply);
   rpc QueryReservationInfo(QueryReservationInfoRequest) returns (QueryReservationInfoReply);
   rpc QueryLicensesInfo(QueryLicensesInfoRequest) returns (QueryLicensesInfoReply);
-  rpc ModifyTask(ModifyTaskRequest) returns (ModifyTaskReply);
+  rpc ModifyJob(ModifyJobRequest) returns (ModifyJobReply);
   rpc ModifyNode(ModifyCranedStateRequest) returns (ModifyCranedStateReply);
   rpc ModifyPartitionAcl(ModifyPartitionAclRequest) returns (ModifyPartitionAclReply);
   rpc EnableAutoPowerControl(EnableAutoPowerControlRequest) returns (EnableAutoPowerControlReply);
-  rpc ModifyTasksExtraAttrs(ModifyTasksExtraAttrsRequest) returns (ModifyTasksExtraAttrsReply);
-  rpc ResetNextTaskId(ResetNextTaskIdRequest) returns (ResetNextTaskIdReply);
+  rpc ModifyJobsExtraAttrs(ModifyJobsExtraAttrsRequest) returns (ModifyJobsExtraAttrsReply);
+  rpc ResetNextJobId(ResetNextJobIdRequest) returns (ResetNextJobIdReply);
   rpc ResetNextStepDbId(ResetNextStepDbIdRequest) returns (ResetNextStepDbIdReply);
-  rpc PurgeTaskHistory(PurgeTaskHistoryRequest) returns (PurgeTaskHistoryReply);
+  rpc PurgeJobHistory(PurgeJobHistoryRequest) returns (PurgeJobHistoryReply);
 
   /* RPCs called from cacctmgr */
   rpc AddAccount(AddAccountRequest) returns (AddAccountReply);
@@ -1340,7 +1340,7 @@ service CraneCtld {
   rpc QueryClusterInfo(QueryClusterInfoRequest) returns (QueryClusterInfoReply);
 
   /* common RPCs */
-  rpc QueryTasksInfo(QueryTasksInfoRequest) returns (QueryTasksInfoReply);
+  rpc QueryJobsInfo(QueryJobsInfoRequest) returns (QueryJobsInfoReply);
   rpc CreateReservation(CreateReservationRequest) returns (CreateReservationReply);
   rpc DeleteReservation(DeleteReservationRequest) returns (DeleteReservationReply);
   rpc ResetPartitionAcl(ResetPartitionAclRequest) returns (ResetPartitionAclReply);
@@ -1360,7 +1360,7 @@ service CraneCtld {
 }
 
 service PluginQueryService {
-  rpc QueryTaskEfficiency(QueryTaskEfficiencyRequest) returns (QueryTaskEfficiencyReply);
+  rpc QueryJobEfficiency(QueryJobEfficiencyRequest) returns (QueryJobEfficiencyReply);
   rpc QueryNodeEvents(QueryNodeEventsRequest) returns (QueryNodeEventsReply);
 }
 
@@ -1388,10 +1388,10 @@ service Craned {
   rpc FreeSteps(FreeStepsRequest) returns (FreeStepsReply);
   rpc FreeJobs(FreeJobsRequest) returns (FreeJobsReply);
   /*
-  If the task is an interactive task, the resource uuid is also revoked.
-   If there's no process in this interactive task, just deallocate all the resources.
-   If there are processes in this interactive task, kill all the processes and deallocate resources.
-  If the task is a batch task, just kill it.
+  If the job is an interactive job, the resource uuid is also revoked.
+   If there's no process in this interactive job, just deallocate all the resources.
+   If there are processes in this interactive job, kill all the processes and deallocate resources.
+  If the job is a batch job, just kill it.
   */
   rpc TerminateSteps(TerminateStepsRequest) returns (TerminateStepsReply);
   rpc TerminateOrphanedStep(TerminateOrphanedStepRequest) returns (TerminateOrphanedStepReply);

--- a/protos/Plugin.proto
+++ b/protos/Plugin.proto
@@ -25,35 +25,35 @@ import "PublicDefs.proto";
 import "google/protobuf/timestamp.proto";
 
 message StartHookRequest {
-  repeated TaskInfo task_info_list = 1;
+  repeated JobInfo job_info_list = 1;
 }
 
 message StartHookReply {
-  message TaskIdReply {
+  message JobIdReply {
     bool ok = 1;
-    uint32 task_id = 2;
+    uint32 job_id = 2;
     string failure_reason = 3;
   }
 
-  repeated TaskIdReply result = 1;
+  repeated JobIdReply result = 1;
 }
 
 message EndHookRequest {
-  repeated TaskInfo task_info_list = 1;
+  repeated JobInfo job_info_list = 1;
 }
 
 message EndHookReply {
-  message TaskIdReply {
+  message JobIdReply {
     bool ok = 1;
-    uint32 task_id = 2;
+    uint32 job_id = 2;
     string failure_reason = 3;
   }
 
-  repeated TaskIdReply result = 1;
+  repeated JobIdReply result = 1;
 }
 
 message CreateCgroupHookRequest {
-  uint32 task_id = 1;
+  uint32 job_id = 1;
   string cgroup = 2;
   ResourceInNode resource = 3;
 }
@@ -63,7 +63,7 @@ message CreateCgroupHookReply {
 }
 
 message DestroyCgroupHookRequest {
-  uint32 task_id = 1;
+  uint32 job_id = 1;
   string cgroup = 2;
 }
 

--- a/protos/PublicDefs.proto
+++ b/protos/PublicDefs.proto
@@ -106,7 +106,7 @@ enum CranedControlState {
   CRANE_UNREGISTER_POWER = 6;
 }
 
-enum TaskStatus {
+enum JobStatus {
   Pending = 0;
   Running = 1;
   Completed = 2;
@@ -121,13 +121,13 @@ enum TaskStatus {
   Invalid = 15;
 }
 
-enum TaskType {
+enum JobType {
   Interactive = 0;
   Batch = 1;
   Container = 2;
 }
 
-enum InteractiveTaskType {
+enum InteractiveJobType {
   Calloc = 0;
   Crun = 1;
 }
@@ -174,13 +174,13 @@ message Signal {
   SignalFlag signal_flag = 3;
 }
 
-message TaskToCtld {
+message JobToCtld {
   /* -------- Fields that are set at the submission time. ------- */
   google.protobuf.Duration time_limit = 1;
 
   string partition_name = 2;
 
-  TaskType type = 4;
+  JobType type = 4;
 
   uint32 uid = 5;
   string account = 6;
@@ -198,15 +198,15 @@ message TaskToCtld {
   Dependencies dependencies = 15;
 
   oneof payload {
-    BatchTaskAdditionalMeta batch_meta = 21;
-    InteractiveTaskAdditionalMeta interactive_meta = 22;
+    BatchJobAdditionalMeta batch_meta = 21;
+    InteractiveJobAdditionalMeta interactive_meta = 22;
   }
 
   // cbatch --pod: Pod
   // ccon (standalone): Pod + Container
   // ccon (nested): Container (StepToCtld only)
-  optional PodTaskAdditionalMeta pod_meta = 23;
-  optional ContainerTaskAdditionalMeta container_meta = 24;
+  optional PodJobAdditionalMeta pod_meta = 23;
+  optional ContainerJobAdditionalMeta container_meta = 24;
 
   string extra_attr = 30;
 
@@ -242,21 +242,21 @@ message TaskToCtld {
   optional DeviceMap gres_per_node = 52;
 }
 
-message TaskInEmbeddedDb {
-  RuntimeAttrOfTask runtime_attr = 1;
-  TaskToCtld task_to_ctld = 2;
+message JobInEmbeddedDb {
+  RuntimeAttrOfJob runtime_attr = 1;
+  JobToCtld job_to_ctld = 2;
 }
 
-message RuntimeAttrOfTask {
-  // Fields that won't change after this task is accepted.
-  uint32 task_id = 1;
-  int64 task_db_id = 3;
+message RuntimeAttrOfJob {
+  // Fields that won't change after this job is accepted.
+  uint32 job_id = 1;
+  int64 job_db_id = 3;
   string username = 5;
 
-  // Fields that will change after this task is accepted.
+  // Fields that will change after this job is accepted.
   int32 requeue_count = 11;
   repeated string craned_ids = 12;
-  TaskStatus status = 13;
+  JobStatus status = 13;
   uint32 exit_code = 14;
 
   google.protobuf.Timestamp submit_time = 15;
@@ -267,7 +267,7 @@ message RuntimeAttrOfTask {
   ResourceV2 allocated_res = 19;
   double cached_priority = 20;
 
-  TaskStatus primary_step_status = 21;
+  JobStatus primary_step_status = 21;
   uint32 primary_step_exit_code = 22;
   map<string, uint32> actual_licenses = 23;
 }
@@ -278,7 +278,7 @@ message StepToCtld {
   // account, qos from job
   uint32 job_id = 2;
 
-  TaskType type = 5;
+  JobType type = 5;
   uint32 uid = 6;  // Only for authorization
   string name = 7;
 
@@ -293,12 +293,12 @@ message StepToCtld {
   uint32 ntasks = 15;
 
   oneof payload {
-    BatchTaskAdditionalMeta batch_meta = 21;
-    InteractiveTaskAdditionalMeta interactive_meta = 22;
+    BatchJobAdditionalMeta batch_meta = 21;
+    InteractiveJobAdditionalMeta interactive_meta = 22;
   }
 
   // Step <-> Container
-  optional ContainerTaskAdditionalMeta container_meta = 24;
+  optional ContainerJobAdditionalMeta container_meta = 24;
 
   string task_prolog = 27;
   string task_epilog = 28;
@@ -337,8 +337,8 @@ message RuntimeAttrOfStep {
   google.protobuf.Timestamp start_time = 26;
   google.protobuf.Timestamp end_time = 27;
 
-  TaskStatus error_status = 30;
-  TaskStatus status = 31;
+  JobStatus error_status = 30;
+  JobStatus status = 31;
   uint32 error_exit_code = 32;
   uint32 exit_code = 33;
 
@@ -378,7 +378,7 @@ message StepToD {
   uint32 job_id = 1;
   uint32 step_id = 2;
   ResourceInNode res = 3;
-  TaskType type = 4;
+  JobType type = 4;
   StepType step_type = 5;
 
   uint32 uid = 6;
@@ -386,14 +386,14 @@ message StepToD {
   map<uint32 /*task id*/, ResourceInNode> task_res_map = 8;
 
   // For execution step
-  optional BatchTaskAdditionalMeta batch_meta = 9;
-  optional InteractiveTaskAdditionalMeta interactive_meta = 10;
-  optional PodTaskAdditionalMeta pod_meta = 11;
-  optional ContainerTaskAdditionalMeta container_meta = 12;
+  optional BatchJobAdditionalMeta batch_meta = 9;
+  optional InteractiveJobAdditionalMeta interactive_meta = 10;
+  optional PodJobAdditionalMeta pod_meta = 11;
+  optional ContainerJobAdditionalMeta container_meta = 12;
 
-  // If this task is PENDING, start_time is either not set (default constructed)
+  // If this step is PENDING, start_time is either not set (default constructed)
   // or an estimated start time.
-  // If this task is RUNNING, start_time is the actual starting time.
+  // If this step is RUNNING, start_time is the actual starting time.
   google.protobuf.Timestamp start_time = 14;   // Currently Only used in CraneCtld
   google.protobuf.Timestamp submit_time = 15;  // Currently Only used in CraneCtld
   google.protobuf.Duration time_limit = 16;
@@ -425,14 +425,14 @@ message StepToD {
 message JobStepsToD {
   JobToD job = 1;
   map<uint32, StepToD> steps = 2;
-  map<uint32, TaskStatus> step_status = 3;
+  map<uint32, JobStatus> step_status = 3;
 }
 
 message JobStepIds {
   repeated uint32 steps = 1;
 }
 
-message BatchTaskAdditionalMeta {
+message BatchJobAdditionalMeta {
   string sh_script = 1;
   optional bool open_mode_append = 2;
   string output_file_pattern = 3;
@@ -448,22 +448,22 @@ message X11Meta {
   bool enable_forwarding = 4;
 }
 
-message InteractiveTaskAdditionalMeta {
+message InteractiveJobAdditionalMeta {
   string cfored_name = 1;
   string sh_script = 2;
   string term_env = 3;
-  InteractiveTaskType interactive_type = 4;
+  InteractiveJobType interactive_type = 4;
 
   bool pty = 5;
 
   bool x11 = 6;
   X11Meta x11_meta = 7;
 
-  // Crun input will forward to these tasks
+  // Task ID to forward crun input to
   optional uint32 input_task_id = 8;
 }
 
-message PodTaskAdditionalMeta {
+message PodJobAdditionalMeta {
   string name = 1;  // Pod name, will use to generate hostname
 
   map<string, string> labels = 2;
@@ -514,7 +514,7 @@ message PodTaskAdditionalMeta {
   repeated string dns_servers = 12;
 }
 
-message ContainerTaskAdditionalMeta {
+message ContainerJobAdditionalMeta {
   string name = 1;
   map<string, string> labels = 2;
   map<string, string> annotations = 3;
@@ -546,10 +546,10 @@ message ContainerTaskAdditionalMeta {
   repeated string cdi_devices = 25;
 }
 
-message TaskInfo {
-  // Static task information
-  TaskType type = 1;
-  uint32 task_id = 2;
+message JobInfo {
+  // Static job information
+  JobType type = 1;
+  uint32 job_id = 2;
   string name = 3;
   string partition = 4;
 
@@ -575,16 +575,16 @@ message TaskInfo {
   string extra_attr = 21;
   string reservation = 22;
 
-  // This is only used when querying Container tasks.
-  // For other types of tasks, this field is ignored.
-  optional PodTaskAdditionalMeta pod_meta = 23;
+  // This is only used when querying Container jobs.
+  // For other types of jobs, this field is ignored.
+  optional PodJobAdditionalMeta pod_meta = 23;
   repeated StepInfo step_info_list = 24;
   /* 25-28 Reserved */
 
-  // Dynamic task information
+  // Dynamic job information
   optional DependencyStatus dependency_status = 29;
   bool held = 30;
-  TaskStatus status = 31;
+  JobStatus status = 31;
 
   uint32 exit_code = 33;
   uint32 priority = 34;
@@ -596,7 +596,7 @@ message TaskInfo {
   // The time of different nodes across the whole cluster might not always be synchronized.
   // If the time on the front end node is more than several seconds ahead of the CraneCtld node,
   // a negative elapsed time might occur.
-  // To avoid this, the elapsed time of a task is calculated on the CraneCtld side.
+  // To avoid this, the elapsed time of a job is calculated on the CraneCtld side.
   google.protobuf.Duration elapsed_time = 37;
   repeated string execution_node = 38;
   bool exclusive = 39;
@@ -609,7 +609,7 @@ message TaskInfo {
 
 message StepInfo {
   // Static step information
-  TaskType type = 1;
+  JobType type = 1;
   StepType step_type = 2;
   uint32 job_id = 3;
   uint32 step_id = 4;
@@ -633,12 +633,12 @@ message StepInfo {
 
   string extra_attr = 21;
 
-  optional ContainerTaskAdditionalMeta container_meta = 23;
+  optional ContainerJobAdditionalMeta container_meta = 23;
   /* 24-29 Reserved */
 
   // Dynamic step information
   bool held = 30;
-  TaskStatus status = 31;
+  JobStatus status = 31;
 
   uint32 exit_code = 33;
   string craned_list = 36;
@@ -646,7 +646,7 @@ message StepInfo {
   // The time of different nodes across the whole cluster might not always be synchronized.
   // If the time on the front end node is more than several seconds ahead of the CraneCtld node,
   // a negative elapsed time might occur.
-  // To avoid this, the elapsed time of a task is calculated on the CraneCtld side.
+  // To avoid this, the elapsed time of a step is calculated on the CraneCtld side.
   google.protobuf.Duration elapsed_time = 37;
   repeated string execution_node = 38;
   ResourceView allocated_res_view = 40;
@@ -684,7 +684,7 @@ message CranedInfo {
   ResourceInNode res_alloc = 7;
 
   repeated string partition_names = 10;
-  uint32 running_task_num = 11;
+  uint32 running_job_num = 11;
 
   string craned_version = 12;
   string system_desc = 13;
@@ -792,8 +792,8 @@ enum ErrCode {
   ERR_NO_ENOUGH_NODE = 48;
   ERR_SYSTEM_ERR = 49;
 
-  ERR_EXISTING_TASK = 50;
-  ERR_BEYOND_TASK_ID = 51;
+  ERR_EXISTING_JOB = 50;
+  ERR_BEYOND_JOB_ID = 51;
   ERR_INVALID_PARAM = 52;
   ERR_STOP = 53;
   ERR_PERMISSION_DENIED = 54;
@@ -850,14 +850,14 @@ enum ErrCode {
 
   ERR_RESOURCE_ALREADY_EXIST = 96;
   ERR_MAX_JOB_COUNT_PER_ACCOUNT = 97;
-  ERR_USER_HAS_TASK = 98;
+  ERR_USER_HAS_JOB = 98;
   ERR_INVALID_RESOURCE = 99;
   ERR_QOS_JOB_COUNT_EXCEEDED = 100;
 
   ERR_CONVERT_TO_RESOURCE_VIEW = 101;
   ERR_MAX_TRES_PER_USER_BEYOND = 102;
   ERR_MAX_TRES_PER_ACCOUNT_BEYOND = 103;
-  ERR_TRES_PER_TASK_BEYOND = 104;
+  ERR_TRES_PER_JOB_BEYOND = 104;
 }
 
 enum EntityType {
@@ -884,7 +884,7 @@ enum ModifyField {
   Priority = 6;
   MaxJobsPerUser = 7;
   MaxCpusPerUser = 8;
-  MaxTimeLimitPerTask = 9;
+  MaxTimeLimitPerJob = 9;
   MaxJobsPerAccount = 10;
   MaxSubmitJobsPerUser = 11;
   MaxSubmitJobsPerAccount = 12;
@@ -950,7 +950,7 @@ message QosInfo {
   uint32 priority = 3;
   uint32 max_jobs_per_user = 4;
   uint32 max_cpus_per_user = 5;
-  uint64 max_time_limit_per_task = 6;
+  uint64 max_time_limit_per_job = 6;
   uint32 max_jobs_per_account = 7;
   uint32 max_submit_jobs_per_user = 8;
   uint32 max_submit_jobs_per_account = 9;

--- a/protos/Supervisor.proto
+++ b/protos/Supervisor.proto
@@ -115,9 +115,9 @@ message SupervisorReady {
   bool ok = 1;
 }
 
-message TaskExecutionRequest {}
+message StepExecutionRequest {}
 
-message TaskExecutionReply {
+message StepExecutionReply {
   ErrCode code = 1;
 }
 
@@ -134,24 +134,24 @@ message CheckStatusReply {
   uint32 job_id = 1;
   uint32 step_id = 2;
   int32 supervisor_pid = 3;
-  TaskStatus status = 4;
+  JobStatus status = 4;
   bool ok = 5;
 }
 
-message ChangeTaskTimeLimitRequest {
+message ChangeStepTimeLimitRequest {
   int64 time_limit_seconds = 1;
 }
 
-message ChangeTaskTimeLimitReply {
+message ChangeStepTimeLimitReply {
   bool ok = 1;
 }
 
-message TerminateTaskRequest {
+message TerminateStepRequest {
   bool mark_orphaned = 1;
   bool terminated_by_user = 2;
 }
 
-message TerminateTaskReply {
+message TerminateStepReply {
   bool ok = 1;
   string reason = 2;
 }
@@ -169,11 +169,11 @@ message ShutdownSupervisorRequest {}
 message ShutdownSupervisorReply {}
 
 service Supervisor {
-  rpc ExecuteTask(TaskExecutionRequest) returns (TaskExecutionReply);
+  rpc ExecuteStep(StepExecutionRequest) returns (StepExecutionReply);
   rpc QueryEnvMap(QueryStepEnvRequest) returns (QueryStepEnvReply);
   rpc CheckStatus(CheckStatusRequest) returns (CheckStatusReply);
-  rpc ChangeTaskTimeLimit(ChangeTaskTimeLimitRequest) returns (ChangeTaskTimeLimitReply);
-  rpc TerminateTask(TerminateTaskRequest) returns (TerminateTaskReply);
+  rpc ChangeStepTimeLimit(ChangeStepTimeLimitRequest) returns (ChangeStepTimeLimitReply);
+  rpc TerminateStep(TerminateStepRequest) returns (TerminateStepReply);
   rpc MigrateSshProcToCgroup(MigrateSshProcToCgroupRequest) returns (MigrateSshProcToCgroupReply);
   rpc ShutdownSupervisor(ShutdownSupervisorRequest) returns (ShutdownSupervisorReply);
 }

--- a/scripts/migrate_db.py
+++ b/scripts/migrate_db.py
@@ -34,7 +34,7 @@ logger = logging.getLogger()
 # Suppress overly verbose logs from pymongo
 logging.getLogger("pymongo").setLevel(logging.INFO)
 
-TASK_COLLECTION = "task_table"
+JOB_COLLECTION = "job_table"
 
 
 # ======================== Migration Registry ========================
@@ -93,7 +93,7 @@ def migrate_has_job_info(db: pymongo.database.Database, dry_run: bool = False):
     'account' field, which is always present in records created by InsertJob
     or InsertRecoveredJob.
     """
-    collection = db[TASK_COLLECTION]
+    collection = db[JOB_COLLECTION]
 
     query = {
         "has_job_info": {"$exists": False},
@@ -131,7 +131,7 @@ def migrate_has_job_info(db: pymongo.database.Database, dry_run: bool = False):
 )
 def migrate_exclusive(db: pymongo.database.Database, dry_run: bool = False):
     """Add 'exclusive: false' to task records missing this field."""
-    collection = db[TASK_COLLECTION]
+    collection = db[JOB_COLLECTION]
     query = {"exclusive": {"$exists": False}}
     count = collection.count_documents(query)
     logger.info(f"[add_exclusive] Found {count} record(s) missing 'exclusive' field.")
@@ -156,7 +156,7 @@ def migrate_cpus_mem_alloc(db: pymongo.database.Database, dry_run: bool = False)
     Add 'cpus_alloc' and 'mem_alloc' to task records missing these fields.
     Values are copied from cpus_req and mem_req respectively.
     """
-    collection = db[TASK_COLLECTION]
+    collection = db[JOB_COLLECTION]
     query = {
         "$or": [
             {"cpus_alloc": {"$exists": False}},
@@ -192,7 +192,7 @@ def migrate_cpus_mem_alloc(db: pymongo.database.Database, dry_run: bool = False)
 )
 def migrate_device_map(db: pymongo.database.Database, dry_run: bool = False):
     """Add 'device_map: {}' to task records missing this field."""
-    collection = db[TASK_COLLECTION]
+    collection = db[JOB_COLLECTION]
     query = {"device_map": {"$exists": False}}
     count = collection.count_documents(query)
     logger.info(f"[add_device_map] Found {count} record(s) missing 'device_map'.")
@@ -214,7 +214,7 @@ def migrate_device_map(db: pymongo.database.Database, dry_run: bool = False):
 )
 def migrate_wckey_fields(db: pymongo.database.Database, dry_run: bool = False):
     """Add 'wckey: ""' and 'using_default_wckey: false' to records missing them."""
-    collection = db[TASK_COLLECTION]
+    collection = db[JOB_COLLECTION]
     query = {
         "$or": [
             {"wckey": {"$exists": False}},
@@ -249,7 +249,7 @@ def migrate_wckey_fields(db: pymongo.database.Database, dry_run: bool = False):
 )
 def migrate_licenses_alloc(db: pymongo.database.Database, dry_run: bool = False):
     """Add 'licenses_alloc: {}' to task records missing this field."""
-    collection = db[TASK_COLLECTION]
+    collection = db[JOB_COLLECTION]
     query = {"licenses_alloc": {"$exists": False}}
     count = collection.count_documents(query)
     logger.info(f"[add_licenses_alloc] Found {count} record(s) missing 'licenses_alloc'.")
@@ -271,7 +271,7 @@ def migrate_licenses_alloc(db: pymongo.database.Database, dry_run: bool = False)
 )
 def migrate_nodename_list(db: pymongo.database.Database, dry_run: bool = False):
     """Add 'nodename_list: []' to task records missing this field."""
-    collection = db[TASK_COLLECTION]
+    collection = db[JOB_COLLECTION]
     query = {"nodename_list": {"$exists": False}}
     count = collection.count_documents(query)
     logger.info(f"[add_nodename_list] Found {count} record(s) missing 'nodename_list'.")
@@ -293,7 +293,7 @@ def migrate_nodename_list(db: pymongo.database.Database, dry_run: bool = False):
 )
 def migrate_cluster(db: pymongo.database.Database, dry_run: bool = False):
     """Add 'cluster: ""' to task records missing this field."""
-    collection = db[TASK_COLLECTION]
+    collection = db[JOB_COLLECTION]
     query = {"cluster": {"$exists": False}}
     count = collection.count_documents(query)
     logger.info(f"[add_cluster] Found {count} record(s) missing 'cluster' field.")

--- a/scripts/wipe_data.py
+++ b/scripts/wipe_data.py
@@ -19,7 +19,7 @@ logging.getLogger("pymongo").setLevel(logging.INFO)
 class Collection(Enum):
     ACCT = "acct_table"
     QOS = "qos_table"
-    TASK = "task_table"
+    JOB = "job_table"
     USER = "user_table"
     WCKEY = "wckey_table"
     RESOURCE = "license_resource_table"
@@ -170,10 +170,10 @@ def parse_arguments():
         help="Include qos_table in MongoDB wipe.",
     )
     parser.add_argument(
-        "-t",
-        "--task_table",
+        "-j",
+        "--job_table",
         action="store_true",
-        help="Include task_table in MongoDB wipe.",
+        help="Include job_table in MongoDB wipe.",
     )
     parser.add_argument(
         "-u",
@@ -237,11 +237,11 @@ def _main():
     if args.mode in ["mongo", "all"]:
         db = connect_to_mongo(username, password, host, port, dbname)
         to_wipe = []
-        if not any([args.acct_table, args.qos_table, args.task_table, args.user_table, args.wckey_table, args.resource_table]):
+        if not any([args.acct_table, args.qos_table, args.job_table, args.user_table, args.wckey_table, args.resource_table]):
             to_wipe = [
                 Collection.ACCT,
                 Collection.QOS,
-                Collection.TASK,
+                Collection.JOB,
                 Collection.USER,
                 Collection.WCKEY,
                 Collection.RESOURCE,
@@ -255,8 +255,8 @@ def _main():
                 to_wipe.append(Collection.ACCT)
             if args.qos_table:
                 to_wipe.append(Collection.QOS)
-            if args.task_table:
-                to_wipe.append(Collection.TASK)
+            if args.job_table:
+                to_wipe.append(Collection.JOB)
             if args.user_table:
                 to_wipe.append(Collection.USER)
             if args.wckey_table:

--- a/scripts/wipe_data.sh
+++ b/scripts/wipe_data.sh
@@ -2,7 +2,7 @@
 
 echo "Usage: $0 \
 mode(1:acct_table | 2:qos_table | \
-3:task_table | 4:user_table+wckey_table | \
+3:job_table | 4:user_table+wckey_table | \
 5:all | 6:acct_table+qos_table+user_table+wckey_table | \
 7:license_resource_table | \
 8:hour_table+day_table+month_table |9: summary_time_table)"
@@ -43,7 +43,7 @@ if [ "$mode" -eq 2 ] || [ "$mode" -eq 5 ] || [ "$mode" -eq 6 ]; then
   wipe_collection qos_table
 fi
 if [ "$mode" -eq 3 ] || [ "$mode" -eq 5 ]; then
-  wipe_collection task_table
+  wipe_collection job_table
 
   # Get the directory and filename of the embedded database
   db_dir=$(dirname "$embedded_db_path")

--- a/src/CraneCtld/AccountManager.cpp
+++ b/src/CraneCtld/AccountManager.cpp
@@ -229,8 +229,8 @@ CraneExpectedRich<void> AccountManager::DeleteUser(uint32_t uid,
         FormatRichErr(CraneErrCode::ERR_USER_ACCOUNT_MISMATCH,
                       fmt::format("user: {}, account: {}", name, account))};
 
-  if (g_account_meta_container->UserHasTask(user->name))
-    return std::unexpected(FormatRichErr(CraneErrCode::ERR_USER_HAS_TASK,
+  if (g_account_meta_container->UserHasJob(user->name))
+    return std::unexpected(FormatRichErr(CraneErrCode::ERR_USER_HAS_JOB,
                                          fmt::format("user: {}", name)));
 
   return DeleteUser_(op_user->name, *user, account);
@@ -1258,7 +1258,7 @@ std::vector<CraneExpectedRich<void>> AccountManager::ModifyQos(
             FormatRichErr(CraneErrCode::ERR_CONVERT_TO_INTEGER, value)});
       }
 
-      if (item == Qos::FieldStringOfMaxTimeLimitPerTask() &&
+      if (item == Qos::FieldStringOfMaxTimeLimitPerJob() &&
           !CheckIfTimeLimitSecIsValid(value_number)) {
         rich_error_list.emplace_back(std::unexpected{
             FormatRichErr(CraneErrCode::ERR_TIME_LIMIT, value)});
@@ -1371,11 +1371,11 @@ std::vector<CraneExpectedRich<void>> AccountManager::ModifyQos(
       log += fmt::format("max_wall: {}\n", value);
       break;
     }
-    case crane::grpc::ModifyField::MaxTimeLimitPerTask: {
+    case crane::grpc::ModifyField::MaxTimeLimitPerJob: {
       int64_t value_number;
       util::ConvertStringToInt64(value, &value_number);
-      res_qos.max_time_limit_per_task = absl::Seconds(value_number);
-      log += fmt::format("max_time_limit_per_task: {}\n", value);
+      res_qos.max_time_limit_per_job = absl::Seconds(value_number);
+      log += fmt::format("max_time_limit_per_job: {}\n", value);
       break;
     }
     case crane::grpc::ModifyField::Flags: {
@@ -1539,16 +1539,16 @@ CraneExpected<void> AccountManager::CheckIfUserOfAccountIsEnabled(
   return {};
 }
 
-CraneExpected<void> AccountManager::CheckQosLimitOnTask(
-    const std::string& user, const std::string& account, TaskInCtld* task) {
+CraneExpected<void> AccountManager::CheckQosLimitOnJob(
+    const std::string& user, const std::string& account, JobInCtld* job) {
   util::read_lock_guard user_guard(m_rw_user_mutex_);
 
   {
-    task->account_chain.clear();
+    job->account_chain.clear();
     const auto account_map_ptr = g_account_manager->GetAllAccountInfo();
-    std::string account_name = task->account;
+    std::string account_name = job->account;
     do {
-      task->account_chain.emplace_back(account_name);
+      job->account_chain.emplace_back(account_name);
       account_name = account_map_ptr->at(account_name)->parent_account;
     } while (!account_name.empty());
   }
@@ -1557,47 +1557,47 @@ CraneExpected<void> AccountManager::CheckQosLimitOnTask(
   if (!user_share_ptr) {
     CRANE_ERROR(
         "The current user {} is not in the user list when submitting the "
-        "task",
+        "job",
         user);
     return std::unexpected(CraneErrCode::ERR_INVALID_OP_USER);
   }
 
-  if (task->uid != 0) {
+  if (job->uid != 0) {
     auto partition_it = user_share_ptr->account_to_attrs_map.at(account)
-                            .allowed_partition_qos_map.find(task->partition_id);
+                            .allowed_partition_qos_map.find(job->partition_id);
     if (partition_it == user_share_ptr->account_to_attrs_map.at(account)
                             .allowed_partition_qos_map.end()) {
       CRANE_ERROR(
           "This user {} does not have partition {} permission when "
           "submitting "
-          "the task",
-          user, task->partition_id);
+          "the job",
+          user, job->partition_id);
       return std::unexpected(CraneErrCode::ERR_PARTITION_MISSING);
     }
-    if (task->qos.empty()) {
+    if (job->qos.empty()) {
       // Default qos
-      task->qos = partition_it->second.first;
-      if (task->qos.empty()) {
+      job->qos = partition_it->second.first;
+      if (job->qos.empty()) {
         CRANE_ERROR(
             "The user '{}' has no QOS available for this partition '{}' to "
             "be "
             "used",
-            task->Username(), task->partition_id);
+            job->Username(), job->partition_id);
         return std::unexpected(CraneErrCode::ERR_HAS_NO_QOS_IN_PARTITION);
       }
     } else {
-      // Check whether task.qos in the qos list
-      if (!ranges::contains(partition_it->second.second, task->qos)) {
+      // Check whether job.qos in the qos list
+      if (!ranges::contains(partition_it->second.second, job->qos)) {
         CRANE_ERROR(
             "The set qos '{}' is not in partition's allowed qos list when "
-            "submitting the task",
-            task->qos);
+            "submitting the job",
+            job->qos);
         return std::unexpected(CraneErrCode::ERR_HAS_ALLOWED_QOS_IN_PARTITION);
       }
     }
   } else {
-    if (task->qos.empty()) {
-      task->qos = kUnlimitedQosName;
+    if (job->qos.empty()) {
+      job->qos = kUnlimitedQosName;
     }
   }
   return {};

--- a/src/CraneCtld/AccountManager.h
+++ b/src/CraneCtld/AccountManager.h
@@ -153,8 +153,8 @@ class AccountManager {
                                                     const std::string& account);
 
   CraneExpected<void> CheckQosLimitOnJob(const std::string& user,
-                                          const std::string& account,
-                                          JobInCtld* job);
+                                         const std::string& account,
+                                         JobInCtld* job);
 
   CraneExpected<std::string> CheckUidIsAdmin(uint32_t uid);
 

--- a/src/CraneCtld/AccountManager.h
+++ b/src/CraneCtld/AccountManager.h
@@ -152,9 +152,9 @@ class AccountManager {
   CraneExpected<void> CheckIfUserOfAccountIsEnabled(const std::string& user,
                                                     const std::string& account);
 
-  CraneExpected<void> CheckQosLimitOnTask(const std::string& user,
+  CraneExpected<void> CheckQosLimitOnJob(const std::string& user,
                                           const std::string& account,
-                                          TaskInCtld* task);
+                                          JobInCtld* job);
 
   CraneExpected<std::string> CheckUidIsAdmin(uint32_t uid);
 

--- a/src/CraneCtld/AccountMetaContainer.cpp
+++ b/src/CraneCtld/AccountMetaContainer.cpp
@@ -62,8 +62,7 @@ std::string MetaResource::DebugString() const {
       util::ReadableResourceView(resource));
 }
 
-CraneErrCode AccountMetaContainer::TryMallocQosSubmitResource(
-    JobInCtld& job) {
+CraneErrCode AccountMetaContainer::TryMallocQosSubmitResource(JobInCtld& job) {
   CraneErrCode result = CraneErrCode::SUCCESS;
 
   CRANE_TRACE(
@@ -133,8 +132,8 @@ void AccountMetaContainer::MallocQosSubmitResource(const JobInCtld& job) {
                              .jobs_count = 0,
                              .submit_jobs_count = 1,
                              .wall_time = absl::ZeroDuration()};
-  DoMallocResource_(job.JobId(), job.Username(), job.account_chain,
-                    job.qos, meta_resource);
+  DoMallocResource_(job.JobId(), job.Username(), job.account_chain, job.qos,
+                    meta_resource);
 }
 
 void AccountMetaContainer::MallocQosResourceToRecoveredRunningJob(
@@ -157,8 +156,8 @@ void AccountMetaContainer::MallocQosResourceToRecoveredRunningJob(
                              .submit_jobs_count = 1,
                              .wall_time = job.time_limit};
 
-  DoMallocResource_(job.JobId(), job.Username(), job.account_chain,
-                    job.qos, meta_resource);
+  DoMallocResource_(job.JobId(), job.Username(), job.account_chain, job.qos,
+                    meta_resource);
 }
 
 std::expected<void, std::string>

--- a/src/CraneCtld/AccountMetaContainer.cpp
+++ b/src/CraneCtld/AccountMetaContainer.cpp
@@ -21,7 +21,7 @@
 #include <absl/time/time.h>
 
 #include "AccountManager.h"
-#include "TaskScheduler.h"
+#include "JobScheduler.h"
 
 namespace Ctld {
 
@@ -63,20 +63,20 @@ std::string MetaResource::DebugString() const {
 }
 
 CraneErrCode AccountMetaContainer::TryMallocQosSubmitResource(
-    TaskInCtld& task) {
+    JobInCtld& job) {
   CraneErrCode result = CraneErrCode::SUCCESS;
 
   CRANE_TRACE(
       "TryMallocQosSubmitResource for job of user {} and account {}.....",
-      task.Username(), task.account);
+      job.Username(), job.account);
 
-  auto qos = g_account_manager->GetExistedQosInfo(task.qos);
+  auto qos = g_account_manager->GetExistedQosInfo(job.qos);
   if (!qos) {
-    CRANE_ERROR("Unknown QOS '{}'", task.qos);
+    CRANE_ERROR("Unknown QOS '{}'", job.qos);
     return CraneErrCode::ERR_INVALID_QOS;
   }
 
-  const ResourceView& resource_use = task.req_total_res_view;
+  const ResourceView& resource_use = job.req_total_res_view;
 
   if (qos->max_submit_jobs_per_user == 0)
     return CraneErrCode::ERR_MAX_JOB_COUNT_PER_USER;
@@ -93,72 +93,72 @@ CraneErrCode AccountMetaContainer::TryMallocQosSubmitResource(
   if (!CheckTres_(resource_use, qos->max_tres_per_user) ||
       !CheckTres_(resource_use, qos->max_tres_per_account) ||
       !CheckTres_(resource_use, qos->max_tres))
-    return CraneErrCode::ERR_TRES_PER_TASK_BEYOND;
+    return CraneErrCode::ERR_TRES_PER_JOB_BEYOND;
 
-  task.qos_priority = qos->priority;
+  job.qos_priority = qos->priority;
 
-  if (task.time_limit >= absl::Seconds(kTaskMaxTimeLimitSec)) {
-    task.time_limit = qos->max_time_limit_per_task;
-  } else if (task.time_limit > qos->max_time_limit_per_task) {
+  if (job.time_limit >= absl::Seconds(kJobMaxTimeLimitSec)) {
+    job.time_limit = qos->max_time_limit_per_job;
+  } else if (job.time_limit > qos->max_time_limit_per_job) {
     CRANE_TRACE("time-limit beyond the user's limit");
     return CraneErrCode::ERR_TIME_TIMIT_BEYOND;
   }
 
   // Lock the specified user/account/qos to minimize the impact on other users
   // and accounts.
-  std::scoped_lock user_lock(m_user_stripes_[StripeForKey_(task.Username())]);
-  auto account_locks = LockAccountStripes_(task.account_chain);
-  std::scoped_lock qos_lock(m_qos_stripes_[StripeForKey_(task.qos)]);
+  std::scoped_lock user_lock(m_user_stripes_[StripeForKey_(job.Username())]);
+  auto account_locks = LockAccountStripes_(job.account_chain);
+  std::scoped_lock qos_lock(m_qos_stripes_[StripeForKey_(job.qos)]);
 
-  result = CheckUserQosSubmitResourceUsage_(task, *qos);
+  result = CheckUserQosSubmitResourceUsage_(job, *qos);
   if (result != CraneErrCode::SUCCESS) return result;
 
-  result = CheckAccountQosSubmitResourceUsage_(task, *qos);
+  result = CheckAccountQosSubmitResourceUsage_(job, *qos);
   if (result != CraneErrCode::SUCCESS) return result;
 
-  result = CheckQosSubmitResourceUsage_(task, *qos);
+  result = CheckQosSubmitResourceUsage_(job, *qos);
   if (result != CraneErrCode::SUCCESS) return result;
 
-  MallocQosSubmitResource(task);
+  MallocQosSubmitResource(job);
 
   return result;
 }
 
-void AccountMetaContainer::MallocQosSubmitResource(const TaskInCtld& task) {
+void AccountMetaContainer::MallocQosSubmitResource(const JobInCtld& job) {
   CRANE_DEBUG(
       "Malloc QOS {} submit resource for job of user {} and account {}.",
-      task.qos, task.Username(), task.account);
+      job.qos, job.Username(), job.account);
 
   MetaResource meta_resource{.resource = ResourceView{},
                              .jobs_count = 0,
                              .submit_jobs_count = 1,
                              .wall_time = absl::ZeroDuration()};
-  DoMallocResource_(task.TaskId(), task.Username(), task.account_chain,
-                    task.qos, meta_resource);
+  DoMallocResource_(job.JobId(), job.Username(), job.account_chain,
+                    job.qos, meta_resource);
 }
 
-void AccountMetaContainer::MallocQosResourceToRecoveredRunningTask(
-    TaskInCtld& task) {
-  auto qos = g_account_manager->GetExistedQosInfo(task.qos);
+void AccountMetaContainer::MallocQosResourceToRecoveredRunningJob(
+    JobInCtld& job) {
+  auto qos = g_account_manager->GetExistedQosInfo(job.qos);
   // Under normal circumstances, QoS must exist.
   if (!qos) {
-    CRANE_ERROR("Try to malloc resource from an unknown qos {}", task.qos);
+    CRANE_ERROR("Try to malloc resource from an unknown qos {}", job.qos);
     return;
   }
 
   CRANE_DEBUG(
       "Malloc QOS {} resource for recover job {} of user {} and account {}.",
-      task.qos, task.TaskId(), task.Username(), task.account);
+      job.qos, job.JobId(), job.Username(), job.account);
 
-  g_account_meta_container->UserAddTask(task.Username());
+  g_account_meta_container->UserAddJob(job.Username());
 
-  MetaResource meta_resource{.resource = task.allocated_res_view,
+  MetaResource meta_resource{.resource = job.allocated_res_view,
                              .jobs_count = 1,
                              .submit_jobs_count = 1,
-                             .wall_time = task.time_limit};
+                             .wall_time = job.time_limit};
 
-  DoMallocResource_(task.TaskId(), task.Username(), task.account_chain,
-                    task.qos, meta_resource);
+  DoMallocResource_(job.JobId(), job.Username(), job.account_chain,
+                    job.qos, meta_resource);
 }
 
 std::expected<void, std::string>
@@ -191,43 +191,43 @@ AccountMetaContainer::CheckAndMallocQosResource(const PdJobInScheduler& job) {
   return {};
 }
 
-void AccountMetaContainer::FreeQosSubmitResource(const TaskInCtld& task) {
+void AccountMetaContainer::FreeQosSubmitResource(const JobInCtld& job) {
   CRANE_DEBUG(
       "Free QOS {} submit resource for job {} of user {} and account {}.",
-      task.qos, task.TaskId(), task.Username(), task.account);
+      job.qos, job.JobId(), job.Username(), job.account);
 
   MetaResource meta_resource{.resource = ResourceView{},
                              .jobs_count = 0,
                              .submit_jobs_count = 1,
                              .wall_time = absl::ZeroDuration()};
 
-  DoFreeResource_(task.TaskId(), task.Username(), task.account_chain, task.qos,
+  DoFreeResource_(job.JobId(), job.Username(), job.account_chain, job.qos,
                   meta_resource);
 }
 
-void AccountMetaContainer::FreeQosResource(const TaskInCtld& task) {
+void AccountMetaContainer::FreeQosResource(const JobInCtld& job) {
   CRANE_DEBUG("Free QOS {} resource for job {} of user {} and account {}.",
-              task.qos, task.TaskId(), task.Username(), task.account);
+              job.qos, job.JobId(), job.Username(), job.account);
 
-  MetaResource meta_resource{.resource = task.allocated_res_view,
+  MetaResource meta_resource{.resource = job.allocated_res_view,
                              .jobs_count = 1,
                              .submit_jobs_count = 1,
-                             .wall_time = task.time_limit};
+                             .wall_time = job.time_limit};
 
-  DoFreeResource_(task.TaskId(), task.Username(), task.account_chain, task.qos,
+  DoFreeResource_(job.JobId(), job.Username(), job.account_chain, job.qos,
                   meta_resource);
 }
 
-void AccountMetaContainer::UserAddTask(const std::string& username) {
-  m_user_to_task_map_.try_emplace_l(
+void AccountMetaContainer::UserAddJob(const std::string& username) {
+  m_user_to_job_map_.try_emplace_l(
       username,
       [&](std::pair<const std::string, uint32_t>& pair) { ++pair.second; }, 1);
 }
 
-void AccountMetaContainer::UserReduceTask(const std::string& username) {
+void AccountMetaContainer::UserReduceJob(const std::string& username) {
   bool is_contains = false;
 
-  m_user_to_task_map_.if_contains(
+  m_user_to_job_map_.if_contains(
       username, [&](std::pair<const std::string, uint32_t>& pair) {
         is_contains = true;
         if (pair.second == 0) {
@@ -238,13 +238,13 @@ void AccountMetaContainer::UserReduceTask(const std::string& username) {
       });
 
   if (!is_contains)
-    CRANE_ERROR("User '{}' not found in m_user_to_task_map_.", username);
+    CRANE_ERROR("User '{}' not found in m_user_to_job_map_.", username);
 }
 
-bool AccountMetaContainer::UserHasTask(const std::string& username) {
+bool AccountMetaContainer::UserHasJob(const std::string& username) {
   bool result = false;
 
-  m_user_to_task_map_.if_contains(
+  m_user_to_job_map_.if_contains(
       username, [&](std::pair<const std::string, uint32_t>& pair) {
         if (pair.second > 0) result = true;
       });
@@ -270,14 +270,14 @@ void AccountMetaContainer::DeleteQosMeta(const std::string& qos) {
  */
 
 CraneErrCode AccountMetaContainer::CheckUserQosSubmitResourceUsage_(
-    const TaskInCtld& task, const Qos& qos) {
+    const JobInCtld& job, const Qos& qos) {
   auto result = CraneErrCode::SUCCESS;
 
   m_user_meta_map_.if_contains(
-      task.Username(),
+      job.Username(),
       [&](std::pair<const std::string, QosToResourceMap>& pair) {
         auto& qos_to_resource_map = pair.second;
-        auto iter = qos_to_resource_map.find(task.qos);
+        auto iter = qos_to_resource_map.find(job.qos);
         if (iter == qos_to_resource_map.end()) return;
 
         auto& val = iter->second;
@@ -292,7 +292,7 @@ CraneErrCode AccountMetaContainer::CheckUserQosSubmitResourceUsage_(
             result = CraneErrCode::ERR_MAX_JOB_COUNT_PER_USER;
             return;
           }
-          ResourceView resource_use{task.req_total_res_view};
+          ResourceView resource_use{job.req_total_res_view};
           resource_use += val.resource;
           // Compatible with the max_cpu_per_user parameter.
           if (resource_use.CpuCount() > qos.max_cpus_per_user) {
@@ -310,15 +310,15 @@ CraneErrCode AccountMetaContainer::CheckUserQosSubmitResourceUsage_(
 }
 
 CraneErrCode AccountMetaContainer::CheckAccountQosSubmitResourceUsage_(
-    const TaskInCtld& task, const Qos& qos) {
+    const JobInCtld& job, const Qos& qos) {
   auto result = CraneErrCode::SUCCESS;
 
-  for (const auto& account_name : task.account_chain) {
+  for (const auto& account_name : job.account_chain) {
     m_account_meta_map_.if_contains(
         account_name,
         [&](std::pair<const std::string, QosToResourceMap>& pair) {
           auto& qos_to_resource_map = pair.second;
-          auto iter = qos_to_resource_map.find(task.qos);
+          auto iter = qos_to_resource_map.find(job.qos);
           if (iter == qos_to_resource_map.end()) return;
 
           auto& val = iter->second;
@@ -333,7 +333,7 @@ CraneErrCode AccountMetaContainer::CheckAccountQosSubmitResourceUsage_(
               result = CraneErrCode::ERR_MAX_JOB_COUNT_PER_ACCOUNT;
               return;
             }
-            ResourceView resource_use{task.req_total_res_view};
+            ResourceView resource_use{job.req_total_res_view};
             resource_use += val.resource;
             if (!CheckTres_(resource_use, qos.max_tres_per_account)) {
               result = CraneErrCode::ERR_MAX_TRES_PER_ACCOUNT_BEYOND;
@@ -347,10 +347,10 @@ CraneErrCode AccountMetaContainer::CheckAccountQosSubmitResourceUsage_(
 }
 
 CraneErrCode AccountMetaContainer::CheckQosSubmitResourceUsage_(
-    const TaskInCtld& task, const Qos& qos) {
+    const JobInCtld& job, const Qos& qos) {
   auto result = CraneErrCode::SUCCESS;
   m_qos_meta_map_.if_contains(
-      task.qos, [&](std::pair<const std::string, MetaResource>& pair) {
+      job.qos, [&](std::pair<const std::string, MetaResource>& pair) {
         auto& val = pair.second;
         if (val.submit_jobs_count + 1 > qos.max_submit_jobs) {
           result = CraneErrCode::ERR_QOS_JOB_COUNT_EXCEEDED;
@@ -363,15 +363,15 @@ CraneErrCode AccountMetaContainer::CheckQosSubmitResourceUsage_(
           }
 
           if (qos.max_wall > absl::ZeroDuration()) {
-            if (val.wall_time + task.time_limit > qos.max_wall) {
+            if (val.wall_time + job.time_limit > qos.max_wall) {
               result = CraneErrCode::ERR_TIME_TIMIT_BEYOND;
               return;
             }
           }
-          ResourceView resource_use{task.req_total_res_view};
+          ResourceView resource_use{job.req_total_res_view};
           resource_use += val.resource;
           if (!CheckTres_(resource_use, qos.max_tres)) {
-            result = CraneErrCode::ERR_TRES_PER_TASK_BEYOND;
+            result = CraneErrCode::ERR_TRES_PER_JOB_BEYOND;
             return;
           }
         }
@@ -410,7 +410,7 @@ std::expected<void, std::string> AccountMetaContainer::CheckQosResource_(
     auto iter = pair.second.find(job.qos);
     if (iter == pair.second.end()) {
       CRANE_ERROR(
-          "Qos '{}' not found for user '{}', cannot free resource for task {}.",
+          "Qos '{}' not found for user '{}', cannot free resource for job {}.",
           job.qos, job.username, job.job_id);
       result = std::unexpected("QosResourceLimit");
       return;
@@ -658,7 +658,7 @@ void AccountMetaContainer::DoFreeResource_(
         }
       });
 
-  UserReduceTask(username);
+  UserReduceJob(username);
 }
 
 }  // namespace Ctld

--- a/src/CraneCtld/AccountMetaContainer.h
+++ b/src/CraneCtld/AccountMetaContainer.h
@@ -58,7 +58,7 @@ class AccountMetaContainer final {
       std::allocator<std::pair<const std::string, QosToResourceMap>>, 4,
       std::shared_mutex>;
 
-  using UserToTaskNumMap = phmap::parallel_flat_hash_map<
+  using UserToJobNumMap = phmap::parallel_flat_hash_map<
       std::string, uint32_t, phmap::priv::hash_default_hash<std::string>,
       phmap::priv::hash_default_eq<std::string>,
       std::allocator<std::pair<const std::string, uint32_t>>, 4,
@@ -73,18 +73,18 @@ class AccountMetaContainer final {
   AccountMetaContainer() = default;
   ~AccountMetaContainer() = default;
 
-  CraneErrCode TryMallocQosSubmitResource(TaskInCtld& task);
+  CraneErrCode TryMallocQosSubmitResource(JobInCtld& job);
 
-  void MallocQosSubmitResource(const TaskInCtld& task);
+  void MallocQosSubmitResource(const JobInCtld& job);
 
-  void MallocQosResourceToRecoveredRunningTask(TaskInCtld& task);
+  void MallocQosResourceToRecoveredRunningJob(JobInCtld& job);
 
   std::expected<void, std::string> CheckAndMallocQosResource(
       const PdJobInScheduler& job);
 
-  void FreeQosSubmitResource(const TaskInCtld& task);
+  void FreeQosSubmitResource(const JobInCtld& job);
 
-  void FreeQosResource(const TaskInCtld& task);
+  void FreeQosResource(const JobInCtld& job);
 
   // When a user/account object is deleted, resources need to be reset.
   void DeleteUserMeta(const std::string& username);
@@ -93,11 +93,11 @@ class AccountMetaContainer final {
 
   void DeleteQosMeta(const std::string& qos);
 
-  void UserAddTask(const std::string& username);
+  void UserAddJob(const std::string& username);
 
-  void UserReduceTask(const std::string& username);
+  void UserReduceJob(const std::string& username);
 
-  bool UserHasTask(const std::string& username);
+  bool UserHasJob(const std::string& username);
 
  private:
   const static int kNumStripes = 128;
@@ -106,13 +106,13 @@ class AccountMetaContainer final {
     return std::hash<std::string>{}(key) % kNumStripes;
   }
 
-  CraneErrCode CheckUserQosSubmitResourceUsage_(const TaskInCtld& task,
+  CraneErrCode CheckUserQosSubmitResourceUsage_(const JobInCtld& job,
                                                 const Qos& qos);
 
-  CraneErrCode CheckAccountQosSubmitResourceUsage_(const TaskInCtld& task,
+  CraneErrCode CheckAccountQosSubmitResourceUsage_(const JobInCtld& job,
                                                    const Qos& qos);
 
-  CraneErrCode CheckQosSubmitResourceUsage_(const TaskInCtld& task,
+  CraneErrCode CheckQosSubmitResourceUsage_(const JobInCtld& job,
                                             const Qos& qos);
 
   std::expected<void, std::string> CheckQosResource_(
@@ -149,7 +149,7 @@ class AccountMetaContainer final {
   ResourceMetaMap m_user_meta_map_;
   ResourceMetaMap m_account_meta_map_;
   QosResourceMap m_qos_meta_map_;
-  UserToTaskNumMap m_user_to_task_map_;
+  UserToJobNumMap m_user_to_job_map_;
 };
 
 }  // namespace Ctld

--- a/src/CraneCtld/CMakeLists.txt
+++ b/src/CraneCtld/CMakeLists.txt
@@ -3,8 +3,8 @@ add_executable(cranectld
         CtldPublicDefs.cpp
         DbClient.h
         DbClient.cpp
-        TaskScheduler.h
-        TaskScheduler.cpp
+        JobScheduler.h
+        JobScheduler.cpp
         CranedMetaContainer.h
         CranedMetaContainer.cpp
         AccountManager.h

--- a/src/CraneCtld/CraneCtld.cpp
+++ b/src/CraneCtld/CraneCtld.cpp
@@ -37,7 +37,7 @@
 #include "RpcService/CranedKeeper.h"
 #include "RpcService/CtldGrpcServer.h"
 #include "Security/VaultClient.h"
-#include "TaskScheduler.h"
+#include "JobScheduler.h"
 #include "crane/Network.h"
 #include "crane/PluginClient.h"
 
@@ -438,9 +438,9 @@ void ParseConfig(int argc, char** argv) {
       g_config.AllLicenseResourcesAbsolute =
           YamlValueOr<bool>(config["AllLicenseResourcesAbsolute"], false);
 
-      g_config.RejectTasksBeyondCapacity =
+      g_config.RejectJobsBeyondCapacity =
           YamlValueOr<bool>(config["RejectJobsBeyondCapacity"],
-                            Ctld::kDefaultRejectTasksBeyondCapacity);
+                            Ctld::kDefaultRejectJobsBeyondCapacity);
 
       if (config["JobFileAppend"]) {
         g_config.JobFileOpenModeAppend = config["JobFileAppend"].as<bool>();
@@ -940,7 +940,7 @@ void DestroyCtldGlobalVariables() {
 
   g_craned_keeper.reset();
   // Craned keeper will query running job from scheduler
-  g_task_scheduler.reset();
+  g_job_scheduler.reset();
 
   // In case that spdlog is destructed before g_embedded_db_client->Close()
   // in which log function is called.
@@ -997,8 +997,8 @@ void InitializeCtldGlobalVariables() {
     std::exit(1);
   }
 
-  // Account manager must be initialized before Task Scheduler
-  // since the recovery stage of the task scheduler will acquire
+  // Account manager must be initialized before Job Scheduler
+  // since the recovery stage of the job scheduler will acquire
   // information from account manager.
   g_account_manager = std::make_unique<AccountManager>();
 
@@ -1046,7 +1046,7 @@ void InitializeCtldGlobalVariables() {
 
   g_craned_keeper->SetCranedDisconnectedCb([](const CranedId& craned_id) {
     CRANE_DEBUG("CranedNode #{} Disconnected.", craned_id);
-    // No need to worry disconnect before task scheduler init
+    // No need to worry disconnect before job scheduler init
     g_meta_container->CranedDown(craned_id);
   });
 
@@ -1059,11 +1059,11 @@ void InitializeCtldGlobalVariables() {
 
   using namespace std::chrono_literals;
 
-  g_task_scheduler = std::make_unique<TaskScheduler>();
+  g_job_scheduler = std::make_unique<JobScheduler>();
 
-  ok = g_task_scheduler->Init();
+  ok = g_job_scheduler->Init();
   if (!ok) {
-    CRANE_ERROR("The initialization of TaskScheduler failed. Exiting...");
+    CRANE_ERROR("The initialization of JobScheduler failed. Exiting...");
     DestroyCtldGlobalVariables();
     std::exit(1);
   }

--- a/src/CraneCtld/CraneCtld.cpp
+++ b/src/CraneCtld/CraneCtld.cpp
@@ -32,12 +32,12 @@
 #include "CtldPublicDefs.h"
 #include "DbClient.h"
 #include "EmbeddedDbClient.h"
+#include "JobScheduler.h"
 #include "LicensesManager.h"
 #include "Lua/LuaJobHandler.h"
 #include "RpcService/CranedKeeper.h"
 #include "RpcService/CtldGrpcServer.h"
 #include "Security/VaultClient.h"
-#include "JobScheduler.h"
 #include "crane/Network.h"
 #include "crane/PluginClient.h"
 

--- a/src/CraneCtld/CranedMetaContainer.cpp
+++ b/src/CraneCtld/CranedMetaContainer.cpp
@@ -165,7 +165,7 @@ CranedMetaContainer::GetResvMetaMapExclusivePtr() {
 }
 
 void CranedMetaContainer::MallocResourceFromNode(CranedId node_id,
-                                                 task_id_t task_id,
+                                                 job_id_t job_id,
                                                  const ResourceV2& resources) {
   if (!craned_meta_map_.Contains(node_id)) {
     CRANE_ERROR("Try to malloc resource from an unknown craned {}", node_id);
@@ -184,27 +184,27 @@ void CranedMetaContainer::MallocResourceFromNode(CranedId node_id,
     part_meta_ptrs.emplace_back(
         raw_part_metas_map_->at(part_id).GetExclusivePtr());
 
-  const ResourceInNode& task_node_res = resources.at(node_id);
+  const ResourceInNode& job_node_res = resources.at(node_id);
 
   // Then acquire craned meta lock.
   auto node_meta = craned_meta_map_[node_id];
 
-  node_meta->rn_task_res_map.emplace(task_id, task_node_res);
+  node_meta->rn_job_res_map.emplace(job_id, job_node_res);
 
-  node_meta->res_avail -= task_node_res;
-  node_meta->res_in_use += task_node_res;
+  node_meta->res_avail -= job_node_res;
+  node_meta->res_in_use += job_node_res;
 
   for (auto& partition_meta : part_meta_ptrs) {
     PartitionGlobalMeta& part_global_meta =
         partition_meta->partition_global_meta;
 
-    part_global_meta.res_avail -= task_node_res;
-    part_global_meta.res_in_use += task_node_res;
+    part_global_meta.res_avail -= job_node_res;
+    part_global_meta.res_in_use += job_node_res;
   }
 }
 
 void CranedMetaContainer::FreeResourceFromNode(CranedId node_id,
-                                               uint32_t task_id) {
+                                               uint32_t job_id) {
   if (!craned_meta_map_.Contains(node_id)) {
     CRANE_ERROR("Try to free resource from an unknown craned {}", node_id);
     return;
@@ -225,10 +225,10 @@ void CranedMetaContainer::FreeResourceFromNode(CranedId node_id,
   // Then acquire craned meta lock.
   auto node_meta = craned_meta_map_[node_id];
 
-  auto resource_iter = node_meta->rn_task_res_map.find(task_id);
-  if (resource_iter == node_meta->rn_task_res_map.end()) {
-    CRANE_ERROR("Try to free resource from an unknown task {} on craned {}",
-                task_id, node_id);
+  auto resource_iter = node_meta->rn_job_res_map.find(job_id);
+  if (resource_iter == node_meta->rn_job_res_map.end()) {
+    CRANE_ERROR("Try to free resource from an unknown job {} on craned {}",
+                job_id, node_id);
     return;
   }
 
@@ -244,11 +244,11 @@ void CranedMetaContainer::FreeResourceFromNode(CranedId node_id,
     part_global_meta.res_in_use -= resources;
   }
 
-  node_meta->rn_task_res_map.erase(resource_iter);
+  node_meta->rn_job_res_map.erase(resource_iter);
 }
 
 void CranedMetaContainer::MallocResourceFromResv(ResvId resv_id,
-                                                 task_id_t job_id,
+                                                 job_id_t job_id,
                                                  const ResourceV2& res) {
   auto resv_meta = resv_meta_map_.GetValueExclusivePtr(resv_id);
   if (!resv_meta) {
@@ -263,7 +263,7 @@ void CranedMetaContainer::MallocResourceFromResv(ResvId resv_id,
 }
 
 void CranedMetaContainer::FreeResourceFromResv(ResvId resv_id,
-                                               task_id_t job_id) {
+                                               job_id_t job_id) {
   auto resv_meta = resv_meta_map_.GetValueExclusivePtr(resv_id);
   if (!resv_meta) {
     CRANE_ERROR("Try to free resource from an unknown reservation {}", resv_id);
@@ -961,7 +961,7 @@ CraneExpected<void> CranedMetaContainer::CheckIfAccountIsAllowedInPartition(
 
   if (part_meta_iter == part_metas_map->end()) {
     CRANE_DEBUG(
-        "the partition {} does not exist, submission of the task is "
+        "the partition {} does not exist, submission of the job is "
         "prohibited.",
         partition_name);
     return std::unexpected(CraneErrCode::ERR_INVALID_PARTITION);
@@ -978,7 +978,7 @@ CraneExpected<void> CranedMetaContainer::CheckIfAccountIsAllowedInPartition(
     if (!allowed_accounts.contains(account_name)) {
       CRANE_DEBUG(
           "The account {} is not in the AllowedAccounts of the partition {}"
-          "specified for the task, submission of the task is prohibited.",
+          "specified for the job, submission of the job is prohibited.",
           account_name, partition_name);
       return std::unexpected(CraneErrCode::ERR_NOT_IN_ALLOWED_LIST);
     }
@@ -986,7 +986,7 @@ CraneExpected<void> CranedMetaContainer::CheckIfAccountIsAllowedInPartition(
     if (denied_accounts.contains(account_name)) {
       CRANE_DEBUG(
           "The account {} is in the DeniedAccounts of the partition {}"
-          "specified for the task, submission of the task is prohibited.",
+          "specified for the job, submission of the job is prohibited.",
           account_name, partition_name);
       return std::unexpected(CraneErrCode::ERR_IN_DENIED_LIST);
     }
@@ -1061,7 +1061,7 @@ void CranedMetaContainer::SetGrpcCranedInfoByCranedMeta_(
                   craned_meta.remote_meta.sys_rel_info.version);
   craned_info->set_system_desc(system_desc);
 
-  craned_info->set_running_task_num(craned_meta.rn_task_res_map.size());
+  craned_info->set_running_job_num(craned_meta.rn_job_res_map.size());
 
   if (craned_meta.drain) {
     craned_info->set_control_state(

--- a/src/CraneCtld/CranedMetaContainer.h
+++ b/src/CraneCtld/CranedMetaContainer.h
@@ -122,10 +122,10 @@ class CranedMetaContainer final {
     return craned_meta_map_.Contains(hostname);
   };
 
-  void MallocResourceFromNode(CranedId node_id, task_id_t task_id,
+  void MallocResourceFromNode(CranedId node_id, job_id_t job_id,
                               const ResourceV2& resources);
 
-  void FreeResourceFromNode(CranedId craned_id, uint32_t task_id);
+  void FreeResourceFromNode(CranedId craned_id, uint32_t job_id);
 
   // TODO: Move to Reservation Mini-Scheduler. Craned only use LogicalPartition.
   using ResvMetaAtomicMap = util::AtomicHashMap<HashMap, std::string, ResvMeta>;
@@ -153,10 +153,10 @@ class CranedMetaContainer final {
 
   ResvMetaMapExclusivePtr GetResvMetaMapExclusivePtr();
 
-  void MallocResourceFromResv(ResvId resv_id, task_id_t task_id,
+  void MallocResourceFromResv(ResvId resv_id, job_id_t job_id,
                               const ResourceV2& res);
 
-  void FreeResourceFromResv(ResvId resv_id, task_id_t task_id);
+  void FreeResourceFromResv(ResvId resv_id, job_id_t job_id);
 
   // Store Resource reduction events happened during scheduling here.
   // Cases:

--- a/src/CraneCtld/CtldPublicDefs.cpp
+++ b/src/CraneCtld/CtldPublicDefs.cpp
@@ -957,8 +957,7 @@ void CommonStepInCtld::InitPrimaryStepFromJob(JobInCtld& job) {
     }
     if (job.JobToCtld().has_container_meta()) {
       // ccon has container_meta.
-      step.mutable_container_meta()->CopyFrom(
-          job.JobToCtld().container_meta());
+      step.mutable_container_meta()->CopyFrom(job.JobToCtld().container_meta());
     }
   }
 
@@ -1549,7 +1548,7 @@ void JobInCtld::UpdateDependency(job_id_t dep_job_id, absl::Time event_time) {
 }
 
 void JobInCtld::AddDependent(crane::grpc::DependencyType dep_type,
-                              job_id_t dep_job_id) {
+                             job_id_t dep_job_id) {
   if (dep_type == crane::grpc::DependencyType::AFTER &&
       status != crane::grpc::JobStatus::Pending) {
     // already satisfied

--- a/src/CraneCtld/CtldPublicDefs.cpp
+++ b/src/CraneCtld/CtldPublicDefs.cpp
@@ -19,7 +19,7 @@
 #include "CtldPublicDefs.h"
 
 #include "EmbeddedDbClient.h"
-#include "TaskScheduler.h"
+#include "JobScheduler.h"
 
 namespace Ctld {
 
@@ -40,7 +40,7 @@ CranedRemoteMeta::CranedRemoteMeta(
   }
 }
 
-PodMetaInTask::PodMetaInTask(const crane::grpc::PodTaskAdditionalMeta& rhs)
+PodMetaInJob::PodMetaInJob(const crane::grpc::PodJobAdditionalMeta& rhs)
     : name(rhs.name()),
       labels(rhs.labels().begin(), rhs.labels().end()),
       annotations(rhs.annotations().begin(), rhs.annotations().end()),
@@ -63,8 +63,8 @@ PodMetaInTask::PodMetaInTask(const crane::grpc::PodTaskAdditionalMeta& rhs)
   }
 }
 
-PodMetaInTask::operator crane::grpc::PodTaskAdditionalMeta() const {
-  crane::grpc::PodTaskAdditionalMeta result;
+PodMetaInJob::operator crane::grpc::PodJobAdditionalMeta() const {
+  crane::grpc::PodJobAdditionalMeta result;
   result.set_name(this->name);
   result.mutable_labels()->insert(this->labels.begin(), this->labels.end());
   result.mutable_annotations()->insert(this->annotations.begin(),
@@ -92,8 +92,8 @@ PodMetaInTask::operator crane::grpc::PodTaskAdditionalMeta() const {
   return result;
 }
 
-ContainerMetaInTask::ContainerMetaInTask(
-    const crane::grpc::ContainerTaskAdditionalMeta& rhs)
+ContainerMetaInJob::ContainerMetaInJob(
+    const crane::grpc::ContainerJobAdditionalMeta& rhs)
     : name(rhs.name()),
       labels(rhs.labels().begin(), rhs.labels().end()),
       annotations(rhs.annotations().begin(), rhs.annotations().end()),
@@ -112,8 +112,8 @@ ContainerMetaInTask::ContainerMetaInTask(
       stdin_once(rhs.stdin_once()),
       mounts(rhs.mounts().begin(), rhs.mounts().end()) {}
 
-ContainerMetaInTask::operator crane::grpc::ContainerTaskAdditionalMeta() const {
-  crane::grpc::ContainerTaskAdditionalMeta result;
+ContainerMetaInJob::operator crane::grpc::ContainerJobAdditionalMeta() const {
+  crane::grpc::ContainerJobAdditionalMeta result;
 
   auto* image = result.mutable_image();
   image->set_image(this->image_info.image);
@@ -158,7 +158,7 @@ ContainerMetaInTask::operator crane::grpc::ContainerTaskAdditionalMeta() const {
   return result;
 }
 
-void DependenciesInJob::update(task_id_t job_id, absl::Time event_time) {
+void DependenciesInJob::update(job_id_t job_id, absl::Time event_time) {
   auto it = deps.find(job_id);
   if (it == deps.end()) {
     CRANE_ERROR("Dependency for job {} not found", job_id);
@@ -262,7 +262,7 @@ void StepInCtld::SetEndTime(absl::Time end_time) {
       ToUnixSeconds(end_time));
 }
 
-void StepInCtld::SetErrorStatus(crane::grpc::TaskStatus failed_status) {
+void StepInCtld::SetErrorStatus(crane::grpc::JobStatus failed_status) {
   m_error_status = failed_status;
   this->m_runtime_attr_.set_error_status(failed_status);
 }
@@ -272,7 +272,7 @@ void StepInCtld::SetErrorExitCode(uint32_t exit_code) {
   this->m_runtime_attr_.set_error_exit_code(exit_code);
 }
 
-void StepInCtld::SetStatus(crane::grpc::TaskStatus new_status) {
+void StepInCtld::SetStatus(crane::grpc::JobStatus new_status) {
   this->m_status_ = new_status;
   this->m_runtime_attr_.set_status(new_status);
 }
@@ -288,11 +288,11 @@ void StepInCtld::SetHeld(bool held) {
 }
 
 void StepInCtld::RecoverFromDb(
-    const TaskInCtld& job, crane::grpc::StepInEmbeddedDb const& step_in_db) {
+    const JobInCtld& job, crane::grpc::StepInEmbeddedDb const& step_in_db) {
   const auto& step_to_ctld = step_in_db.step_to_ctld();
   const auto& runtime_attr = step_in_db.runtime_attr();
 
-  this->job = const_cast<TaskInCtld*>(&job);
+  this->job = const_cast<JobInCtld*>(&job);
 
   type = step_to_ctld.type();
   job_id = step_to_ctld.job_id();
@@ -316,7 +316,7 @@ void StepInCtld::RecoverFromDb(
     } else if (step_to_ctld.has_container_meta()) {
       // For common step, recover both container_meta and pod_meta.
       container_meta =
-          static_cast<ContainerMetaInTask>(step_to_ctld.container_meta());
+          static_cast<ContainerMetaInJob>(step_to_ctld.container_meta());
       pod_meta = job.pod_meta;
     }
   }
@@ -419,7 +419,7 @@ void StepInCtld::SetFieldsOfStepInfo(
 
   if (container_meta.has_value()) {
     step_info->mutable_container_meta()->CopyFrom(
-        crane::grpc::ContainerTaskAdditionalMeta(container_meta.value()));
+        crane::grpc::ContainerJobAdditionalMeta(container_meta.value()));
   }
   step_info->set_held(m_held_);
   step_info->set_status(m_status_);
@@ -432,12 +432,12 @@ void StepInCtld::SetFieldsOfStepInfo(
   // ResourceView allocated_res_view = 40;
 }
 
-void DaemonStepInCtld::InitFromJob(const TaskInCtld& job) {
+void DaemonStepInCtld::InitFromJob(const JobInCtld& job) {
   /* Fields in StepInCtld */
-  this->job = const_cast<TaskInCtld*>(&job);
+  this->job = const_cast<JobInCtld*>(&job);
   type = job.type;
 
-  job_id = job.TaskId();
+  job_id = job.JobId();
   name = job.name;
   cwd = job.cwd;
 
@@ -479,9 +479,9 @@ void DaemonStepInCtld::InitFromJob(const TaskInCtld& job) {
   SetStartTime(job.StartTime());
   SetEndTime(job.EndTime());
 
-  SetErrorStatus(crane::grpc::TaskStatus::Invalid);
+  SetErrorStatus(crane::grpc::JobStatus::Invalid);
   SetErrorExitCode(0U);
-  SetStatus(crane::grpc::TaskStatus::Configuring);
+  SetStatus(crane::grpc::JobStatus::Configuring);
   SetHeld(false);
 
   /* Fields in DaemonStepInCtld */
@@ -494,19 +494,19 @@ void DaemonStepInCtld::InitFromJob(const TaskInCtld& job) {
   step.mutable_time_limit()->CopyFrom(
       google::protobuf::util::TimeUtil::MillisecondsToDuration(
           ToInt64Milliseconds(time_limit)));
-  step.set_job_id(job.TaskId());
+  step.set_job_id(job.JobId());
 
-  if (job.TaskToCtld().has_mem_per_node()) {
-    step.set_mem_per_node(job.TaskToCtld().mem_per_node());
+  if (job.JobToCtld().has_mem_per_node()) {
+    step.set_mem_per_node(job.JobToCtld().mem_per_node());
   }
-  if (job.TaskToCtld().has_gres_per_node()) {
-    *step.mutable_gres_per_node() = job.TaskToCtld().gres_per_node();
+  if (job.JobToCtld().has_gres_per_node()) {
+    *step.mutable_gres_per_node() = job.JobToCtld().gres_per_node();
   }
-  if (job.TaskToCtld().has_cpus_per_task()) {
-    step.set_cpus_per_task(job.TaskToCtld().cpus_per_task());
+  if (job.JobToCtld().has_cpus_per_task()) {
+    step.set_cpus_per_task(job.JobToCtld().cpus_per_task());
   }
-  if (job.TaskToCtld().has_mem_per_cpu()) {
-    step.set_mem_per_cpu(job.TaskToCtld().mem_per_cpu());
+  if (job.JobToCtld().has_mem_per_cpu()) {
+    step.set_mem_per_cpu(job.JobToCtld().mem_per_cpu());
   }
 
   step.set_type(job.type);
@@ -528,11 +528,11 @@ void DaemonStepInCtld::InitFromJob(const TaskInCtld& job) {
 
   step.set_get_user_env(get_user_env);
   step.mutable_env()->insert(env.begin(), env.end());
-  step.set_excludes(job.TaskToCtld().excludes());
-  step.set_nodelist(job.TaskToCtld().nodelist());
+  step.set_excludes(job.JobToCtld().excludes());
+  step.set_nodelist(job.JobToCtld().nodelist());
 
-  step.set_task_prolog(job.TaskToCtld().task_prolog());
-  step.set_task_epilog(job.TaskToCtld().task_epilog());
+  step.set_task_prolog(job.JobToCtld().task_prolog());
+  step.set_task_epilog(job.JobToCtld().task_epilog());
 
   *MutableStepToCtld() = std::move(step);
 }
@@ -587,9 +587,9 @@ crane::grpc::StepToD DaemonStepInCtld::GetStepToD(
 
   if (this->pod_meta.has_value())
     step_to_d.mutable_pod_meta()->CopyFrom(
-        crane::grpc::PodTaskAdditionalMeta(pod_meta.value()));
+        crane::grpc::PodJobAdditionalMeta(pod_meta.value()));
 
-  step_to_d.set_submit_hostname(job->TaskToCtld().submit_hostname());
+  step_to_d.set_submit_hostname(job->JobToCtld().submit_hostname());
   ResourceView res_view_in_node;
   res_view_in_node += m_allocated_res_.at(craned_id);
   step_to_d.set_total_gpus(res_view_in_node.GpuCount());
@@ -597,13 +597,13 @@ crane::grpc::StepToD DaemonStepInCtld::GetStepToD(
   step_to_d.set_ntasks(this->job->ntasks);
   step_to_d.set_ntasks_per_node(this->job->ntasks_per_node_max);
   step_to_d.set_cpus_per_task(this->job->req_task_res_view.CpuCount());
-  step_to_d.set_submit_dir(this->job->TaskToCtld().submit_dir());
+  step_to_d.set_submit_dir(this->job->JobToCtld().submit_dir());
 
   return step_to_d;
 }
 
-std::optional<std::pair<crane::grpc::TaskStatus, uint32_t>>
-DaemonStepInCtld::StepStatusChange(crane::grpc::TaskStatus new_status,
+std::optional<std::pair<crane::grpc::JobStatus, uint32_t>>
+DaemonStepInCtld::StepStatusChange(crane::grpc::JobStatus new_status,
                                    uint32_t exit_code,
                                    const std::string& reason,
                                    const CranedId& craned_id,
@@ -615,7 +615,7 @@ DaemonStepInCtld::StepStatusChange(crane::grpc::TaskStatus new_status,
               job_id, this->StepId(), this->Status(), new_status, craned_id);
 
   switch (this->Status()) {
-  case crane::grpc::TaskStatus::Configuring:
+  case crane::grpc::JobStatus::Configuring:
     // Configuring -> Failed / Running
     if (craned_id != kCtldPrologInternalNodeIndex) [[likely]] {
       this->NodeConfigured(craned_id);
@@ -625,10 +625,10 @@ DaemonStepInCtld::StepStatusChange(crane::grpc::TaskStatus new_status,
     }
 
     switch (new_status) {
-    case crane::grpc::TaskStatus::Running:
+    case crane::grpc::JobStatus::Running:
       break;
 
-    case crane::grpc::TaskStatus::Failed:
+    case crane::grpc::JobStatus::Failed:
       this->SetErrorStatus(new_status);
       this->SetErrorExitCode(exit_code);
       break;
@@ -650,15 +650,15 @@ DaemonStepInCtld::StepStatusChange(crane::grpc::TaskStatus new_status,
             "[Step #{}.{}] Cancel was requested during Configuring. "
             "Finishing as Cancelled.",
             job_id, this->StepId());
-        this->SetErrorStatus(crane::grpc::TaskStatus::Cancelled);
+        this->SetErrorStatus(crane::grpc::JobStatus::Cancelled);
         this->SetErrorExitCode(ExitCode::EC_TERMINATED);
         job_finished = true;
       } else {
         CRANE_TRACE("[Step #{}.{}] CONFIGURING->RUNNING", job_id,
                     this->StepId());
 
-        this->SetStatus(crane::grpc::TaskStatus::Running);
-        this->SetErrorStatus(crane::grpc::TaskStatus::Invalid);
+        this->SetStatus(crane::grpc::JobStatus::Running);
+        this->SetErrorStatus(crane::grpc::JobStatus::Invalid);
         this->SetErrorExitCode(0U);
 
         // After all daemon steps running, create the primary step from the
@@ -669,10 +669,10 @@ DaemonStepInCtld::StepStatusChange(crane::grpc::TaskStatus new_status,
 
         // TODO: Aggregate this operation
         if (!g_embedded_db_client->AppendSteps({primary_step.get()})) {
-          this->SetStatus(crane::grpc::TaskStatus::Failed);
+          this->SetStatus(crane::grpc::JobStatus::Failed);
           job_finished = true;
           CRANE_ERROR("[Job #{}] Failed to append a step to embedded db.",
-                      job->TaskId());
+                      job->JobId());
           context->rn_step_raw_ptrs.erase(this);
           break;
         }
@@ -697,16 +697,16 @@ DaemonStepInCtld::StepStatusChange(crane::grpc::TaskStatus new_status,
 
     break;
 
-  case crane::grpc::TaskStatus::Running:
-  case crane::grpc::TaskStatus::Completing:
+  case crane::grpc::JobStatus::Running:
+  case crane::grpc::JobStatus::Completing:
     // Completing -> Completed / Failed
     switch (new_status) {
-    case crane::grpc::TaskStatus::Failed:
+    case crane::grpc::JobStatus::Failed:
       this->SetErrorStatus(new_status);
       this->SetErrorExitCode(exit_code);
       break;
 
-    case crane::grpc::TaskStatus::Completed:
+    case crane::grpc::JobStatus::Completed:
       break;
 
     [[unlikely]] default:
@@ -739,7 +739,7 @@ DaemonStepInCtld::StepStatusChange(crane::grpc::TaskStatus new_status,
     this->SetEndTime(absl::FromUnixSeconds(timestamp.seconds()) +
                      absl::Nanoseconds(timestamp.nanos()));
 
-    if (this->Status() == crane::grpc::TaskStatus::Configuring) {
+    if (this->Status() == crane::grpc::JobStatus::Configuring) {
       this->SetStatus(this->PrevErrorStatus().value());
       this->SetExitCode(this->PrevErrorExitCode());
       CRANE_INFO("[Step #{}.{}] Configuring failed with status {}.", job_id,
@@ -751,13 +751,13 @@ DaemonStepInCtld::StepStatusChange(crane::grpc::TaskStatus new_status,
       // the same daemon step, both trying to free the supervisor, double-freed.
 
       // FreeJobs() is enough to free the daemon step's supervisor.
-      context->craned_jobs_to_free[craned_id].emplace_back(job->TaskId());
+      context->craned_jobs_to_free[craned_id].emplace_back(job->JobId());
       if (job->IsInteractive()) {
         auto& meta = std::get<InteractiveMeta>(job->meta);
         if (!meta.has_been_cancelled_on_front_end) {
           meta.has_been_cancelled_on_front_end = true;
           meta.cb_step_cancel({.job_id = job_id, .step_id = kPrimaryStepId});
-          // Completion ack will send in grpc server triggered by task complete
+          // Completion ack will send in grpc server triggered by job complete
           // req
           meta.cb_step_completed({.job_id = job_id,
                                   .step_id = kPrimaryStepId,
@@ -778,14 +778,14 @@ DaemonStepInCtld::StepStatusChange(crane::grpc::TaskStatus new_status,
         this->SetStatus(error_status.value());
         this->SetExitCode(this->PrevErrorExitCode());
       } else {
-        this->SetStatus(crane::grpc::TaskStatus::Completed);
+        this->SetStatus(crane::grpc::JobStatus::Completed);
         this->SetExitCode(0U);
       }
 
       CRANE_INFO("[Step #{}.{}] finished with status {}.", job_id,
                  this->StepId(), this->Status());
       // Daemon step terminated by user before primary step created
-      if (job->PrimaryStepStatus() == crane::grpc::TaskStatus::Invalid) {
+      if (job->PrimaryStepStatus() == crane::grpc::JobStatus::Invalid) {
         return std::pair{this->Status(), this->ExitCode()};
       } else {
         if (job->AllStepsFinished()) {
@@ -802,7 +802,7 @@ DaemonStepInCtld::StepStatusChange(crane::grpc::TaskStatus new_status,
 }
 
 void DaemonStepInCtld::RecoverFromDb(
-    const TaskInCtld& job, const crane::grpc::StepInEmbeddedDb& step_in_db) {
+    const JobInCtld& job, const crane::grpc::StepInEmbeddedDb& step_in_db) {
   StepInCtld::RecoverFromDb(job, step_in_db);
   partition = job.partition_id;
   account = job.account;
@@ -818,11 +818,11 @@ void DaemonStepInCtld::SetFieldsOfStepInfo(
       static_cast<crane::grpc::ResourceView>(job->allocated_res_view);
 }
 
-void CommonStepInCtld::InitPrimaryStepFromJob(TaskInCtld& job) {
+void CommonStepInCtld::InitPrimaryStepFromJob(JobInCtld& job) {
   /* Fields in StepInCtld */
-  this->job = const_cast<TaskInCtld*>(&job);
+  this->job = const_cast<JobInCtld*>(&job);
   type = job.type;
-  job_id = job.TaskId();
+  job_id = job.JobId();
   name = job.name;
   cwd = job.cwd;
 
@@ -851,8 +851,8 @@ void CommonStepInCtld::InitPrimaryStepFromJob(TaskInCtld& job) {
     // NOTE: job is Container doesn't necessarily mean the step has
     // container_meta as we can submit batch/crun steps inside a container job.
     pod_meta = job.pod_meta;
-    if (std::holds_alternative<ContainerMetaInTask>(job.meta))
-      container_meta = std::get<ContainerMetaInTask>(job.meta);
+    if (std::holds_alternative<ContainerMetaInJob>(job.meta))
+      container_meta = std::get<ContainerMetaInJob>(job.meta);
   }
 
   SetStepType(crane::grpc::StepType::PRIMARY);
@@ -870,9 +870,9 @@ void CommonStepInCtld::InitPrimaryStepFromJob(TaskInCtld& job) {
   SetStartTime(job.StartTime());
   SetEndTime(job.EndTime());
 
-  SetErrorStatus(crane::grpc::TaskStatus::Invalid);
+  SetErrorStatus(crane::grpc::JobStatus::Invalid);
   SetErrorExitCode(0U);
-  SetStatus(crane::grpc::TaskStatus::Configuring);
+  SetStatus(crane::grpc::JobStatus::Configuring);
   SetHeld(false);
 
   /*Fields in CommonStepInCtld*/
@@ -883,12 +883,12 @@ void CommonStepInCtld::InitPrimaryStepFromJob(TaskInCtld& job) {
   }
 
   allocated_craneds_regex = job.allocated_craneds_regex;
-  task_prolog = job.TaskToCtld().task_prolog();
-  task_epilog = job.TaskToCtld().task_epilog();
-  // FIXME: Following task fields should set by scheduler
+  task_prolog = job.JobToCtld().task_prolog();
+  task_epilog = job.JobToCtld().task_epilog();
+  // FIXME: Following job fields should set by scheduler
   task_id_t cur_task_id = 0;
   if (job.IsBatch() || job.IsCalloc()) {
-    // Batch/Calloc: will launch one task on one node only
+    // Batch/Calloc: will launch one job on one node only
     craned_task_map[job.executing_craned_ids.front()].insert(cur_task_id);
     task_res_map[cur_task_id] =
         job.AllocatedRes().at(job.executing_craned_ids.front());
@@ -918,19 +918,19 @@ void CommonStepInCtld::InitPrimaryStepFromJob(TaskInCtld& job) {
   step.mutable_time_limit()->CopyFrom(
       google::protobuf::util::TimeUtil::MillisecondsToDuration(
           ToInt64Milliseconds(time_limit)));
-  step.set_job_id(job.TaskId());
+  step.set_job_id(job.JobId());
 
-  if (job.TaskToCtld().has_mem_per_node()) {
-    step.set_mem_per_node(job.TaskToCtld().mem_per_node());
+  if (job.JobToCtld().has_mem_per_node()) {
+    step.set_mem_per_node(job.JobToCtld().mem_per_node());
   }
-  if (job.TaskToCtld().has_gres_per_node()) {
-    *step.mutable_gres_per_node() = job.TaskToCtld().gres_per_node();
+  if (job.JobToCtld().has_gres_per_node()) {
+    *step.mutable_gres_per_node() = job.JobToCtld().gres_per_node();
   }
-  if (job.TaskToCtld().has_cpus_per_task()) {
-    step.set_cpus_per_task(job.TaskToCtld().cpus_per_task());
+  if (job.JobToCtld().has_cpus_per_task()) {
+    step.set_cpus_per_task(job.JobToCtld().cpus_per_task());
   }
-  if (job.TaskToCtld().has_mem_per_cpu()) {
-    step.set_mem_per_cpu(job.TaskToCtld().mem_per_cpu());
+  if (job.JobToCtld().has_mem_per_cpu()) {
+    step.set_mem_per_cpu(job.JobToCtld().mem_per_cpu());
   }
 
   step.set_type(job.type);
@@ -945,20 +945,20 @@ void CommonStepInCtld::InitPrimaryStepFromJob(TaskInCtld& job) {
   step.mutable_gid()->Assign(gids.begin(), gids.end());
 
   if (job.type == crane::grpc::Batch) {
-    step.mutable_batch_meta()->CopyFrom(job.TaskToCtld().batch_meta());
+    step.mutable_batch_meta()->CopyFrom(job.JobToCtld().batch_meta());
   } else if (job.IsInteractive()) {
     step.mutable_interactive_meta()->CopyFrom(
-        job.TaskToCtld().interactive_meta());
+        job.JobToCtld().interactive_meta());
   } else if (job.IsContainer()) {
     // Primary step of a container job comes from ccon/cbatch.
-    if (job.TaskToCtld().has_batch_meta()) {
+    if (job.JobToCtld().has_batch_meta()) {
       // cbatch has batch_meta.
-      step.mutable_batch_meta()->CopyFrom(job.TaskToCtld().batch_meta());
+      step.mutable_batch_meta()->CopyFrom(job.JobToCtld().batch_meta());
     }
-    if (job.TaskToCtld().has_container_meta()) {
+    if (job.JobToCtld().has_container_meta()) {
       // ccon has container_meta.
       step.mutable_container_meta()->CopyFrom(
-          job.TaskToCtld().container_meta());
+          job.JobToCtld().container_meta());
     }
   }
 
@@ -966,10 +966,10 @@ void CommonStepInCtld::InitPrimaryStepFromJob(TaskInCtld& job) {
   step.set_cmd_line(job.cmd_line);
   step.set_cwd(job.cwd);
   step.mutable_env()->insert(env.begin(), env.end());
-  step.set_excludes(job.TaskToCtld().excludes());
-  step.set_nodelist(job.TaskToCtld().nodelist());
-  step.set_task_prolog(job.TaskToCtld().task_prolog());
-  step.set_task_epilog(job.TaskToCtld().task_epilog());
+  step.set_excludes(job.JobToCtld().excludes());
+  step.set_nodelist(job.JobToCtld().nodelist());
+  step.set_task_prolog(job.JobToCtld().task_prolog());
+  step.set_task_epilog(job.JobToCtld().task_epilog());
 
   *MutableStepToCtld() = std::move(step);
 }
@@ -1044,16 +1044,16 @@ void CommonStepInCtld::SetFieldsByStepToCtld(
     excluded_nodes = excluded_list | std::ranges::to<std::unordered_set>();
   }
 
-  if (step_to_ctld.type() == crane::grpc::TaskType::Container)
+  if (step_to_ctld.type() == crane::grpc::JobType::Container)
     container_meta =
-        static_cast<ContainerMetaInTask>(step_to_ctld.container_meta());
+        static_cast<ContainerMetaInJob>(step_to_ctld.container_meta());
 
   SetStepType(crane::grpc::StepType::COMMON);
 
   SetRequeueCount(0);
-  SetErrorStatus(crane::grpc::TaskStatus::Invalid);
+  SetErrorStatus(crane::grpc::JobStatus::Invalid);
   SetErrorExitCode(0U);
-  SetStatus(crane::grpc::TaskStatus::Pending);
+  SetStatus(crane::grpc::JobStatus::Pending);
   SetHeld(false);
   SetStartTime(absl::Now());
 
@@ -1120,7 +1120,7 @@ crane::grpc::StepToD CommonStepInCtld::GetStepToD(
   } else if (this->type == crane::grpc::Container) {
     if (pod_meta.has_value()) {
       step_to_d.mutable_pod_meta()->CopyFrom(
-          crane::grpc::PodTaskAdditionalMeta(pod_meta.value()));
+          crane::grpc::PodJobAdditionalMeta(pod_meta.value()));
     }
     if (container_meta.has_value()) {
       step_to_d.mutable_container_meta()->CopyFrom(
@@ -1131,7 +1131,7 @@ crane::grpc::StepToD CommonStepInCtld::GetStepToD(
     }
   }
 
-  step_to_d.mutable_signals()->CopyFrom(job->TaskToCtld().signals());
+  step_to_d.mutable_signals()->CopyFrom(job->JobToCtld().signals());
 
   step_to_d.set_task_prolog(task_prolog);
   step_to_d.set_task_epilog(task_epilog);
@@ -1139,8 +1139,8 @@ crane::grpc::StepToD CommonStepInCtld::GetStepToD(
   return step_to_d;
 }
 
-std::optional<std::pair<crane::grpc::TaskStatus, uint32_t>>
-CommonStepInCtld::StepStatusChange(crane::grpc::TaskStatus new_status,
+std::optional<std::pair<crane::grpc::JobStatus, uint32_t>>
+CommonStepInCtld::StepStatusChange(crane::grpc::JobStatus new_status,
                                    uint32_t exit_code,
                                    const std::string& reason,
                                    const CranedId& craned_id,
@@ -1163,10 +1163,10 @@ CommonStepInCtld::StepStatusChange(crane::grpc::TaskStatus new_status,
               job_id, step_id, this->Status(), new_status, craned_id);
 
   switch (this->Status()) {
-  case crane::grpc::TaskStatus::Configuring:
+  case crane::grpc::JobStatus::Configuring:
     // Configuring -> Starting / Failed / Cancelled,
     if (!craned_id.empty()) this->NodeConfigured(craned_id);
-    if (new_status != crane::grpc::TaskStatus::Starting) {
+    if (new_status != crane::grpc::JobStatus::Starting) {
       this->SetErrorStatus(new_status);
       this->SetErrorExitCode(exit_code);
     }
@@ -1180,14 +1180,14 @@ CommonStepInCtld::StepStatusChange(crane::grpc::TaskStatus new_status,
         CRANE_INFO("[Step #{}.{}] is ready to run.", job_id, step_id);
         // No need to set to Configured, make it running and process failed
         // cases by step status change
-        this->SetStatus(crane::grpc::TaskStatus::Running);
-        this->SetErrorStatus(crane::grpc::TaskStatus::Invalid);
+        this->SetStatus(crane::grpc::JobStatus::Running);
+        this->SetErrorStatus(crane::grpc::JobStatus::Invalid);
         this->SetErrorExitCode(0U);
         this->SetRunningNodes(this->ExecutionNodes());
 
         // Primary:Update job status when primary step is Running.
         if (this->IsPrimaryStep()) {
-          job->SetStatus(crane::grpc::TaskStatus::Running);
+          job->SetStatus(crane::grpc::JobStatus::Running);
           context->rn_job_raw_ptrs.insert(job);
         }
 
@@ -1199,13 +1199,13 @@ CommonStepInCtld::StepStatusChange(crane::grpc::TaskStatus new_status,
       }
     }
     break;
-  case crane::grpc::TaskStatus::Running:
-  case crane::grpc::TaskStatus::Completing:
+  case crane::grpc::JobStatus::Running:
+  case crane::grpc::JobStatus::Completing:
     // Running/Completing -> Completed / Failed / Cancelled,
     // Primary: the job is completed.
 
     this->StepOnNodeFinish(craned_id);
-    if (new_status != crane::grpc::TaskStatus::Completed) {
+    if (new_status != crane::grpc::JobStatus::Completed) {
       this->SetErrorStatus(new_status);
       this->SetErrorExitCode(exit_code);
     }
@@ -1231,7 +1231,7 @@ CommonStepInCtld::StepStatusChange(crane::grpc::TaskStatus new_status,
       if (!meta.has_been_cancelled_on_front_end) {
         meta.has_been_cancelled_on_front_end = true;
         meta.cb_step_cancel({.job_id = job_id, .step_id = step_id});
-        // Completion ack will send in grpc server triggered by task complete
+        // Completion ack will send in grpc server triggered by job complete
         // req
         meta.cb_step_completed({.job_id = job_id,
                                 .step_id = step_id,
@@ -1247,7 +1247,7 @@ CommonStepInCtld::StepStatusChange(crane::grpc::TaskStatus new_status,
     }
     this->SetEndTime(absl::FromUnixSeconds(timestamp.seconds()) +
                      absl::Nanoseconds(timestamp.nanos()));
-    if (this->Status() == crane::grpc::TaskStatus::Configuring) {
+    if (this->Status() == crane::grpc::JobStatus::Configuring) {
       CRANE_INFO("[Step #{}.{}] CONFIGURE_FAILED.", job_id, step_id);
       // CONFIGURE_FAILED
       this->SetStatus(this->PrevErrorStatus().value());
@@ -1255,7 +1255,7 @@ CommonStepInCtld::StepStatusChange(crane::grpc::TaskStatus new_status,
       // Step failed to configure, terminate this step
       for (const auto& node : this->ExecutionNodes()) {
         if (node != craned_id)
-          context->craned_orphaned_steps[node][job->TaskId()].emplace(step_id);
+          context->craned_orphaned_steps[node][job->JobId()].emplace(step_id);
       }
 
       if (this->IsPrimaryStep()) {
@@ -1264,7 +1264,7 @@ CommonStepInCtld::StepStatusChange(crane::grpc::TaskStatus new_status,
         // Primary step CONFIGURE_FAILED, free daemon step, will send status
         // change.
         for (const auto& node : job->DaemonStep()->CranedIds()) {
-          context->craned_jobs_to_free[node].emplace_back(job->TaskId());
+          context->craned_jobs_to_free[node].emplace_back(job->JobId());
         }
       } else {
         for (const auto& node : this->CranedIds()) {
@@ -1278,7 +1278,7 @@ CommonStepInCtld::StepStatusChange(crane::grpc::TaskStatus new_status,
         context->rn_step_raw_ptrs.emplace(job->DaemonStep());
         // Primary step finish, free daemon step, will send status change.
         for (const auto& node : job->DaemonStep()->CranedIds()) {
-          context->craned_jobs_to_free[node].emplace_back(job->TaskId());
+          context->craned_jobs_to_free[node].emplace_back(job->JobId());
         }
 
         std::unordered_set<step_id_t> pd_steps;
@@ -1289,7 +1289,7 @@ CommonStepInCtld::StepStatusChange(crane::grpc::TaskStatus new_status,
         const absl::Time& cancel_time = this->EndTime();
         for (const auto& comm_step : job->Steps() | std::views::values) {
           // All pending steps are crun steps, just set status to cancelled
-          if (comm_step->Status() == crane::grpc::TaskStatus::Pending) {
+          if (comm_step->Status() == crane::grpc::JobStatus::Pending) {
             comm_step->SetStatus(crane::grpc::Cancelled);
             comm_step->SetStartTime(cancel_time);
             comm_step->SetEndTime(cancel_time);
@@ -1339,7 +1339,7 @@ CommonStepInCtld::StepStatusChange(crane::grpc::TaskStatus new_status,
         this->SetStatus(this->PrevErrorStatus().value());
         this->SetExitCode(this->PrevErrorExitCode());
       } else {
-        this->SetStatus(crane::grpc::TaskStatus::Completed);
+        this->SetStatus(crane::grpc::JobStatus::Completed);
         this->SetExitCode(exit_code);
       }
 
@@ -1364,7 +1364,7 @@ CommonStepInCtld::StepStatusChange(crane::grpc::TaskStatus new_status,
 }
 
 void CommonStepInCtld::RecoverFromDb(
-    const TaskInCtld& job, const crane::grpc::StepInEmbeddedDb& step_in_db) {
+    const JobInCtld& job, const crane::grpc::StepInEmbeddedDb& step_in_db) {
   StepInCtld::RecoverFromDb(job, step_in_db);
 
   /* Fields only in CommonStepInCtld */
@@ -1385,27 +1385,27 @@ void CommonStepInCtld::SetFieldsOfStepInfo(
       static_cast<crane::grpc::ResourceView>(m_allocated_res_.View());
 }
 
-bool TaskInCtld::IsX11() const {
+bool JobInCtld::IsX11() const {
   if (!IsInteractive()) return false;
-  auto const& ia_meta = this->task_to_ctld.interactive_meta();
+  auto const& ia_meta = this->job_to_ctld.interactive_meta();
   return ia_meta.x11();
 }
 
-bool TaskInCtld::IsX11WithPty() const {
+bool JobInCtld::IsX11WithPty() const {
   if (!IsX11()) return false;
-  auto const& ia_meta = this->task_to_ctld.interactive_meta();
+  auto const& ia_meta = this->job_to_ctld.interactive_meta();
   return ia_meta.pty();
 }
 
-bool TaskInCtld::ShouldLaunchOnAllNodes() const {
+bool JobInCtld::ShouldLaunchOnAllNodes() const {
   if (IsBatch()) {
     // For cbatch jobs whose --node > 1,
     // only execute the command at the first allocated node.
     return false;
 
   } else if (IsInteractive()) {
-    const auto& ia_meta = TaskToCtld().interactive_meta();
-    // For calloc jobs we still need to execute a dummy empty task to
+    const auto& ia_meta = JobToCtld().interactive_meta();
+    // For calloc jobs we still need to execute a dummy empty job to
     // set up a timer.
     if (ia_meta.interactive_type() == crane::grpc::Calloc) return false;
 
@@ -1419,94 +1419,94 @@ bool TaskInCtld::ShouldLaunchOnAllNodes() const {
     // For container jobs, there is two cases:
     // 1. ccon jobs: always launch on all nodes.
     // 2. cbatch jobs with container support: only launch on the first node.
-    return TaskToCtld().has_container_meta();
+    return JobToCtld().has_container_meta();
 
   } else {
     std::unreachable();
   }
 }
 
-void TaskInCtld::SetTaskId(task_id_t id) {
-  task_id = id;
-  runtime_attr.set_task_id(id);
+void JobInCtld::SetJobId(job_id_t id) {
+  job_id = id;
+  runtime_attr.set_job_id(id);
 }
 
-void TaskInCtld::SetTaskDbId(task_db_id_t id) {
-  task_db_id = id;
-  runtime_attr.set_task_db_id(id);
+void JobInCtld::SetJobDbId(job_db_id_t id) {
+  job_db_id = id;
+  runtime_attr.set_job_db_id(id);
 }
 
-void TaskInCtld::SetUsername(std::string const& val) {
+void JobInCtld::SetUsername(std::string const& val) {
   username = val;
   runtime_attr.set_username(val);
 }
 
-void TaskInCtld::SetCranedIds(std::vector<CranedId>&& val) {
+void JobInCtld::SetCranedIds(std::vector<CranedId>&& val) {
   runtime_attr.mutable_craned_ids()->Assign(val.begin(), val.end());
   craned_ids = std::move(val);
 }
 
-void TaskInCtld::CranedIdsClear() {
+void JobInCtld::CranedIdsClear() {
   craned_ids.clear();
   runtime_attr.mutable_craned_ids()->Clear();
 }
 
-void TaskInCtld::CranedIdsAdd(CranedId const& i) {
+void JobInCtld::CranedIdsAdd(CranedId const& i) {
   craned_ids.emplace_back(i);
   *runtime_attr.mutable_craned_ids()->Add() = i;
 }
 
-void TaskInCtld::SetPrimaryStepStatus(crane::grpc::TaskStatus val) {
+void JobInCtld::SetPrimaryStepStatus(crane::grpc::JobStatus val) {
   primary_status = val;
   runtime_attr.set_primary_step_status(val);
 }
 
-void TaskInCtld::SetStatus(crane::grpc::TaskStatus val) {
+void JobInCtld::SetStatus(crane::grpc::JobStatus val) {
   status = val;
   runtime_attr.set_status(val);
 }
 
-void TaskInCtld::SetPrimaryStepExitCode(uint32_t val) {
+void JobInCtld::SetPrimaryStepExitCode(uint32_t val) {
   primary_exit_code = val;
   runtime_attr.set_primary_step_exit_code(val);
 }
 
-void TaskInCtld::SetExitCode(uint32_t val) {
+void JobInCtld::SetExitCode(uint32_t val) {
   exit_code = val;
   runtime_attr.set_exit_code(val);
 }
 
-void TaskInCtld::SetSubmitTime(absl::Time const& val) {
+void JobInCtld::SetSubmitTime(absl::Time const& val) {
   submit_time = val;
   runtime_attr.mutable_submit_time()->set_seconds(ToUnixSeconds(submit_time));
 }
 
-void TaskInCtld::SetSubmitTimeByUnixSecond(uint64_t val) {
+void JobInCtld::SetSubmitTimeByUnixSecond(uint64_t val) {
   submit_time = absl::FromUnixSeconds(val);
   runtime_attr.mutable_submit_time()->set_seconds(val);
 }
 
-void TaskInCtld::SetStartTime(absl::Time const& val) {
+void JobInCtld::SetStartTime(absl::Time const& val) {
   start_time = val;
   runtime_attr.mutable_start_time()->set_seconds(ToUnixSeconds(start_time));
 }
 
-void TaskInCtld::SetStartTimeByUnixSecond(uint64_t val) {
+void JobInCtld::SetStartTimeByUnixSecond(uint64_t val) {
   start_time = absl::FromUnixSeconds(val);
   runtime_attr.mutable_start_time()->set_seconds(val);
 }
 
-void TaskInCtld::SetEndTime(absl::Time const& val) {
+void JobInCtld::SetEndTime(absl::Time const& val) {
   SetEndTimeByUnixSecond(ToUnixSeconds(val));
 }
 
-void TaskInCtld::SetEndTimeByUnixSecond(uint64_t val) {
-  val = std::min<uint64_t>(val, kTaskMaxTimeStampSec);
+void JobInCtld::SetEndTimeByUnixSecond(uint64_t val) {
+  val = std::min<uint64_t>(val, kJobMaxTimeStampSec);
   end_time = absl::FromUnixSeconds(val);
   runtime_attr.mutable_end_time()->set_seconds(val);
 }
 
-void TaskInCtld::SetActualLicenses(
+void JobInCtld::SetActualLicenses(
     std::unordered_map<LicenseId, uint32_t>&& actual_licenses) {
   auto* mutable_map = runtime_attr.mutable_actual_licenses();
   for (const auto& [id, count] : actual_licenses) {
@@ -1515,23 +1515,23 @@ void TaskInCtld::SetActualLicenses(
   licenses_count = std::move(actual_licenses);
 }
 
-void TaskInCtld::SetHeld(bool val) {
+void JobInCtld::SetHeld(bool val) {
   held = val;
   runtime_attr.set_held(val);
 }
 
-void TaskInCtld::SetCachedPriority(double val) {
+void JobInCtld::SetCachedPriority(double val) {
   cached_priority = val;
   runtime_attr.set_cached_priority(val);
 }
 
-void TaskInCtld::SetAllocatedRes(ResourceV2&& val) {
+void JobInCtld::SetAllocatedRes(ResourceV2&& val) {
   *runtime_attr.mutable_allocated_res() =
       static_cast<crane::grpc::ResourceV2>(val);
   allocated_res = std::move(val);
 }
 
-void TaskInCtld::SetDependency(const crane::grpc::Dependencies& grpc_deps) {
+void JobInCtld::SetDependency(const crane::grpc::Dependencies& grpc_deps) {
   if (grpc_deps.is_or()) {
     dependencies.is_or = true;
     dependencies.ready_time = absl::InfiniteFuture();
@@ -1544,30 +1544,30 @@ void TaskInCtld::SetDependency(const crane::grpc::Dependencies& grpc_deps) {
   }
 }
 
-void TaskInCtld::UpdateDependency(task_id_t dep_job_id, absl::Time event_time) {
+void JobInCtld::UpdateDependency(job_id_t dep_job_id, absl::Time event_time) {
   dependencies.update(dep_job_id, event_time);
 }
 
-void TaskInCtld::AddDependent(crane::grpc::DependencyType dep_type,
-                              task_id_t dep_job_id) {
+void JobInCtld::AddDependent(crane::grpc::DependencyType dep_type,
+                              job_id_t dep_job_id) {
   if (dep_type == crane::grpc::DependencyType::AFTER &&
-      status != crane::grpc::TaskStatus::Pending) {
+      status != crane::grpc::JobStatus::Pending) {
     // already satisfied
-    g_task_scheduler->AddDependencyEvent(dep_job_id, task_id, start_time);
+    g_job_scheduler->AddDependencyEvent(dep_job_id, job_id, start_time);
   } else {
     dependents[dep_type].push_back(dep_job_id);
   }
 }
 
-void TaskInCtld::TriggerDependencyEvents(
+void JobInCtld::TriggerDependencyEvents(
     const crane::grpc::DependencyType& dep_type, absl::Time event_time) {
-  for (task_id_t dependent_id : dependents[dep_type]) {
-    g_task_scheduler->AddDependencyEvent(dependent_id, task_id, event_time);
+  for (job_id_t dependent_id : dependents[dep_type]) {
+    g_job_scheduler->AddDependencyEvent(dependent_id, job_id, event_time);
   }
 }
 
-void TaskInCtld::SetFieldsByTaskToCtld(crane::grpc::TaskToCtld const& val) {
-  task_to_ctld = val;
+void JobInCtld::SetFieldsByJobToCtld(crane::grpc::JobToCtld const& val) {
+  job_to_ctld = val;
 
   partition_id = (val.partition_name().empty()) ? g_config.DefaultPartition
                                                 : val.partition_name();
@@ -1577,10 +1577,10 @@ void TaskInCtld::SetFieldsByTaskToCtld(crane::grpc::TaskToCtld const& val) {
   type = val.type();
 
   if (IsContainer()) {
-    if (val.has_pod_meta()) pod_meta = PodMetaInTask(val.pod_meta());
+    if (val.has_pod_meta()) pod_meta = PodMetaInJob(val.pod_meta());
     if (val.has_container_meta()) {
-      meta.emplace<ContainerMetaInTask>(
-          ContainerMetaInTask(val.container_meta()));
+      meta.emplace<ContainerMetaInJob>(
+          ContainerMetaInJob(val.container_meta()));
     } else {
       meta.emplace<std::monostate>();
     }
@@ -1653,12 +1653,12 @@ void TaskInCtld::SetFieldsByTaskToCtld(crane::grpc::TaskToCtld const& val) {
   SetDependency(val.dependencies());
 }
 
-void TaskInCtld::SetFieldsByRuntimeAttr(
-    crane::grpc::RuntimeAttrOfTask const& val) {
+void JobInCtld::SetFieldsByRuntimeAttrOfJob(
+    crane::grpc::RuntimeAttrOfJob const& val) {
   runtime_attr = val;
 
-  task_id = runtime_attr.task_id();
-  task_db_id = runtime_attr.task_db_id();
+  job_id = runtime_attr.job_id();
+  job_db_id = runtime_attr.job_db_id();
   username = runtime_attr.username();
 
   requeue_count = runtime_attr.requeue_count();
@@ -1671,7 +1671,7 @@ void TaskInCtld::SetFieldsByRuntimeAttr(
   held = runtime_attr.held();
   cached_priority = runtime_attr.cached_priority();
 
-  if (status != crane::grpc::TaskStatus::Pending) {
+  if (status != crane::grpc::JobStatus::Pending) {
     craned_ids.assign(runtime_attr.craned_ids().begin(),
                       runtime_attr.craned_ids().end());
     allocated_craneds_regex = util::HostNameListToStr(craned_ids);
@@ -1696,51 +1696,51 @@ void TaskInCtld::SetFieldsByRuntimeAttr(
                                       runtime_attr.actual_licenses().end()};
 }
 
-void TaskInCtld::SetFieldsOfTaskInfo(crane::grpc::TaskInfo* task_info) {
-  task_info->set_type(type);
-  task_info->set_task_id(task_id);
-  task_info->set_name(name);
+void JobInCtld::SetFieldsOfJobInfo(crane::grpc::JobInfo* job_info) {
+  job_info->set_type(type);
+  job_info->set_job_id(job_id);
+  job_info->set_name(name);
 
-  task_info->set_account(account);
-  task_info->set_partition(partition_id);
-  task_info->set_qos(qos);
+  job_info->set_account(account);
+  job_info->set_partition(partition_id);
+  job_info->set_qos(qos);
 
-  task_info->mutable_time_limit()->set_seconds(ToInt64Seconds(time_limit));
-  task_info->mutable_submit_time()->CopyFrom(runtime_attr.submit_time());
-  task_info->mutable_start_time()->CopyFrom(runtime_attr.start_time());
-  task_info->mutable_end_time()->CopyFrom(runtime_attr.end_time());
+  job_info->mutable_time_limit()->set_seconds(ToInt64Seconds(time_limit));
+  job_info->mutable_submit_time()->CopyFrom(runtime_attr.submit_time());
+  job_info->mutable_start_time()->CopyFrom(runtime_attr.start_time());
+  job_info->mutable_end_time()->CopyFrom(runtime_attr.end_time());
 
-  task_info->set_uid(uid);
-  task_info->set_gid(gid);
-  task_info->set_username(username);
-  task_info->set_node_num(node_num);
-  task_info->set_cmd_line(cmd_line);
-  task_info->set_cwd(cwd);
-  task_info->mutable_req_nodes()->Assign(included_nodes.begin(),
-                                         included_nodes.end());
-  task_info->mutable_exclude_nodes()->Assign(excluded_nodes.begin(),
-                                             excluded_nodes.end());
+  job_info->set_uid(uid);
+  job_info->set_gid(gid);
+  job_info->set_username(username);
+  job_info->set_node_num(node_num);
+  job_info->set_cmd_line(cmd_line);
+  job_info->set_cwd(cwd);
+  job_info->mutable_req_nodes()->Assign(included_nodes.begin(),
+                                        included_nodes.end());
+  job_info->mutable_exclude_nodes()->Assign(excluded_nodes.begin(),
+                                            excluded_nodes.end());
 
-  task_info->set_extra_attr(extra_attr);
-  task_info->set_reservation(reservation);
+  job_info->set_extra_attr(extra_attr);
+  job_info->set_reservation(reservation);
 
-  task_info->set_submit_hostname(submit_hostname);
+  job_info->set_submit_hostname(submit_hostname);
 
   // Only pass container meta if it's a container step
   // This is because ccon command requires more info than cqueue/cacct.
   if (IsContainer()) {
     if (pod_meta.has_value()) {
-      task_info->mutable_pod_meta()->CopyFrom(
-          static_cast<crane::grpc::PodTaskAdditionalMeta>(pod_meta.value()));
+      job_info->mutable_pod_meta()->CopyFrom(
+          static_cast<crane::grpc::PodJobAdditionalMeta>(pod_meta.value()));
     } else {
-      CRANE_ERROR("Container job #{} missing pod info!", task_info->task_id());
+      CRANE_ERROR("Container job #{} missing pod info!", job_info->job_id());
     }
   }
 
   // Dynamic fields
   if (!dependencies.deps.empty() ||
       dependencies.ready_time != absl::InfinitePast()) {
-    auto* dep_status = task_info->mutable_dependency_status();
+    auto* dep_status = job_info->mutable_dependency_status();
     dep_status->set_is_or(dependencies.is_or);
 
     for (const auto& [dep_job_id, dep_info] : dependencies.deps) {
@@ -1761,43 +1761,43 @@ void TaskInCtld::SetFieldsOfTaskInfo(crane::grpc::TaskInfo* task_info) {
     }
   }
 
-  task_info->set_held(held);
-  task_info->mutable_execution_node()->Assign(executing_craned_ids.begin(),
-                                              executing_craned_ids.end());
+  job_info->set_held(held);
+  job_info->mutable_execution_node()->Assign(executing_craned_ids.begin(),
+                                             executing_craned_ids.end());
 
-  *task_info->mutable_req_total_res_view() =
+  *job_info->mutable_req_total_res_view() =
       static_cast<crane::grpc::ResourceView>(req_total_res_view);
 
-  task_info->set_exit_code(runtime_attr.exit_code());
-  task_info->set_priority(cached_priority);  // FIXME: A BUG?
+  job_info->set_exit_code(runtime_attr.exit_code());
+  job_info->set_priority(cached_priority);  // FIXME: A BUG?
 
-  task_info->set_status(status);
+  job_info->set_status(status);
   if (Status() == crane::grpc::Pending) {
-    task_info->set_pending_reason(pending_reason);
+    job_info->set_pending_reason(pending_reason);
   } else {
-    task_info->set_craned_list(allocated_craneds_regex);
+    job_info->set_craned_list(allocated_craneds_regex);
   }
-  task_info->set_exclusive(task_to_ctld.exclusive());
+  job_info->set_exclusive(job_to_ctld.exclusive());
 
-  *task_info->mutable_allocated_res_view() =
+  *job_info->mutable_allocated_res_view() =
       static_cast<crane::grpc::ResourceView>(allocated_res_view);
 
   std::string wckey_info;
   if (using_default_wckey) wckey_info += "*";
   if (!wckey.empty()) wckey_info += wckey;
-  task_info->set_wckey(wckey_info);
+  job_info->set_wckey(wckey_info);
 
-  task_info->mutable_licenses_count()->insert(licenses_count.begin(),
-                                              licenses_count.end());
+  job_info->mutable_licenses_count()->insert(licenses_count.begin(),
+                                             licenses_count.end());
 
-  auto* mutable_env = task_info->mutable_env();
+  auto* mutable_env = job_info->mutable_env();
   for (auto const& [k, v] : env) {
     (*mutable_env)[k] = v;
   }
-  task_info->set_ntasks(ntasks);
+  job_info->set_ntasks(ntasks);
 }
 
-int TaskInCtld::SchedulePendingSteps(
+int JobInCtld::SchedulePendingSteps(
     std::vector<CommonStepInCtld*>* scheduled_steps) {
   int popped_count = 0;
   auto now = absl::Now();
@@ -1893,7 +1893,7 @@ int TaskInCtld::SchedulePendingSteps(
     step->SetConfiguringNodes(step_craned_ids);
     step->SetExecutionNodes(step_craned_ids);
     step->SetStartTime(now);
-    step->SetStatus(crane::grpc::TaskStatus::Configuring);
+    step->SetStatus(crane::grpc::JobStatus::Configuring);
     const auto& meta = step->ia_meta.value();
     if (step->ia_meta.has_value()) {
       const auto& meta = step->ia_meta.value();

--- a/src/CraneCtld/CtldPublicDefs.h
+++ b/src/CraneCtld/CtldPublicDefs.h
@@ -28,33 +28,33 @@ namespace Ctld {
 using moodycamel::ConcurrentQueue;
 using RegToken = google::protobuf::Timestamp;
 
-using task_db_id_t = int64_t;
+using job_db_id_t = int64_t;
 using step_db_id_t = int64_t;
 
 // *****************************************************
-// TaskScheduler Constants
+// JobScheduler Constants
 
 constexpr step_id_t kPrimaryStepId = 1;
 
-constexpr uint32_t kTaskScheduleIntervalMs = 1000;
+constexpr uint32_t kJobScheduleIntervalMs = 1000;
 constexpr uint32_t kNodePerRpcWorker = 100;
 constexpr std::size_t kMinRpcWorkerNum = 4;
 
-// Clean TaskHoldTimerQueue when timeout or exceeding batch num
-constexpr uint32_t kTaskHoldTimerTimeoutMs = 500;
-constexpr uint32_t kTaskHoldTimerBatchNum = 1000;
+// Clean JobHoldTimerQueue when timeout or exceeding batch num
+constexpr uint32_t kJobHoldTimerTimeoutMs = 500;
+constexpr uint32_t kJobHoldTimerBatchNum = 1000;
 
-// Clean CancelTaskQueue when timeout or exceeding batch num
-constexpr uint32_t kCancelTaskTimeoutMs = 500;
-constexpr uint32_t kCancelTaskBatchNum = 1000;
+// Clean CancelJobQueue when timeout or exceeding batch num
+constexpr uint32_t kCancelJobTimeoutMs = 500;
+constexpr uint32_t kCancelJobBatchNum = 1000;
 
-// Clean SubmitTaskQueue when timeout or exceeding batch num
-constexpr uint32_t kSubmitTaskTimeoutMs = 500;
-constexpr uint32_t kSubmitTaskBatchNum = 1000;
+// Clean SubmitJobQueue when timeout or exceeding batch num
+constexpr uint32_t kSubmitJobTimeoutMs = 500;
+constexpr uint32_t kSubmitJobBatchNum = 1000;
 
-// Clean TaskStatusChangeQueue when timeout or exceeding batch num
-constexpr uint32_t kTaskStatusChangeTimeoutMS = 100;
-constexpr uint32_t kTaskStatusChangeBatchNum = 1000;
+// Clean JobStatusChangeQueue when timeout or exceeding batch num
+constexpr uint32_t kJobStatusChangeTimeoutMS = 100;
+constexpr uint32_t kJobStatusChangeBatchNum = 1000;
 
 // Validate and adjust end_time to prevent it from exceeding time_limit
 // by too much. Allow 5 seconds of floating tolerance.
@@ -70,7 +70,7 @@ constexpr uint16_t kCompletionQueueEstablishedTimeoutSeconds = 45;
 
 constexpr uint16_t kProxiedCriReqTimeoutSeconds = 180;
 
-// Since Unqlite has a limitation of about 900000 tasks per transaction,
+// Since Unqlite has a limitation of about 900000 jobs per transaction,
 // we use this value to set the batch size of one dequeue action on
 // pending concurrent queue.
 constexpr uint32_t kPendingQueueMaxSize = 900000;
@@ -78,7 +78,7 @@ constexpr uint32_t kMaxScheduledBatchSize = 200000;
 constexpr uint32_t kDefaultScheduledBatchSize = 100000;
 
 constexpr int64_t kCtldRpcTimeoutSeconds = 5;
-constexpr bool kDefaultRejectTasksBeyondCapacity = false;
+constexpr bool kDefaultRejectJobsBeyondCapacity = false;
 constexpr bool kDefaultJobFileOpenModeAppend = false;
 constexpr bool kDefaultTrackWCKey = false;
 
@@ -220,7 +220,7 @@ struct Config {
 
   std::unordered_map<LicenseId, uint32_t> lic_id_to_count_map;
 
-  bool RejectTasksBeyondCapacity{false};
+  bool RejectJobsBeyondCapacity{false};
   bool JobFileOpenModeAppend{false};
   bool IgnoreConfigInconsistency{false};
   bool WckeyValid{false};
@@ -297,7 +297,7 @@ struct CranedMeta {
   absl::Time last_busy_time;
   absl::Time craned_down_time;
 
-  absl::flat_hash_map<task_id_t, ResourceInNode> rn_task_res_map;
+  absl::flat_hash_map<job_id_t, ResourceInNode> rn_job_res_map;
 
   absl::flat_hash_map<ResvId, std::pair<absl::Time, absl::Time>>
       resv_in_node_map;
@@ -317,8 +317,8 @@ struct ResvMeta {
   absl::flat_hash_set<CranedId> craned_ids;
   ResourceV2 res_total;
   ResourceV2 res_avail;
-  absl::flat_hash_map<task_id_t, ResourceV2> rn_job_res_map;
-  absl::flat_hash_set<task_id_t> pd_job_ids;
+  absl::flat_hash_map<job_id_t, ResourceV2> rn_job_res_map;
+  absl::flat_hash_set<job_id_t> pd_job_ids;
 };
 
 struct PartitionGlobalMeta {
@@ -369,7 +369,7 @@ struct InteractiveMeta {
     has_been_terminated_on_craned = other.has_been_terminated_on_craned.load();
     cfored_name = other.cfored_name;
   }
-  crane::grpc::InteractiveTaskType interactive_type;
+  crane::grpc::InteractiveJobType interactive_type;
 
   struct StepResAllocArgs {
     job_id_t job_id;
@@ -395,44 +395,44 @@ struct InteractiveMeta {
   // This will ask front end like crun/calloc to exit
   std::function<void(StepCancelArgs)> cb_step_cancel;
 
-  // ccancel for an interactive CALLOC task should call the front end to kill
-  // the user's shell, let Cfored to inform CraneCtld of task completion rather
-  // than directly sending TerminateTask to its craned node.
+  // ccancel for an interactive CALLOC job should call the front end to kill
+  // the user's shell, let Cfored to inform CraneCtld of job completion rather
+  // than directly sending TerminateStep to its craned node.
   //
   // However, when TIMEOUT event on its craned node happens, Cranectld should
-  // also send TaskCancelRequest to the front end. So we need a flag
+  // also send JobCancelRequest to the front end. So we need a flag
   // ` has_been_cancelled_on_front_end` to record whether the front end for the
-  // task has been sent a TaskCancelRequest and a flag
-  // `has_been_terminated_on_craned` to record whether the task resource
+  // job has been sent a JobCancelRequest and a flag
+  // `has_been_terminated_on_craned` to record whether the job resource
   // (cgroup) has been destroyed on its craned node.
   //
-  // If `has_been_cancelled` is true, no more TaskCancelRequest should be sent
+  // If `has_been_cancelled` is true, no more JobCancelRequest should be sent
   // to the front end. It is set when the user runs ccancel command or the
   // timeout event has been triggered on the craned node.
   //
-  // If `has_been_terminated_on_craned` is true, no more TerminateTask RPC
+  // If `has_been_terminated_on_craned` is true, no more StepTerminate RPC
   // should be sent to its craned node. It is set when the timeout event is
-  // triggered on the craned node or a TaskTerminate RPC has been sent
+  // triggered on the craned node or a StepTerminate RPC has been sent
   // (triggered by either normal shell exit or ccancel).
   std::atomic<bool> has_been_cancelled_on_front_end{false};
   std::atomic<bool> has_been_terminated_on_craned{false};
   std::string cfored_name;
 };
 
-struct PodMetaInTask {
+struct PodMetaInJob {
   struct NamespaceOption {
-    crane::grpc::PodTaskAdditionalMeta::NamespaceMode network{
-        crane::grpc::PodTaskAdditionalMeta::POD};
-    crane::grpc::PodTaskAdditionalMeta::NamespaceMode pid{
-        crane::grpc::PodTaskAdditionalMeta::POD};
-    crane::grpc::PodTaskAdditionalMeta::NamespaceMode ipc{
-        crane::grpc::PodTaskAdditionalMeta::POD};
+    crane::grpc::PodJobAdditionalMeta::NamespaceMode network{
+        crane::grpc::PodJobAdditionalMeta::POD};
+    crane::grpc::PodJobAdditionalMeta::NamespaceMode pid{
+        crane::grpc::PodJobAdditionalMeta::POD};
+    crane::grpc::PodJobAdditionalMeta::NamespaceMode ipc{
+        crane::grpc::PodJobAdditionalMeta::POD};
     std::string target_id;
   };
 
   struct PortMapping {
-    crane::grpc::PodTaskAdditionalMeta::PortMapping::Protocol protocol{
-        crane::grpc::PodTaskAdditionalMeta::PortMapping::TCP};
+    crane::grpc::PodJobAdditionalMeta::PortMapping::Protocol protocol{
+        crane::grpc::PodJobAdditionalMeta::PortMapping::TCP};
     int32_t container_port{0};
     int32_t host_port{0};
     std::string host_ip;
@@ -450,12 +450,12 @@ struct PodMetaInTask {
   std::vector<PortMapping> port_mappings;
   std::vector<std::string> dns_servers;
 
-  PodMetaInTask() = default;
-  explicit PodMetaInTask(const crane::grpc::PodTaskAdditionalMeta& rhs);
-  explicit operator crane::grpc::PodTaskAdditionalMeta() const;
+  PodMetaInJob() = default;
+  explicit PodMetaInJob(const crane::grpc::PodJobAdditionalMeta& rhs);
+  explicit operator crane::grpc::PodJobAdditionalMeta() const;
 };
 
-struct ContainerMetaInTask {
+struct ContainerMetaInJob {
   struct ImageInfo {
     std::string image;
     std::string username;
@@ -484,15 +484,15 @@ struct ContainerMetaInTask {
   // No need to define it here.
 
  public:
-  ContainerMetaInTask() = default;
+  ContainerMetaInJob() = default;
 
-  explicit ContainerMetaInTask(
-      const crane::grpc::ContainerTaskAdditionalMeta& rhs);
-  explicit operator crane::grpc::ContainerTaskAdditionalMeta() const;
+  explicit ContainerMetaInJob(
+      const crane::grpc::ContainerJobAdditionalMeta& rhs);
+  explicit operator crane::grpc::ContainerJobAdditionalMeta() const;
 };
 
 struct DependenciesInJob {
-  std::unordered_map<task_id_t,
+  std::unordered_map<job_id_t,
                      std::pair<crane::grpc::DependencyType, uint64_t>>
       deps;
   bool is_or{false};
@@ -506,10 +506,10 @@ struct DependenciesInJob {
     return ready_time >= absl::InfiniteFuture() && (!is_or || deps.empty());
   }
 
-  void update(task_id_t job_id, absl::Time event_time);
+  void update(job_id_t job_id, absl::Time event_time);
 };
 
-struct TaskInCtld;
+struct JobInCtld;
 struct StepInCtld;
 
 using StepInteractiveMeta = InteractiveMeta;
@@ -548,19 +548,19 @@ struct StepStatusChangeContext {
 
   std::unordered_map<CranedId, std::vector<job_id_t>> craned_jobs_to_free;
   // Jobs will update in embedded db
-  std::unordered_set<TaskInCtld*> rn_job_raw_ptrs{};
-  // Carry the ownership of TaskInCtld for automatic destruction.
-  std::unordered_set<std::unique_ptr<TaskInCtld>> job_ptrs;
+  std::unordered_set<JobInCtld*> rn_job_raw_ptrs{};
+  // Carry the ownership of JobInCtld for automatic destruction.
+  std::unordered_set<std::unique_ptr<JobInCtld>> job_ptrs;
   // Ended jobs will transfer from embedded db to mongodb
-  std::unordered_set<TaskInCtld*> job_raw_ptrs;
+  std::unordered_set<JobInCtld*> job_raw_ptrs;
 };
 
 // Abstract interface of all the steps in Ctld.
 struct StepInCtld {
  public:
-  crane::grpc::TaskType type;
+  crane::grpc::JobType type;
 
-  TaskInCtld* job;
+  JobInCtld* job;
   job_id_t job_id;
 
   uid_t uid;
@@ -591,15 +591,15 @@ struct StepInCtld {
 
   // In daemon step of container job, only use pod_meta.
   // In common step of container job, both are provided.
-  std::optional<PodMetaInTask> pod_meta;
-  std::optional<ContainerMetaInTask> container_meta;
+  std::optional<PodMetaInJob> pod_meta;
+  std::optional<ContainerMetaInJob> container_meta;
 
   std::string task_prolog;
   std::string task_epilog;
 
  protected:
   /* ------------- [2] -------------
-   * Fields that won't change after this task is accepted.
+   * Fields that won't change after this job is accepted.
    * Also, these fields are persisted on the disk.
    * ------------------------------- */
   step_db_id_t m_step_db_id_{0};
@@ -616,16 +616,16 @@ struct StepInCtld {
   std::unordered_set<CranedId> m_configuring_nodes_;
   std::unordered_set<CranedId> m_running_nodes_;
 
-  // If this task is PENDING, start_time is either not set (default constructed)
+  // If this job is PENDING, start_time is either not set (default constructed)
   // or an estimated start time.
-  // If this task is RUNNING, start_time is the actual starting time.
+  // If this job is RUNNING, start_time is the actual starting time.
   absl::Time m_submit_time_;
   absl::Time m_start_time_;
   absl::Time m_end_time_;
 
-  crane::grpc::TaskStatus m_error_status{crane::grpc::TaskStatus::Invalid};
+  crane::grpc::JobStatus m_error_status{crane::grpc::JobStatus::Invalid};
   uint32_t m_error_exit_code_{0u};
-  crane::grpc::TaskStatus m_status_{crane::grpc::TaskStatus::Invalid};
+  crane::grpc::JobStatus m_status_{crane::grpc::JobStatus::Invalid};
   uint32_t m_exit_code_{};
 
   bool m_held_{false};
@@ -691,17 +691,17 @@ struct StepInCtld {
   void SetEndTime(absl::Time end_time);
   absl::Time EndTime() const { return m_end_time_; }
 
-  void SetErrorStatus(crane::grpc::TaskStatus failed_status);
-  std::optional<crane::grpc::TaskStatus> PrevErrorStatus() {
-    if (m_error_status == crane::grpc::TaskStatus::Invalid) {
+  void SetErrorStatus(crane::grpc::JobStatus failed_status);
+  std::optional<crane::grpc::JobStatus> PrevErrorStatus() {
+    if (m_error_status == crane::grpc::JobStatus::Invalid) {
       return std::nullopt;
     }
     return m_error_status;
   }
   void SetErrorExitCode(uint32_t exit_code);
   uint32_t PrevErrorExitCode() { return m_error_exit_code_; }
-  void SetStatus(crane::grpc::TaskStatus new_status);
-  crane::grpc::TaskStatus Status() const { return m_status_; }
+  void SetStatus(crane::grpc::JobStatus new_status);
+  crane::grpc::JobStatus Status() const { return m_status_; }
 
   void SetExitCode(uint32_t exit_code);
   uint32_t ExitCode() const { return m_exit_code_; }
@@ -717,7 +717,7 @@ struct StepInCtld {
   [[nodiscard]] virtual crane::grpc::StepToD GetStepToD(
       const CranedId& craned_id) const = 0;
 
-  virtual void RecoverFromDb(const TaskInCtld& job,
+  virtual void RecoverFromDb(const JobInCtld& job,
                              crane::grpc::StepInEmbeddedDb const& step_in_db);
 
   // Helper function to set the fields of StepInfo using info in
@@ -740,20 +740,20 @@ struct DaemonStepInCtld : StepInCtld {
     return !m_ctld_prolog_pending_;
   }
 
-  void InitFromJob(const TaskInCtld& job);
+  void InitFromJob(const JobInCtld& job);
   [[nodiscard]] crane::grpc::JobToD GetJobToD(const CranedId& craned_id) const;
 
   // Interface methods
   [[nodiscard]] crane::grpc::StepToD GetStepToD(
       const CranedId& craned_id) const override;
 
-  std::optional<std::pair<crane::grpc::TaskStatus, uint32_t /*exit code*/>>
-  StepStatusChange(crane::grpc::TaskStatus new_status, uint32_t exit_code,
+  std::optional<std::pair<crane::grpc::JobStatus, uint32_t /*exit code*/>>
+  StepStatusChange(crane::grpc::JobStatus new_status, uint32_t exit_code,
                    const std::string& reason, const CranedId& craned_id,
                    const google::protobuf::Timestamp& timestamp,
                    StepStatusChangeContext* context);
 
-  void RecoverFromDb(const TaskInCtld& job,
+  void RecoverFromDb(const JobInCtld& job,
                      const crane::grpc::StepInEmbeddedDb& step_in_db) override;
   void SetFieldsOfStepInfo(
       crane::grpc::StepInfo* step_info) const noexcept override;
@@ -773,30 +773,30 @@ struct CommonStepInCtld : StepInCtld {
    * ----------- */
 
   std::string allocated_craneds_regex;
-  // TODO: Schedule thread should fill in following task map
+  // TODO: Schedule thread should fill in following job map
   std::unordered_map<task_id_t, ResourceInNode> task_res_map;
   std::unordered_map<CranedId, std::unordered_set<task_id_t>> craned_task_map;
 
   ~CommonStepInCtld() override = default;
 
-  void InitPrimaryStepFromJob(TaskInCtld& job);
+  void InitPrimaryStepFromJob(JobInCtld& job);
   bool IsPrimaryStep() const noexcept;
   void SetFieldsByStepToCtld(const crane::grpc::StepToCtld& step_to_ctld);
   [[nodiscard]] crane::grpc::StepToD GetStepToD(
       const CranedId& craned_id) const override;
 
-  std::optional<std::pair<crane::grpc::TaskStatus, uint32_t>> StepStatusChange(
-      crane::grpc::TaskStatus new_status, uint32_t exit_code,
+  std::optional<std::pair<crane::grpc::JobStatus, uint32_t>> StepStatusChange(
+      crane::grpc::JobStatus new_status, uint32_t exit_code,
       const std::string& reason, const CranedId& craned_id,
       const google::protobuf::Timestamp& timestamp,
       StepStatusChangeContext* context);
-  void RecoverFromDb(const TaskInCtld& job,
+  void RecoverFromDb(const JobInCtld& job,
                      const crane::grpc::StepInEmbeddedDb& step_in_db) override;
   void SetFieldsOfStepInfo(
       crane::grpc::StepInfo* step_info) const noexcept override;
 };
 
-struct TaskInCtld {
+struct JobInCtld {
   /* -------- [1] Fields that are set at the submission time. ------- */
   absl::Duration time_limit;
 
@@ -806,7 +806,7 @@ struct TaskInCtld {
   ResourceView req_task_res_view;
   ResourceView req_total_res_view;
 
-  crane::grpc::TaskType type;
+  crane::grpc::JobType type;
 
   uid_t uid;
   gid_t gid;
@@ -832,10 +832,10 @@ struct TaskInCtld {
   std::string extra_attr;
 
   // used to construct a primary step.
-  std::variant<std::monostate, InteractiveMeta, ContainerMetaInTask> meta;
+  std::variant<std::monostate, InteractiveMeta, ContainerMetaInJob> meta;
 
   // used to construct daemon step for container enabled job.
-  std::optional<PodMetaInTask> pod_meta;
+  std::optional<PodMetaInJob> pod_meta;
 
   std::string reservation;
   absl::Time begin_time{absl::InfinitePast()};
@@ -853,13 +853,13 @@ struct TaskInCtld {
 
  private:
   /* ------------- [2] -------------
-   * Fields that won't change after this task is accepted.
+   * Fields that won't change after this job is accepted.
    * Also, these fields are persisted on the disk.
    * ------------------------------- */
-  task_id_t task_id{0};
-  task_db_id_t task_db_id{0};
+  job_id_t job_id{0};
+  job_db_id_t job_db_id{0};
   std::string username;
-  std::vector<task_id_t> dependents[crane::grpc::DependencyType_ARRAYSIZE];
+  std::vector<job_id_t> dependents[crane::grpc::DependencyType_ARRAYSIZE];
 
   /* ----------- [3] ----------------
    * Fields that may change at run time.
@@ -867,8 +867,8 @@ struct TaskInCtld {
    * -------------------------------- */
   int32_t requeue_count{0};
   std::vector<CranedId> craned_ids;
-  crane::grpc::TaskStatus primary_status{};
-  crane::grpc::TaskStatus status{};
+  crane::grpc::JobStatus primary_status{};
+  crane::grpc::JobStatus status{};
   uint32_t primary_exit_code{};
   uint32_t exit_code{};
   bool held{false};
@@ -884,24 +884,24 @@ struct TaskInCtld {
   std::queue<step_id_t> pending_step_ids_;
   ResourceV2 step_res_avail_;
 
-  // If this task is PENDING, start_time is either not set (default constructed)
+  // If this job is PENDING, start_time is either not set (default constructed)
   // or an estimated start time.
-  // If this task is RUNNING, start_time is the actual starting time.
+  // If this job is RUNNING, start_time is the actual starting time.
   absl::Time submit_time;
   absl::Time start_time;
   absl::Time end_time;
 
-  // persisted for querying priority of running tasks
+  // persisted for querying priority of running jobs
   double cached_priority{0.0};
 
   // Might change at each scheduling cycle.
   ResourceV2 allocated_res;
 
   /* ------ duplicate of the fields [1] above just for convenience ----- */
-  crane::grpc::TaskToCtld task_to_ctld;
+  crane::grpc::JobToCtld job_to_ctld;
 
   /* ------ duplicate of the fields [2][3] above just for convenience ----- */
-  crane::grpc::RuntimeAttrOfTask runtime_attr;
+  crane::grpc::RuntimeAttrOfJob runtime_attr;
 
  public:
   /* -----------
@@ -909,10 +909,10 @@ struct TaskInCtld {
    * However, these fields are NOT persisted on the disk.
    * These fields are cached for performance purpose.
    * ----------- */
-  // set in SetFieldsByTaskToCtld from uid
+  // set in SetFieldsByJobToCtld from uid
   std::unique_ptr<PasswordEntry> password_entry;
 
-  // Set in TaskScheduler->AcquireAttributes()
+  // Set in JobScheduler->AcquireAttributes()
   uint32_t partition_priority{0};
   uint32_t qos_priority{0};
 
@@ -938,32 +938,32 @@ struct TaskInCtld {
   bool IsBatch() const { return type == crane::grpc::Batch; }
   bool IsInteractive() const { return type == crane::grpc::Interactive; }
   bool IsCrun() const {
-    return type == crane::grpc::TaskType::Interactive &&
-           task_to_ctld.interactive_meta().interactive_type() ==
-               crane::grpc::InteractiveTaskType::Crun;
+    return type == crane::grpc::JobType::Interactive &&
+           job_to_ctld.interactive_meta().interactive_type() ==
+               crane::grpc::InteractiveJobType::Crun;
   }
   bool IsCalloc() const {
-    return type == crane::grpc::TaskType::Interactive &&
-           task_to_ctld.interactive_meta().interactive_type() ==
-               crane::grpc::InteractiveTaskType::Calloc;
+    return type == crane::grpc::JobType::Interactive &&
+           job_to_ctld.interactive_meta().interactive_type() ==
+               crane::grpc::InteractiveJobType::Calloc;
   }
   bool IsContainer() const { return type == crane::grpc::Container; }
   bool IsX11() const;
   bool IsX11WithPty() const;
   bool ShouldLaunchOnAllNodes() const;
 
-  crane::grpc::TaskToCtld const& TaskToCtld() const { return task_to_ctld; }
-  crane::grpc::TaskToCtld* MutableTaskToCtld() { return &task_to_ctld; }
+  crane::grpc::JobToCtld const& JobToCtld() const { return job_to_ctld; }
+  crane::grpc::JobToCtld* MutableJobToCtld() { return &job_to_ctld; }
 
-  crane::grpc::RuntimeAttrOfTask const& RuntimeAttr() { return runtime_attr; }
+  crane::grpc::RuntimeAttrOfJob const& RuntimeAttr() { return runtime_attr; }
 
   // =================== Setter/Getter ===================
 
-  void SetTaskId(task_id_t id);
-  task_id_t TaskId() const { return task_id; }
+  void SetJobId(job_id_t id);
+  job_id_t JobId() const { return job_id; }
 
-  void SetTaskDbId(task_db_id_t id);
-  task_id_t TaskDbId() const { return task_db_id; }
+  void SetJobDbId(job_db_id_t id);
+  job_id_t JobDbId() const { return job_db_id; }
 
   void SetUsername(std::string const& val);
   std::string const& Username() const { return username; }
@@ -973,11 +973,11 @@ struct TaskInCtld {
   void CranedIdsClear();
   void CranedIdsAdd(CranedId const& i);
 
-  void SetPrimaryStepStatus(crane::grpc::TaskStatus val);
-  crane::grpc::TaskStatus PrimaryStepStatus() const { return primary_status; }
+  void SetPrimaryStepStatus(crane::grpc::JobStatus val);
+  crane::grpc::JobStatus PrimaryStepStatus() const { return primary_status; }
 
-  void SetStatus(crane::grpc::TaskStatus val);
-  crane::grpc::TaskStatus Status() const { return status; }
+  void SetStatus(crane::grpc::JobStatus val);
+  crane::grpc::JobStatus Status() const { return status; }
 
   void SetPrimaryStepExitCode(uint32_t val);
   uint32_t PrimaryStepExitCode() const { return primary_exit_code; }
@@ -1027,7 +1027,7 @@ struct TaskInCtld {
   }
 
   void AddStep(std::unique_ptr<CommonStepInCtld>&& step) {
-    CRANE_ASSERT(step->type != crane::grpc::TaskType::Batch);
+    CRANE_ASSERT(step->type != crane::grpc::JobType::Batch);
     step->job = this;
     pending_step_ids_.push(step->StepId());
     m_steps_.emplace(step->StepId(), std::move(step));
@@ -1068,21 +1068,21 @@ struct TaskInCtld {
   ResourceV2 const& AllocatedRes() const { return allocated_res; }
 
   void SetDependency(const crane::grpc::Dependencies& grpc_deps);
-  void UpdateDependency(task_id_t dep_job_id, absl::Time event_time);
+  void UpdateDependency(job_id_t dep_job_id, absl::Time event_time);
   DependenciesInJob const& Dependencies() const { return dependencies; }
-  void AddDependent(crane::grpc::DependencyType dep_type, task_id_t dep_job_id);
+  void AddDependent(crane::grpc::DependencyType dep_type, job_id_t dep_job_id);
   void TriggerDependencyEvents(const crane::grpc::DependencyType& dep_type,
                                absl::Time event_time);
 
-  void SetFieldsByTaskToCtld(crane::grpc::TaskToCtld const& val);
+  void SetFieldsByJobToCtld(crane::grpc::JobToCtld const& val);
 
-  // Must be called after SetFieldsByTaskToCtld!
-  void SetFieldsByRuntimeAttr(crane::grpc::RuntimeAttrOfTask const& val);
+  // Must be called after SetFieldsByJobToCtld!
+  void SetFieldsByRuntimeAttrOfJob(crane::grpc::RuntimeAttrOfJob const& val);
 
-  // Helper function to set the fields of TaskInfo using info in
-  // TaskInCtld. Note that mutable_elapsed_time() is not set here for
+  // Helper function to set the fields of JobInfo using info in
+  // JobInCtld. Note that mutable_elapsed_time() is not set here for
   // performance reason. The caller should set it manually.
-  void SetFieldsOfTaskInfo(crane::grpc::TaskInfo* task_info);
+  void SetFieldsOfJobInfo(crane::grpc::JobInfo* job_info);
 };
 
 enum class QosFlags { DenyOnLimit, _Count };
@@ -1095,8 +1095,8 @@ struct Qos {
   uint32_t priority;
   uint32_t max_jobs_per_user;
   uint32_t max_jobs_per_account;
-  uint32_t max_running_tasks_per_user;
-  absl::Duration max_time_limit_per_task;
+  uint32_t max_running_jobs_per_user;
+  absl::Duration max_time_limit_per_job;
   uint32_t max_cpus_per_user;
   uint32_t max_submit_jobs_per_user;
   uint32_t max_submit_jobs_per_account;
@@ -1123,8 +1123,8 @@ struct Qos {
   static constexpr const char* FieldStringOfMaxJobsPerAccount() {
     return "max_jobs_per_account";
   }
-  static constexpr const char* FieldStringOfMaxTimeLimitPerTask() {
-    return "max_time_limit_per_task";
+  static constexpr const char* FieldStringOfMaxTimeLimitPerJob() {
+    return "max_time_limit_per_job";
   }
   static constexpr const char* FieldStringOfMaxCpusPerUser() {
     return "max_cpus_per_user";
@@ -1152,15 +1152,15 @@ struct Qos {
   std::string QosToString() const {
     return fmt::format(
         "name: {}, description: {}, reference_count: {}, priority: {}, "
-        "max_jobs_per_user: {}, max_running_tasks_per_user: {}, "
-        "max_time_limit_per_task: {}, max_cpus_per_user: {}, "
+        "max_jobs_per_user: {}, max_running_jobs_per_user: {}, "
+        "max_time_limit_per_job: {}, max_cpus_per_user: {}, "
         "max_jobs_per_account: {}, "
         "max_submit_jobs_per_user: {}, max_submit_jobs_per_account: {}, "
         "max_jobs: {}, max_submit_jobs: {}, max_wall: {}, flags: {}, max_tres: "
         "{}, max_tres_per_user: {}, max_tres_per_account: {}",
         name, description, reference_count, priority, max_jobs_per_user,
-        max_running_tasks_per_user,
-        absl::FormatDuration(max_time_limit_per_task), max_cpus_per_user,
+        max_running_jobs_per_user,
+        absl::FormatDuration(max_time_limit_per_job), max_cpus_per_user,
         max_jobs_per_account, max_submit_jobs_per_user,
         max_submit_jobs_per_account, max_jobs, max_submit_jobs,
         absl::FormatDuration(max_wall), flags.ToString(),
@@ -1180,8 +1180,8 @@ struct Qos {
       return "max_jobs_per_user";
     case crane::grpc::ModifyField::MaxCpusPerUser:
       return "max_cpus_per_user";
-    case crane::grpc::ModifyField::MaxTimeLimitPerTask:
-      return "max_time_limit_per_task";
+    case crane::grpc::ModifyField::MaxTimeLimitPerJob:
+      return "max_time_limit_per_job";
     case crane::grpc::ModifyField::MaxJobsPerAccount:
       return "max_jobs_per_account";
     case crane::grpc::ModifyField::MaxSubmitJobsPerUser:
@@ -1366,7 +1366,7 @@ struct License {
 };
 
 inline bool CheckIfTimeLimitSecIsValid(int64_t sec) {
-  return sec >= kTaskMinTimeLimitSec && sec <= kTaskMaxTimeLimitSec;
+  return sec >= kJobMinTimeLimitSec && sec <= kJobMaxTimeLimitSec;
 }
 
 inline bool CheckIfTimeLimitIsValid(absl::Duration d) {

--- a/src/CraneCtld/CtldPublicDefs.h
+++ b/src/CraneCtld/CtldPublicDefs.h
@@ -962,7 +962,7 @@ struct JobInCtld {
   job_id_t JobId() const { return job_id; }
 
   void SetJobDbId(job_db_id_t id);
-  job_id_t JobDbId() const { return job_db_id; }
+  job_db_id_t JobDbId() const { return job_db_id; }
 
   void SetUsername(std::string const& val);
   std::string const& Username() const { return username; }

--- a/src/CraneCtld/CtldPublicDefs.h
+++ b/src/CraneCtld/CtldPublicDefs.h
@@ -492,8 +492,7 @@ struct ContainerMetaInJob {
 };
 
 struct DependenciesInJob {
-  std::unordered_map<job_id_t,
-                     std::pair<crane::grpc::DependencyType, uint64_t>>
+  std::unordered_map<job_id_t, std::pair<crane::grpc::DependencyType, uint64_t>>
       deps;
   bool is_or{false};
   absl::Time ready_time{absl::InfinitePast()};
@@ -1159,9 +1158,8 @@ struct Qos {
         "max_jobs: {}, max_submit_jobs: {}, max_wall: {}, flags: {}, max_tres: "
         "{}, max_tres_per_user: {}, max_tres_per_account: {}",
         name, description, reference_count, priority, max_jobs_per_user,
-        max_running_jobs_per_user,
-        absl::FormatDuration(max_time_limit_per_job), max_cpus_per_user,
-        max_jobs_per_account, max_submit_jobs_per_user,
+        max_running_jobs_per_user, absl::FormatDuration(max_time_limit_per_job),
+        max_cpus_per_user, max_jobs_per_account, max_submit_jobs_per_user,
         max_submit_jobs_per_account, max_jobs, max_submit_jobs,
         absl::FormatDuration(max_wall), flags.ToString(),
         util::ReadableResourceView(max_tres),

--- a/src/CraneCtld/DbClient.cpp
+++ b/src/CraneCtld/DbClient.cpp
@@ -420,9 +420,8 @@ bool MongodbClient::InsertRecoveredJob(
 
   // Create filter by job_id
   document filter;
-  filter.append(
-      kvp("job_id",
-          static_cast<int32_t>(job_in_embedded_db.runtime_attr().job_id())));
+  filter.append(kvp("job_id", static_cast<int32_t>(
+                                  job_in_embedded_db.runtime_attr().job_id())));
 
   // Use $set to update job fields, and $setOnInsert for steps array
   document update_doc;
@@ -737,7 +736,7 @@ bool MongodbClient::FetchJobRecords(
 
   mongocxx::cursor cursor =
       (*GetClient_())[m_db_name_][m_job_collection_name_].find(filter.view(),
-                                                                option);
+                                                               option);
 
   // 0  job_id        job_db_id      mod_time       deleted       account
   // 5  cpus_req      mem_req        job_name       env           id_user
@@ -1020,7 +1019,7 @@ bool MongodbClient::FetchJobStepRecords(
 
   mongocxx::cursor cursor =
       (*GetClient_())[m_db_name_][m_job_collection_name_].find(filter.view(),
-                                                                option);
+                                                               option);
 
   // 0  job_id        job_db_id      mod_time       deleted       account
   // 5  cpus_req      mem_req        job_name       env           id_user
@@ -1090,8 +1089,8 @@ bool MongodbClient::CheckJobDbIdExisted(int64_t job_db_id) {
 std::unordered_map<
     job_id_t, std::tuple<crane::grpc::JobStatus, uint32_t, int64_t, int64_t>>
 MongodbClient::FetchJobStatus(const std::unordered_set<job_id_t>& job_ids) {
-  std::unordered_map<job_id_t, std::tuple<crane::grpc::JobStatus, uint32_t,
-                                           int64_t, int64_t>>
+  std::unordered_map<
+      job_id_t, std::tuple<crane::grpc::JobStatus, uint32_t, int64_t, int64_t>>
       result;
 
   if (job_ids.empty()) {
@@ -1119,7 +1118,7 @@ MongodbClient::FetchJobStatus(const std::unordered_set<job_id_t>& job_ids) {
 
     mongocxx::cursor cursor =
         (*GetClient_())[m_db_name_][m_job_collection_name_].find(filter.view(),
-                                                                  options);
+                                                                 options);
 
     for (auto view : cursor) {
       job_id_t fetched_job_id = view["job_id"].get_int32().value;
@@ -1254,8 +1253,7 @@ bool MongodbClient::CheckStepExisted(job_id_t job_id, step_id_t step_id) {
 
 // Real-time aggregation: Append job to acc_usage tables (hour/day/month)
 void MongodbClient::AppendToAccUsageTable(
-    const bsoncxx::document::view& job_doc,
-    mongocxx::client_session* session) {
+    const bsoncxx::document::view& job_doc, mongocxx::client_session* session) {
   using namespace std::chrono;
 
   try {
@@ -1325,8 +1323,8 @@ void MongodbClient::AppendToAccUsageTable(const JobInCtld* job,
     AppendToMonthTable_(info, session);
 
   } catch (const std::exception& e) {
-    CRANE_ERROR("Failed to append job {} to acc_usage tables: {}",
-                job->JobId(), e.what());
+    CRANE_ERROR("Failed to append job {} to acc_usage tables: {}", job->JobId(),
+                e.what());
     throw;
   }
 }
@@ -1537,7 +1535,7 @@ void MongodbClient::AppendToMonthTable_(const JobAggregationInfo& info,
 
 // Mark job as aggregated in job_table
 void MongodbClient::MarkJobAsAggregated(job_id_t job_id,
-                                         mongocxx::client_session* session) {
+                                        mongocxx::client_session* session) {
   using bsoncxx::builder::basic::kvp;
   using bsoncxx::builder::basic::make_document;
   using namespace std::chrono;
@@ -1554,7 +1552,7 @@ void MongodbClient::MarkJobAsAggregated(job_id_t job_id,
         *session, filter.view(), update.view());
   } else {
     (*client)[m_db_name_][m_job_collection_name_].update_one(filter.view(),
-                                                              update.view());
+                                                             update.view());
   }
 }
 
@@ -1786,8 +1784,7 @@ void MongodbClient::RecoverExistingClusterAggregations_() {
                   static_cast<int64_t>(crane::grpc::JobStatus::Cancelled),
                   static_cast<int64_t>(crane::grpc::JobStatus::Completed),
                   static_cast<int64_t>(crane::grpc::JobStatus::OutOfMemory),
-                  static_cast<int64_t>(
-                      crane::grpc::JobStatus::ExceedTimeLimit),
+                  static_cast<int64_t>(crane::grpc::JobStatus::ExceedTimeLimit),
                   static_cast<int64_t>(crane::grpc::JobStatus::Failed))))));
 
   auto cursor =
@@ -1971,8 +1968,7 @@ bool MongodbClient::QueryJobSizeSummary(
   int64_t result_count = 0;
   try {
     auto cursor =
-        (*GetClient_())[m_db_name_][m_job_collection_name_].aggregate(
-            pipeline);
+        (*GetClient_())[m_db_name_][m_job_collection_name_].aggregate(pipeline);
     for (auto doc : cursor) {
       auto id = doc["_id"].get_document().view();
       crane::grpc::JobSizeSummaryItem item;
@@ -4214,9 +4210,9 @@ MongodbClient::document MongodbClient::JobInEmbeddedDbToDocument_(
     mem_req += job_to_ctld.mem_per_node() * job_to_ctld.node_num();
   }
   if (job_to_ctld.has_cpus_per_task() && job_to_ctld.has_mem_per_cpu()) {
-    mem_req += static_cast<int64_t>(job_to_ctld.cpus_per_task() *
-                                    job_to_ctld.mem_per_cpu() *
-                                    job_to_ctld.ntasks());
+    mem_req +=
+        static_cast<int64_t>(job_to_ctld.cpus_per_task() *
+                             job_to_ctld.mem_per_cpu() * job_to_ctld.ntasks());
   }
 
   bool using_default_wckey = false;
@@ -4246,8 +4242,7 @@ MongodbClient::document MongodbClient::JobInEmbeddedDbToDocument_(
     execution_nodes.push_back(runtime_attr.craned_ids(0));
   } else if (job_to_ctld.type() == crane::grpc::JobType::Interactive) {
     const auto& ia_meta = job_to_ctld.interactive_meta();
-    if (ia_meta.interactive_type() ==
-        crane::grpc::InteractiveJobType::Calloc) {
+    if (ia_meta.interactive_type() == crane::grpc::InteractiveJobType::Calloc) {
       execution_nodes.push_back(runtime_attr.craned_ids(0));
     } else if (ia_meta.pty())
       execution_nodes.push_back(runtime_attr.craned_ids(0));
@@ -4298,60 +4293,59 @@ MongodbClient::document MongodbClient::JobInEmbeddedDbToDocument_(
   };
   // clang-format on
 
-  std::tuple<int32_t, job_db_id_t, int64_t, bool, std::string,     /*0-4*/
+  std::tuple<int32_t, job_db_id_t, int64_t, bool, std::string,      /*0-4*/
              double, int64_t, std::string, std::string, int32_t,    /*5-9*/
              int32_t, std::string, int32_t, int32_t, std::string,   /*10-14*/
              int64_t, int64_t, int64_t, int64_t, int64_t,           /*15-19*/
              std::string, int32_t, int64_t, int64_t, std::string,   /*20-24*/
              std::string, int32_t, std::string, std::string, bool,  /*25-29*/
              int32_t, std::string, std::string, bool, double,       /*30-34*/
-             int64_t, DeviceMap, std::optional<PodMetaInJob>,      /*35-37*/
-             std::optional<ContainerMetaInJob>, bool,              /*38-39*/
+             int64_t, DeviceMap, std::optional<PodMetaInJob>,       /*35-37*/
+             std::optional<ContainerMetaInJob>, bool,               /*38-39*/
              std::unordered_map<std::string, uint32_t>,             /*40*/
              bsoncxx::array::value, std::string, bool, std::string, /*41-44*/
              std::string, std::list<CranedId>, std::list<CranedId>, /*45-46*/
              std::vector<CranedId>>                                 /*45-49*/
-      values{                                                       // 0-4
-             static_cast<int32_t>(runtime_attr.job_id()),
-             runtime_attr.job_db_id(), absl::ToUnixSeconds(absl::Now()), false,
-             job_to_ctld.account(),
-             // 5-9
-             cpus_req, mem_req, job_to_ctld.name(), env_str,
-             static_cast<int32_t>(job_to_ctld.uid()),
-             // 10-14
-             static_cast<int32_t>(job_to_ctld.gid()),
-             util::HostNameListToStr(runtime_attr.craned_ids()),
-             runtime_attr.craned_ids().size(), 0, job_to_ctld.partition_name(),
-             // 15-19
-             runtime_attr.cached_priority(), 0,
-             runtime_attr.start_time().seconds(),
-             runtime_attr.end_time().seconds(), 0,
-             // 20-24
-             job_to_ctld.batch_meta().sh_script(), runtime_attr.status(),
-             job_to_ctld.time_limit().seconds(),
-             runtime_attr.submit_time().seconds(), job_to_ctld.cwd(),
-             // 25-29
-             job_to_ctld.cmd_line(), runtime_attr.exit_code(),
-             runtime_attr.username(), job_to_ctld.qos(),
-             job_to_ctld.get_user_env(),
-             // 30-34
-             job_to_ctld.type(), job_to_ctld.extra_attr(),
-             job_to_ctld.reservation(), job_to_ctld.exclusive(),
-             allocated_res_view.CpuCount(),
-             // 35-39
-             static_cast<int64_t>(allocated_res_view.MemoryBytes()),
-             allocated_res_view.GetDeviceMap(), pod_meta, container_meta,
-             true /* Mark the document having complete job info */,
-             // 40-44
-             std::unordered_map<std::string, uint32_t>{
-                 runtime_attr.actual_licenses().begin(),
-                 runtime_attr.actual_licenses().end()},
-             bsoncxx::array::value{nodename_list_array.view()},
-             job_to_ctld.wckey(), using_default_wckey,
-             g_config.CraneClusterName,
-             // 45-48
-             job_to_ctld.submit_hostname(), req_node_list, exclude_node_list,
-             execution_nodes};
+      values{
+          // 0-4
+          static_cast<int32_t>(runtime_attr.job_id()), runtime_attr.job_db_id(),
+          absl::ToUnixSeconds(absl::Now()), false, job_to_ctld.account(),
+          // 5-9
+          cpus_req, mem_req, job_to_ctld.name(), env_str,
+          static_cast<int32_t>(job_to_ctld.uid()),
+          // 10-14
+          static_cast<int32_t>(job_to_ctld.gid()),
+          util::HostNameListToStr(runtime_attr.craned_ids()),
+          runtime_attr.craned_ids().size(), 0, job_to_ctld.partition_name(),
+          // 15-19
+          runtime_attr.cached_priority(), 0,
+          runtime_attr.start_time().seconds(),
+          runtime_attr.end_time().seconds(), 0,
+          // 20-24
+          job_to_ctld.batch_meta().sh_script(), runtime_attr.status(),
+          job_to_ctld.time_limit().seconds(),
+          runtime_attr.submit_time().seconds(), job_to_ctld.cwd(),
+          // 25-29
+          job_to_ctld.cmd_line(), runtime_attr.exit_code(),
+          runtime_attr.username(), job_to_ctld.qos(),
+          job_to_ctld.get_user_env(),
+          // 30-34
+          job_to_ctld.type(), job_to_ctld.extra_attr(),
+          job_to_ctld.reservation(), job_to_ctld.exclusive(),
+          allocated_res_view.CpuCount(),
+          // 35-39
+          static_cast<int64_t>(allocated_res_view.MemoryBytes()),
+          allocated_res_view.GetDeviceMap(), pod_meta, container_meta,
+          true /* Mark the document having complete job info */,
+          // 40-44
+          std::unordered_map<std::string, uint32_t>{
+              runtime_attr.actual_licenses().begin(),
+              runtime_attr.actual_licenses().end()},
+          bsoncxx::array::value{nodename_list_array.view()},
+          job_to_ctld.wckey(), using_default_wckey, g_config.CraneClusterName,
+          // 45-48
+          job_to_ctld.submit_hostname(), req_node_list, exclude_node_list,
+          execution_nodes};
 
   return DocumentConstructor_(fields, values);
 }
@@ -4453,15 +4447,15 @@ MongodbClient::document MongodbClient::JobInCtldToDocument_(JobInCtld* job) {
   };
   // clang-format on
 
-  std::tuple<int32_t, job_db_id_t, int64_t, bool, std::string,     /*0-4*/
+  std::tuple<int32_t, job_db_id_t, int64_t, bool, std::string,      /*0-4*/
              double, int64_t, std::string, std::string, int32_t,    /*5-9*/
              int32_t, std::string, int32_t, int32_t, std::string,   /*10-14*/
              int64_t, int64_t, int64_t, int64_t, int64_t,           /*15-19*/
              std::string, int32_t, int64_t, int64_t, std::string,   /*20-24*/
              std::string, int32_t, std::string, std::string, bool,  /*25-29*/
              int32_t, std::string, std::string, bool, double,       /*30-34*/
-             int64_t, DeviceMap, std::optional<PodMetaInJob>,      /*35-37*/
-             std::optional<ContainerMetaInJob>, bool,              /*38-39*/
+             int64_t, DeviceMap, std::optional<PodMetaInJob>,       /*35-37*/
+             std::optional<ContainerMetaInJob>, bool,               /*38-39*/
              std::unordered_map<std::string, uint32_t>,             /*40*/
              std::vector<CranedId>, std::string, bool, std::string, /*41-44*/
              std::string, std::unordered_set<CranedId>,             /*45-49*/
@@ -4487,8 +4481,7 @@ MongodbClient::document MongodbClient::JobInCtldToDocument_(JobInCtld* job) {
              job->get_user_env,
              // 30-34
              job->type, job->extra_attr, job->reservation,
-             job->JobToCtld().exclusive(),
-             job->allocated_res_view.CpuCount(),
+             job->JobToCtld().exclusive(), job->allocated_res_view.CpuCount(),
              // 35-39
              static_cast<int64_t>(job->allocated_res_view.MemoryBytes()),
              job->allocated_res_view.GetDeviceMap(), pod_meta, container_meta,

--- a/src/CraneCtld/DbClient.cpp
+++ b/src/CraneCtld/DbClient.cpp
@@ -24,6 +24,10 @@
 
 namespace Ctld {
 
+// NOTE: MongoDB field names "job_id", "job_db_id", "job_name" were renamed
+// to "job_id", "job_db_id", "job_name" in this version. Existing databases from
+// older versions require field name migration before upgrading.
+
 using bsoncxx::builder::basic::kvp;
 using namespace std::chrono_literals;
 
@@ -337,9 +341,9 @@ bool MongodbClient::CheckDefaultRootAccountUserAndInit_() {
     qos.priority = 0;
     qos.max_jobs_per_user =
         std::numeric_limits<decltype(qos.max_jobs_per_user)>::max();
-    qos.max_running_tasks_per_user =
-        std::numeric_limits<decltype(qos.max_running_tasks_per_user)>::max();
-    qos.max_time_limit_per_task = absl::Seconds(kTaskMaxTimeLimitSec);
+    qos.max_running_jobs_per_user =
+        std::numeric_limits<decltype(qos.max_running_jobs_per_user)>::max();
+    qos.max_time_limit_per_job = absl::Seconds(kJobMaxTimeLimitSec);
     qos.max_cpus_per_user =
         std::numeric_limits<decltype(qos.max_cpus_per_user)>::max();
     qos.reference_count = 1;
@@ -411,14 +415,14 @@ bool MongodbClient::CheckDefaultRootAccountUserAndInit_() {
 }
 
 bool MongodbClient::InsertRecoveredJob(
-    const crane::grpc::TaskInEmbeddedDb& task_in_embedded_db) {
-  document job_doc = TaskInEmbeddedDbToDocument_(task_in_embedded_db);
+    const crane::grpc::JobInEmbeddedDb& job_in_embedded_db) {
+  document job_doc = JobInEmbeddedDbToDocument_(job_in_embedded_db);
 
-  // Create filter by task_id
+  // Create filter by job_id
   document filter;
   filter.append(
-      kvp("task_id",
-          static_cast<int32_t>(task_in_embedded_db.runtime_attr().task_id())));
+      kvp("job_id",
+          static_cast<int32_t>(job_in_embedded_db.runtime_attr().job_id())));
 
   // Use $set to update job fields, and $setOnInsert for steps array
   document update_doc;
@@ -429,7 +433,7 @@ bool MongodbClient::InsertRecoveredJob(
 
   try {
     bsoncxx::stdx::optional<mongocxx::result::update> ret =
-        (*GetClient_())[m_db_name_][m_task_collection_name_].update_one(
+        (*GetClient_())[m_db_name_][m_job_collection_name_].update_one(
             *GetSession_(), filter.view(), update_doc.view(),
             mongocxx::options::update{}.upsert(true));
 
@@ -442,29 +446,29 @@ bool MongodbClient::InsertRecoveredJob(
             AppendToAccUsageTable(job_doc.view(), session);
 
             // 2. Mark as aggregated
-            MarkTaskAsAggregated(
-                ViewGetArithmeticValue_<int32_t>(job_doc.view()["task_id"]),
+            MarkJobAsAggregated(
+                ViewGetArithmeticValue_<int32_t>(job_doc.view()["job_id"]),
                 session);
           });
       if (txn_success) return true;
       CRANE_WARN(
           "Transaction failed for job {} aggregation. "
           "Will be recovered on startup.",
-          task_in_embedded_db.runtime_attr().task_id());
+          job_in_embedded_db.runtime_attr().job_id());
     }
   } catch (const std::exception& e) {
     CRANE_LOGGER_ERROR(m_logger_, e.what());
   }
-  CRANE_LOGGER_ERROR(m_logger_, "Failed to insert in-memory TaskInCtld.");
+  CRANE_LOGGER_ERROR(m_logger_, "Failed to insert in-memory JobInCtld.");
   return false;
 }
 
-bool MongodbClient::InsertJob(TaskInCtld* task) {
-  document job_doc = TaskInCtldToDocument_(task);
+bool MongodbClient::InsertJob(JobInCtld* job) {
+  document job_doc = JobInCtldToDocument_(job);
 
-  // Create filter by task_id
+  // Create filter by job_id
   document filter;
-  filter.append(kvp("task_id", static_cast<int32_t>(task->TaskId())));
+  filter.append(kvp("job_id", static_cast<int32_t>(job->JobId())));
   // Use $set to update job fields, and $setOnInsert for steps array
   document update_doc;
   update_doc.append(kvp("$set", job_doc));
@@ -474,7 +478,7 @@ bool MongodbClient::InsertJob(TaskInCtld* task) {
 
   try {
     bsoncxx::stdx::optional<mongocxx::result::update> ret =
-        (*GetClient_())[m_db_name_][m_task_collection_name_].update_one(
+        (*GetClient_())[m_db_name_][m_job_collection_name_].update_one(
             *GetSession_(), filter.view(), update_doc.view(),
             mongocxx::options::update{}.upsert(true));
 
@@ -484,31 +488,31 @@ bool MongodbClient::InsertJob(TaskInCtld* task) {
       // Uses transaction to ensure atomicity of aggregation and marking
       try {
         using bsoncxx::builder::basic::make_document;
-        auto task_doc_copy = bsoncxx::document::value(job_doc.view());
+        auto job_doc_copy = bsoncxx::document::value(job_doc.view());
         auto filter_copy = bsoncxx::document::value(filter.view());
 
         bool txn_success = CommitTransaction(
-            [this, &task_doc_copy, task](mongocxx::client_session* session) {
+            [this, &job_doc_copy, job](mongocxx::client_session* session) {
               // 1. Append to acc_usage tables (hour/day/month)
-              AppendToAccUsageTable(task_doc_copy.view(), session);
+              AppendToAccUsageTable(job_doc_copy.view(), session);
 
               // 2. Mark as aggregated
-              MarkTaskAsAggregated(task->TaskId(), session);
+              MarkJobAsAggregated(job->JobId(), session);
             });
 
         if (!txn_success) {
           CRANE_WARN(
-              "Transaction failed for task {} aggregation. "
+              "Transaction failed for job {} aggregation. "
               "Will be recovered on startup.",
-              task->TaskId());
+              job->JobId());
         }
       } catch (const std::exception& e) {
-        // Best effort: failure doesn't affect task insertion
-        // Startup recovery will handle unaggregated tasks
+        // Best effort: failure does not affect job insertion
+        // Startup recovery will handle unaggregated jobs
         CRANE_WARN(
-            "Failed to append task {} to acc_usage tables: {}. "
+            "Failed to append job {} to acc_usage tables: {}. "
             "Will be recovered on startup.",
-            task->TaskId(), e.what());
+            job->JobId(), e.what());
       }
 
       return true;
@@ -517,24 +521,24 @@ bool MongodbClient::InsertJob(TaskInCtld* task) {
     CRANE_LOGGER_ERROR(m_logger_, e.what());
   }
 
-  CRANE_LOGGER_ERROR(m_logger_, "Failed to insert in-memory TaskInCtld.");
+  CRANE_LOGGER_ERROR(m_logger_, "Failed to insert in-memory JobInCtld.");
   return false;
 }
 
-bool MongodbClient::InsertJobs(const std::unordered_set<TaskInCtld*>& tasks) {
-  if (tasks.empty()) return false;
+bool MongodbClient::InsertJobs(const std::unordered_set<JobInCtld*>& jobs) {
+  if (jobs.empty()) return false;
   try {
     mongocxx::options::bulk_write bulk_options;
     auto bulk =
-        (*GetClient_())[m_db_name_][m_task_collection_name_].create_bulk_write(
+        (*GetClient_())[m_db_name_][m_job_collection_name_].create_bulk_write(
             *GetSession_(), bulk_options);
 
-    for (const auto& task : tasks) {
-      document job_doc = TaskInCtldToDocument_(task);
+    for (const auto& job : jobs) {
+      document job_doc = JobInCtldToDocument_(job);
 
-      // Create filter by task_id
+      // Create filter by job_id
       document filter;
-      filter.append(kvp("task_id", static_cast<int32_t>(task->TaskId())));
+      filter.append(kvp("job_id", static_cast<int32_t>(job->JobId())));
 
       // Use $set to update job fields, and $setOnInsert for steps array
       // This ensures job fields are always updated, but steps array is only
@@ -553,21 +557,21 @@ bool MongodbClient::InsertJobs(const std::unordered_set<TaskInCtld*>& tasks) {
 
     auto result = bulk.execute();
     if (result) {
-      // Real-time aggregation for each task (best effort)
+      // Real-time aggregation for each job (best effort)
       // Failures will be recovered on startup via RecoverMissingAggregations
-      for (const TaskInCtld* task : tasks) {
+      for (const JobInCtld* job : jobs) {
         using bsoncxx::builder::basic::make_document;
         bool txn_success =
-            CommitTransaction([this, task](mongocxx::client_session* session) {
-              AppendToAccUsageTable(task, session);
+            CommitTransaction([this, job](mongocxx::client_session* session) {
+              AppendToAccUsageTable(job, session);
               // 2. Mark as aggregated
-              MarkTaskAsAggregated(task->TaskId(), session);
+              MarkJobAsAggregated(job->JobId(), session);
             });
         if (!txn_success)
           CRANE_WARN(
-              "Failed to append task {} to acc_usage tables. "
+              "Failed to append job {} to acc_usage tables. "
               "Will be recovered on startup.",
-              task->TaskId());
+              job->JobId());
       }
       return true;
     }
@@ -575,13 +579,13 @@ bool MongodbClient::InsertJobs(const std::unordered_set<TaskInCtld*>& tasks) {
     CRANE_LOGGER_ERROR(m_logger_, e.what());
   }
 
-  CRANE_LOGGER_ERROR(m_logger_, "Failed to insert in-memory TaskInCtld.");
+  CRANE_LOGGER_ERROR(m_logger_, "Failed to insert in-memory JobInCtld.");
   return false;
 }
 
 bool MongodbClient::FetchJobRecords(
-    const crane::grpc::QueryTasksInfoRequest* request,
-    std::unordered_map<job_id_t, crane::grpc::TaskInfo>* job_info_map,
+    const crane::grpc::QueryJobsInfoRequest* request,
+    std::unordered_map<job_id_t, crane::grpc::JobInfo>* job_info_map,
     size_t limit) {
   document filter;
 
@@ -646,14 +650,14 @@ bool MongodbClient::FetchJobRecords(
     }));
   }
 
-  bool has_task_names_constraint = !request->filter_task_names().empty();
-  if (has_task_names_constraint) {
-    filter.append(kvp("task_name", [&request](sub_document task_name_doc) {
-      array task_name_array;
-      for (const auto& task_name : request->filter_task_names()) {
-        task_name_array.append(task_name);
+  bool has_job_names_constraint = !request->filter_job_names().empty();
+  if (has_job_names_constraint) {
+    filter.append(kvp("job_name", [&request](sub_document job_name_doc) {
+      array job_name_array;
+      for (const auto& job_name : request->filter_job_names()) {
+        job_name_array.append(job_name);
       }
-      task_name_doc.append(kvp("$in", task_name_array));
+      job_name_doc.append(kvp("$in", job_name_array));
     }));
   }
 
@@ -679,19 +683,19 @@ bool MongodbClient::FetchJobRecords(
     }));
   }
 
-  bool has_task_ids_constraint = !request->filter_ids().empty();
-  if (has_task_ids_constraint) {
-    filter.append(kvp("task_id", [&request](sub_document task_id_doc) {
-      array task_id_array;
-      for (const auto& task_id : request->filter_ids() | std::views::keys) {
-        task_id_array.append(static_cast<std::int32_t>(task_id));
+  bool has_job_ids_constraint = !request->filter_ids().empty();
+  if (has_job_ids_constraint) {
+    filter.append(kvp("job_id", [&request](sub_document job_id_doc) {
+      array job_id_array;
+      for (const auto& job_id : request->filter_ids() | std::views::keys) {
+        job_id_array.append(static_cast<std::int32_t>(job_id));
       }
-      task_id_doc.append(kvp("$in", task_id_array));
+      job_id_doc.append(kvp("$in", job_id_array));
     }));
   }
 
-  bool has_task_status_constraint = !request->filter_states().empty();
-  if (has_task_status_constraint) {
+  bool has_job_status_constraint = !request->filter_states().empty();
+  if (has_job_status_constraint) {
     filter.append(kvp("state", [&request](sub_document state_doc) {
       array state_array;
       for (const auto& state : request->filter_states()) {
@@ -713,11 +717,11 @@ bool MongodbClient::FetchJobRecords(
         }));
   }
 
-  bool has_task_types_constraint = !request->filter_task_types().empty();
-  if (has_task_types_constraint) {
+  bool has_job_types_constraint = !request->filter_job_types().empty();
+  if (has_job_types_constraint) {
     filter.append(kvp("type", [&request](sub_document type_doc) {
       array type_array;
-      for (const auto& type : request->filter_task_types()) {
+      for (const auto& type : request->filter_job_types()) {
         type_array.append(static_cast<std::int32_t>(type));
       }
       type_doc.append(kvp("$in", type_array));
@@ -728,15 +732,15 @@ bool MongodbClient::FetchJobRecords(
   option = option.limit(limit);
 
   document sort_doc;
-  sort_doc.append(kvp("task_db_id", -1));
+  sort_doc.append(kvp("job_db_id", -1));
   option = option.sort(sort_doc.view());
 
   mongocxx::cursor cursor =
-      (*GetClient_())[m_db_name_][m_task_collection_name_].find(filter.view(),
+      (*GetClient_())[m_db_name_][m_job_collection_name_].find(filter.view(),
                                                                 option);
 
-  // 0  task_id       task_db_id     mod_time       deleted       account
-  // 5  cpus_req      mem_req        task_name      env           id_user
+  // 0  job_id        job_db_id      mod_time       deleted       account
+  // 5  cpus_req      mem_req        job_name       env           id_user
   // 10 id_group      nodelist       nodes_alloc    node_inx      partition_name
   // 15 priority      time_eligible  time_start     time_end      time_suspended
   // 20 script        state          timelimit      time_submit   work_dir
@@ -746,8 +750,8 @@ bool MongodbClient::FetchJobRecords(
   // 40 nodename_list wckey          submit_hostname
   try {
     for (auto view : cursor) {
-      job_id_t job_id = view["task_id"].get_int32().value;
-      crane::grpc::TaskInfo* job_info_ptr = nullptr;
+      job_id_t job_id = view["job_id"].get_int32().value;
+      crane::grpc::JobInfo* job_info_ptr = nullptr;
       auto in_mem_job_it = job_info_map->find(job_id);
       bool has_in_mem_job_info = in_mem_job_it != job_info_map->end();
       bool has_db_job_info = ViewValueOr_(view["has_job_info"], false);
@@ -755,10 +759,10 @@ bool MongodbClient::FetchJobRecords(
         // Only got step info in db, no such jobinfo in db or memory, this is an
         // incomplete record, skip.
         if (!has_db_job_info) continue;
-        crane::grpc::TaskInfo job_info;
+        crane::grpc::JobInfo job_info;
         job_info.set_type(
-            static_cast<crane::grpc::TaskType>(view["type"].get_int32().value));
-        job_info.set_task_id(job_id);
+            static_cast<crane::grpc::JobType>(view["type"].get_int32().value));
+        job_info.set_job_id(job_id);
 
         job_info.set_node_num(view["nodes_alloc"].get_int32().value);
 
@@ -788,7 +792,7 @@ bool MongodbClient::FetchJobRecords(
             view["mem_alloc"].get_int64().value);
         auto* device_map_ptr = mutable_allocated_res_view->mutable_device_map();
         *device_map_ptr = ToGrpcDeviceMap(BsonToDeviceMap(view));
-        job_info.set_name(std::string(view["task_name"].get_string().value));
+        job_info.set_name(std::string(view["job_name"].get_string().value));
         job_info.set_qos(std::string(view["qos"].get_string().value));
         job_info.set_uid(view["id_user"].get_int32().value);
         job_info.set_gid(view["id_group"].get_int32().value);
@@ -801,7 +805,7 @@ bool MongodbClient::FetchJobRecords(
         job_info.mutable_end_time()->set_seconds(
             view["time_end"].get_int64().value);
 
-        job_info.set_status(static_cast<crane::grpc::TaskStatus>(
+        job_info.set_status(static_cast<crane::grpc::JobStatus>(
             view["state"].get_int32().value));
         job_info.mutable_time_limit()->set_seconds(
             view["timelimit"].get_int64().value);
@@ -843,7 +847,7 @@ bool MongodbClient::FetchJobRecords(
           if (auto pod_elem = view["meta_pod"];
               pod_elem && pod_elem.type() == bsoncxx::type::k_document) {
             job_info.mutable_pod_meta()->CopyFrom(
-                static_cast<crane::grpc::PodTaskAdditionalMeta>(
+                static_cast<crane::grpc::PodJobAdditionalMeta>(
                     BsonToPodMeta(view)));
           } else {
             CRANE_ERROR("Container job {} missing pod meta in db record!",
@@ -879,8 +883,8 @@ bool MongodbClient::FetchJobRecords(
 }
 
 bool MongodbClient::FetchJobStepRecords(
-    const crane::grpc::QueryTasksInfoRequest* request,
-    std::unordered_map<job_id_t, crane::grpc::TaskInfo>* job_info_map) {
+    const crane::grpc::QueryJobsInfoRequest* request,
+    std::unordered_map<job_id_t, crane::grpc::JobInfo>* job_info_map) {
   if (job_info_map->empty()) return true;
   document filter;
 
@@ -945,14 +949,14 @@ bool MongodbClient::FetchJobStepRecords(
     }));
   }
 
-  bool has_task_names_constraint = !request->filter_task_names().empty();
-  if (has_task_names_constraint) {
-    filter.append(kvp("task_name", [&request](sub_document task_name_doc) {
-      array task_name_array;
-      for (const auto& task_name : request->filter_task_names()) {
-        task_name_array.append(task_name);
+  bool has_job_names_constraint = !request->filter_job_names().empty();
+  if (has_job_names_constraint) {
+    filter.append(kvp("job_name", [&request](sub_document job_name_doc) {
+      array job_name_array;
+      for (const auto& job_name : request->filter_job_names()) {
+        job_name_array.append(job_name);
       }
-      task_name_doc.append(kvp("$in", task_name_array));
+      job_name_doc.append(kvp("$in", job_name_array));
     }));
   }
 
@@ -978,16 +982,16 @@ bool MongodbClient::FetchJobStepRecords(
     }));
   }
 
-  filter.append(kvp("task_id", [&job_info_map](sub_document task_id_doc) {
-    array task_id_array;
+  filter.append(kvp("job_id", [&job_info_map](sub_document job_id_doc) {
+    array job_id_array;
     for (const auto job_id : *job_info_map | std::views::keys) {
-      task_id_array.append(static_cast<std::int32_t>(job_id));
+      job_id_array.append(static_cast<std::int32_t>(job_id));
     }
-    task_id_doc.append(kvp("$in", task_id_array));
+    job_id_doc.append(kvp("$in", job_id_array));
   }));
 
-  bool has_task_status_constraint = !request->filter_states().empty();
-  if (has_task_status_constraint) {
+  bool has_job_status_constraint = !request->filter_states().empty();
+  if (has_job_status_constraint) {
     filter.append(kvp("state", [&request](sub_document state_doc) {
       array state_array;
       for (const auto& state : request->filter_states()) {
@@ -997,11 +1001,11 @@ bool MongodbClient::FetchJobStepRecords(
     }));
   }
 
-  bool has_task_types_constraint = !request->filter_task_types().empty();
-  if (has_task_types_constraint) {
+  bool has_job_types_constraint = !request->filter_job_types().empty();
+  if (has_job_types_constraint) {
     filter.append(kvp("type", [&request](sub_document type_doc) {
       array type_array;
-      for (const auto& type : request->filter_task_types()) {
+      for (const auto& type : request->filter_job_types()) {
         type_array.append(static_cast<std::int32_t>(type));
       }
       type_doc.append(kvp("$in", type_array));
@@ -1011,15 +1015,15 @@ bool MongodbClient::FetchJobStepRecords(
   mongocxx::options::find option;
 
   document sort_doc;
-  sort_doc.append(kvp("task_db_id", -1));
+  sort_doc.append(kvp("job_db_id", -1));
   option = option.sort(sort_doc.view());
 
   mongocxx::cursor cursor =
-      (*GetClient_())[m_db_name_][m_task_collection_name_].find(filter.view(),
+      (*GetClient_())[m_db_name_][m_job_collection_name_].find(filter.view(),
                                                                 option);
 
-  // 0  task_id       task_db_id     mod_time       deleted       account
-  // 5  cpus_req      mem_req        task_name      env           id_user
+  // 0  job_id        job_db_id      mod_time       deleted       account
+  // 5  cpus_req      mem_req        job_name       env           id_user
   // 10 id_group      nodelist       nodes_alloc    node_inx      partition_name
   // 15 priority      time_eligible  time_start     time_end      time_suspended
   // 20 script        state          timelimit      time_submit   work_dir
@@ -1029,7 +1033,7 @@ bool MongodbClient::FetchJobStepRecords(
 
   try {
     for (auto view : cursor) {
-      job_id_t job_id = view["task_id"].get_int32().value;
+      job_id_t job_id = view["job_id"].get_int32().value;
       auto in_mem_job_it = job_info_map->find(job_id);
       bool has_in_mem_job_info = in_mem_job_it != job_info_map->end();
       if (!has_in_mem_job_info) {
@@ -1065,13 +1069,13 @@ bool MongodbClient::FetchJobStepRecords(
   return true;
 }
 
-bool MongodbClient::CheckTaskDbIdExisted(int64_t task_db_id) {
+bool MongodbClient::CheckJobDbIdExisted(int64_t job_db_id) {
   document doc;
-  doc.append(kvp("job_db_inx", task_db_id));
+  doc.append(kvp("job_db_inx", job_db_id));
 
   try {
     bsoncxx::stdx::optional<bsoncxx::document::value> result =
-        (*GetClient_())[m_db_name_][m_task_collection_name_].find_one(
+        (*GetClient_())[m_db_name_][m_job_collection_name_].find_one(
             doc.view());
     if (result) {
       return true;
@@ -1084,9 +1088,9 @@ bool MongodbClient::CheckTaskDbIdExisted(int64_t task_db_id) {
 }
 
 std::unordered_map<
-    task_id_t, std::tuple<crane::grpc::TaskStatus, uint32_t, int64_t, int64_t>>
-MongodbClient::FetchJobStatus(const std::unordered_set<task_id_t>& job_ids) {
-  std::unordered_map<task_id_t, std::tuple<crane::grpc::TaskStatus, uint32_t,
+    job_id_t, std::tuple<crane::grpc::JobStatus, uint32_t, int64_t, int64_t>>
+MongodbClient::FetchJobStatus(const std::unordered_set<job_id_t>& job_ids) {
+  std::unordered_map<job_id_t, std::tuple<crane::grpc::JobStatus, uint32_t,
                                            int64_t, int64_t>>
       result;
 
@@ -1096,17 +1100,17 @@ MongodbClient::FetchJobStatus(const std::unordered_set<task_id_t>& job_ids) {
 
   try {
     document filter;
-    filter.append(kvp("task_id", [&job_ids](sub_document task_id_doc) {
-      array task_id_array;
+    filter.append(kvp("job_id", [&job_ids](sub_document job_id_doc) {
+      array job_id_array;
       for (const auto& job_id : job_ids) {
-        task_id_array.append(static_cast<std::int32_t>(job_id));
+        job_id_array.append(static_cast<std::int32_t>(job_id));
       }
-      task_id_doc.append(kvp("$in", task_id_array));
+      job_id_doc.append(kvp("$in", job_id_array));
     }));
 
     mongocxx::options::find options;
     document projection;
-    projection.append(kvp("task_id", 1));
+    projection.append(kvp("job_id", 1));
     projection.append(kvp("state", 1));
     projection.append(kvp("exit_code", 1));
     projection.append(kvp("time_end", 1));
@@ -1114,18 +1118,18 @@ MongodbClient::FetchJobStatus(const std::unordered_set<task_id_t>& job_ids) {
     options.projection(projection.view());
 
     mongocxx::cursor cursor =
-        (*GetClient_())[m_db_name_][m_task_collection_name_].find(filter.view(),
+        (*GetClient_())[m_db_name_][m_job_collection_name_].find(filter.view(),
                                                                   options);
 
     for (auto view : cursor) {
-      task_id_t task_id = view["task_id"].get_int32().value;
-      crane::grpc::TaskStatus status =
-          static_cast<crane::grpc::TaskStatus>(view["state"].get_int32().value);
+      job_id_t fetched_job_id = view["job_id"].get_int32().value;
+      crane::grpc::JobStatus status =
+          static_cast<crane::grpc::JobStatus>(view["state"].get_int32().value);
       uint32_t exit_code = view["exit_code"].get_int32().value;
       int64_t time_end = view["time_end"].get_int64().value;
       int64_t time_start = view["time_start"].get_int64().value;
 
-      result.emplace(task_id,
+      result.emplace(fetched_job_id,
                      std::make_tuple(status, exit_code, time_end, time_start));
     }
   } catch (const std::exception& e) {
@@ -1140,9 +1144,9 @@ bool MongodbClient::InsertRecoveredStep(
   document step_doc = StepInEmbeddedDbToDocument_(step_in_embedded_db);
   job_id_t job_id = step_in_embedded_db.step_to_ctld().job_id();
 
-  // Filter by task_id (job_id)
+  // Filter by job_id
   document filter;
-  filter.append(kvp("task_id", static_cast<int32_t>(job_id)));
+  filter.append(kvp("job_id", static_cast<int32_t>(job_id)));
 
   // Use $push to append step, and $setOnInsert to create minimal document if
   // needed
@@ -1151,12 +1155,12 @@ bool MongodbClient::InsertRecoveredStep(
     push_doc.append(kvp("steps", step_doc));
   }));
   update_doc.append(kvp("$setOnInsert", [&job_id](sub_document set_on_insert) {
-    set_on_insert.append(kvp("task_id", static_cast<int32_t>(job_id)));
+    set_on_insert.append(kvp("job_id", static_cast<int32_t>(job_id)));
   }));
 
   try {
     bsoncxx::stdx::optional<mongocxx::result::update> ret =
-        (*GetClient_())[m_db_name_][m_task_collection_name_].update_one(
+        (*GetClient_())[m_db_name_][m_job_collection_name_].update_one(
             *GetSession_(), filter.view(), update_doc.view(),
             mongocxx::options::update{}.upsert(true));
 
@@ -1180,7 +1184,7 @@ bool MongodbClient::InsertSteps(const std::unordered_set<StepInCtld*>& steps) {
 
   try {
     auto bulk =
-        (*GetClient_())[m_db_name_][m_task_collection_name_].create_bulk_write(
+        (*GetClient_())[m_db_name_][m_job_collection_name_].create_bulk_write(
             *GetSession_(), bulk_options);
 
     for (const auto& [job_id, job_steps] : steps_by_job) {
@@ -1191,9 +1195,9 @@ bool MongodbClient::InsertSteps(const std::unordered_set<StepInCtld*>& steps) {
         steps_array.append(step_doc);
       }
 
-      // Filter by task_id (job_id)
+      // Filter by job_id
       document filter;
-      filter.append(kvp("task_id", static_cast<int32_t>(job_id)));
+      filter.append(kvp("job_id", static_cast<int32_t>(job_id)));
 
       // Combine $push and $setOnInsert
       // $push: append steps to existing document
@@ -1206,7 +1210,7 @@ bool MongodbClient::InsertSteps(const std::unordered_set<StepInCtld*>& steps) {
       }));
       update_doc.append(
           kvp("$setOnInsert", [&job_id](sub_document set_on_insert) {
-            set_on_insert.append(kvp("task_id", static_cast<int32_t>(job_id)));
+            set_on_insert.append(kvp("job_id", static_cast<int32_t>(job_id)));
           }));
 
       mongocxx::model::update_one update_op{filter.view(), update_doc.view()};
@@ -1228,15 +1232,15 @@ bool MongodbClient::InsertSteps(const std::unordered_set<StepInCtld*>& steps) {
 }
 
 bool MongodbClient::CheckStepExisted(job_id_t job_id, step_id_t step_id) {
-  // Query for a job with the given task_id that contains a step with the given
+  // Query for a job with the given job_id that contains a step with the given
   // step_id
   document filter;
-  filter.append(kvp("task_id", static_cast<int32_t>(job_id)));
+  filter.append(kvp("job_id", static_cast<int32_t>(job_id)));
   filter.append(kvp("steps.step_id", static_cast<int32_t>(step_id)));
 
   try {
     bsoncxx::stdx::optional<bsoncxx::document::value> result =
-        (*GetClient_())[m_db_name_][m_task_collection_name_].find_one(
+        (*GetClient_())[m_db_name_][m_job_collection_name_].find_one(
             filter.view());
     if (result) {
       return true;
@@ -1248,28 +1252,28 @@ bool MongodbClient::CheckStepExisted(job_id_t job_id, step_id_t step_id) {
   return false;
 }
 
-// Real-time aggregation: Append task to acc_usage tables (hour/day/month)
+// Real-time aggregation: Append job to acc_usage tables (hour/day/month)
 void MongodbClient::AppendToAccUsageTable(
-    const bsoncxx::document::view& task_doc,
+    const bsoncxx::document::view& job_doc,
     mongocxx::client_session* session) {
   using namespace std::chrono;
 
   try {
-    // Extract task information from BSON document
-    std::string account = std::string(task_doc["account"].get_string().value);
-    std::string username = std::string(task_doc["username"].get_string().value);
-    std::string qos = std::string(task_doc["qos"].get_string().value);
-    std::string wckey = task_doc["wckey"]
-                            ? std::string(task_doc["wckey"].get_string().value)
+    // Extract job information from BSON document
+    std::string account = std::string(job_doc["account"].get_string().value);
+    std::string username = std::string(job_doc["username"].get_string().value);
+    std::string qos = std::string(job_doc["qos"].get_string().value);
+    std::string wckey = job_doc["wckey"]
+                            ? std::string(job_doc["wckey"].get_string().value)
                             : "";
-    // Get task start/end time and resources
-    auto time_start = ViewGetArithmeticValue_<int64_t>(task_doc["time_start"]);
+    // Get job start/end time and resources
+    auto time_start = ViewGetArithmeticValue_<int64_t>(job_doc["time_start"]);
     if (time_start == 0) {
       return;
     }
-    auto time_end = ViewGetArithmeticValue_<int64_t>(task_doc["time_end"]);
-    auto cpus_alloc = ViewGetArithmeticValue_<double>(task_doc["cpus_alloc"]);
-    auto nodes_alloc = ViewGetArithmeticValue_<double>(task_doc["nodes_alloc"]);
+    auto time_end = ViewGetArithmeticValue_<int64_t>(job_doc["time_end"]);
+    auto cpus_alloc = ViewGetArithmeticValue_<double>(job_doc["cpus_alloc"]);
+    auto nodes_alloc = ViewGetArithmeticValue_<double>(job_doc["nodes_alloc"]);
 
     auto start_time = sys_seconds(seconds(time_start));
     auto end_time = sys_seconds(seconds(time_end));
@@ -1290,30 +1294,30 @@ void MongodbClient::AppendToAccUsageTable(
     AppendToMonthTable_(info, session);
 
   } catch (const std::exception& e) {
-    CRANE_ERROR("Failed to append task to acc_usage tables: {}", e.what());
+    CRANE_ERROR("Failed to append job to acc_usage tables: {}", e.what());
     throw;
   }
 }
 
-// Overload: append task from TaskInCtld pointer (builds JobAggregationInfo)
-void MongodbClient::AppendToAccUsageTable(const TaskInCtld* task,
+// Overload: append job from JobInCtld pointer (builds JobAggregationInfo)
+void MongodbClient::AppendToAccUsageTable(const JobInCtld* job,
                                           mongocxx::client_session* session) {
   using namespace std::chrono;
 
   try {
-    if (task->StartTimeInUnixSecond() == 0) {
+    if (job->StartTimeInUnixSecond() == 0) {
       return;
     }
-    // Build JobAggregationInfo from TaskInCtld
+    // Build JobAggregationInfo from JobInCtld
     JobAggregationInfo info{
-        .account = task->account,
-        .username = task->Username(),
-        .qos = task->qos,
-        .wckey = task->wckey,
-        .start_time = sys_seconds(seconds(task->StartTimeInUnixSecond())),
-        .end_time = sys_seconds(seconds(task->EndTimeInUnixSecond())),
-        .total_cpus = task->allocated_res_view.CpuCount() *
-                      static_cast<double>(task->nodes_alloc)};
+        .account = job->account,
+        .username = job->Username(),
+        .qos = job->qos,
+        .wckey = job->wckey,
+        .start_time = sys_seconds(seconds(job->StartTimeInUnixSecond())),
+        .end_time = sys_seconds(seconds(job->EndTimeInUnixSecond())),
+        .total_cpus = job->allocated_res_view.CpuCount() *
+                      static_cast<double>(job->nodes_alloc)};
 
     // Append to all three granularity tables
     AppendToHourTable_(info, session);
@@ -1321,13 +1325,13 @@ void MongodbClient::AppendToAccUsageTable(const TaskInCtld* task,
     AppendToMonthTable_(info, session);
 
   } catch (const std::exception& e) {
-    CRANE_ERROR("Failed to append task {} to acc_usage tables: {}",
-                task->TaskId(), e.what());
+    CRANE_ERROR("Failed to append job {} to acc_usage tables: {}",
+                job->JobId(), e.what());
     throw;
   }
 }
 
-// Append task to hour table - handles cross-hour allocation internally
+// Append job to hour table - handles cross-hour allocation internally
 void MongodbClient::AppendToHourTable_(const JobAggregationInfo& info,
                                        mongocxx::client_session* session) {
   using bsoncxx::builder::basic::kvp;
@@ -1338,7 +1342,7 @@ void MongodbClient::AppendToHourTable_(const JobAggregationInfo& info,
   auto current_hour = floor<hours>(info.start_time);
   auto end_hour = floor<hours>(info.end_time);
 
-  // Loop through each hour the task spans
+  // Loop through each hour the job spans
   while (current_hour <= end_hour) {
     auto next_hour = current_hour + hours(1);
 
@@ -1346,11 +1350,11 @@ void MongodbClient::AppendToHourTable_(const JobAggregationInfo& info,
     // Convert hour-precision time_point to sys_seconds for comparison
     auto current_hour_sec = time_point_cast<seconds>(current_hour);
     auto next_hour_sec = time_point_cast<seconds>(next_hour);
-    auto hour_start_in_task = std::max(current_hour_sec, info.start_time);
-    auto hour_end_in_task = std::min(next_hour_sec, info.end_time);
+    auto hour_start_in_job = std::max(current_hour_sec, info.start_time);
+    auto hour_end_in_job = std::min(next_hour_sec, info.end_time);
 
     int64_t duration_this_hour =
-        duration_cast<seconds>(hour_end_in_task - hour_start_in_task).count();
+        duration_cast<seconds>(hour_end_in_job - hour_start_in_job).count();
 
     if (duration_this_hour > 0) {
       double cpu_time_this_hour = info.total_cpus * duration_this_hour;
@@ -1392,7 +1396,7 @@ void MongodbClient::AppendToHourTable_(const JobAggregationInfo& info,
   }
 }
 
-// Append task to day table - handles cross-day allocation internally
+// Append job to day table - handles cross-day allocation internally
 void MongodbClient::AppendToDayTable_(const JobAggregationInfo& info,
                                       mongocxx::client_session* session) {
   using bsoncxx::builder::basic::kvp;
@@ -1403,7 +1407,7 @@ void MongodbClient::AppendToDayTable_(const JobAggregationInfo& info,
   auto current_day = floor<days>(info.start_time);
   auto end_day = floor<days>(info.end_time);
 
-  // Loop through each day the task spans
+  // Loop through each day the job spans
   while (current_day <= end_day) {
     auto next_day = current_day + days(1);
 
@@ -1411,11 +1415,11 @@ void MongodbClient::AppendToDayTable_(const JobAggregationInfo& info,
     // Convert sys_days to sys_seconds for comparison
     auto current_day_sec = time_point_cast<seconds>(current_day);
     auto next_day_sec = time_point_cast<seconds>(next_day);
-    auto day_start_in_task = std::max(current_day_sec, info.start_time);
-    auto day_end_in_task = std::min(next_day_sec, info.end_time);
+    auto day_start_in_job = std::max(current_day_sec, info.start_time);
+    auto day_end_in_job = std::min(next_day_sec, info.end_time);
 
     int64_t duration_this_day =
-        duration_cast<seconds>(day_end_in_task - day_start_in_task).count();
+        duration_cast<seconds>(day_end_in_job - day_start_in_job).count();
 
     if (duration_this_day > 0) {
       double cpu_time_this_day = info.total_cpus * duration_this_day;
@@ -1457,7 +1461,7 @@ void MongodbClient::AppendToDayTable_(const JobAggregationInfo& info,
   }
 }
 
-// Append task to month table - handles cross-month allocation internally
+// Append job to month table - handles cross-month allocation internally
 void MongodbClient::AppendToMonthTable_(const JobAggregationInfo& info,
                                         mongocxx::client_session* session) {
   using bsoncxx::builder::basic::kvp;
@@ -1474,7 +1478,7 @@ void MongodbClient::AppendToMonthTable_(const JobAggregationInfo& info,
   auto current_month = year_month{start_ymd.year(), start_ymd.month()};
   auto end_month = year_month{end_ymd.year(), end_ymd.month()};
 
-  // Loop through each month the task spans
+  // Loop through each month the job spans
   while (current_month <= end_month) {
     auto month_start = sys_days{current_month / 1};
     auto next_month = current_month + months(1);
@@ -1484,11 +1488,11 @@ void MongodbClient::AppendToMonthTable_(const JobAggregationInfo& info,
     // Convert sys_days to sys_seconds for comparison
     auto month_start_sec = time_point_cast<seconds>(month_start);
     auto month_end_sec = time_point_cast<seconds>(month_end);
-    auto month_start_in_task = std::max(month_start_sec, info.start_time);
-    auto month_end_in_task = std::min(month_end_sec, info.end_time);
+    auto month_start_in_job = std::max(month_start_sec, info.start_time);
+    auto month_end_in_job = std::min(month_end_sec, info.end_time);
 
     int64_t duration_this_month =
-        duration_cast<seconds>(month_end_in_task - month_start_in_task).count();
+        duration_cast<seconds>(month_end_in_job - month_start_in_job).count();
 
     if (duration_this_month > 0) {
       double cpu_time_this_month = info.total_cpus * duration_this_month;
@@ -1531,25 +1535,25 @@ void MongodbClient::AppendToMonthTable_(const JobAggregationInfo& info,
   }
 }
 
-// Mark task as aggregated in task_table
-void MongodbClient::MarkTaskAsAggregated(job_id_t job_id,
+// Mark job as aggregated in job_table
+void MongodbClient::MarkJobAsAggregated(job_id_t job_id,
                                          mongocxx::client_session* session) {
   using bsoncxx::builder::basic::kvp;
   using bsoncxx::builder::basic::make_document;
   using namespace std::chrono;
 
   auto client = GetClient_();
-  auto filter = make_document(kvp("task_id", static_cast<int32_t>(job_id)));
+  auto filter = make_document(kvp("job_id", static_cast<int32_t>(job_id)));
   auto update = make_document(kvp(
       "$set", make_document(kvp("aggregated", true),
                             kvp("aggregated_at",
                                 bsoncxx::types::b_date{system_clock::now()}))));
 
   if (session) {
-    (*client)[m_db_name_][m_task_collection_name_].update_one(
+    (*client)[m_db_name_][m_job_collection_name_].update_one(
         *session, filter.view(), update.view());
   } else {
-    (*client)[m_db_name_][m_task_collection_name_].update_one(filter.view(),
+    (*client)[m_db_name_][m_job_collection_name_].update_one(filter.view(),
                                                               update.view());
   }
 }
@@ -1582,7 +1586,7 @@ void MongodbClient::RecoverNewClusterAggregations_(bool hour_done,
   //    Mark in batches of 10000 to avoid connection timeout
   if (!hour_done) {
     CRANE_INFO("Marking all jobs as aggregated before batch aggregation...");
-    auto task_coll = (*client)[m_db_name_][m_task_collection_name_];
+    auto job_coll = (*client)[m_db_name_][m_job_collection_name_];
 
     constexpr int64_t kBatchSize = 10000;
     int64_t total_marked = 0;
@@ -1599,7 +1603,7 @@ void MongodbClient::RecoverNewClusterAggregations_(bool hour_done,
       find_opts.projection(make_document(kvp("_id", 1)));
 
       std::vector<bsoncxx::types::bson_value::value> ids;
-      auto cursor = task_coll.find(filter.view(), find_opts);
+      auto cursor = job_coll.find(filter.view(), find_opts);
       for (const auto& doc : cursor) {
         ids.push_back(doc["_id"].get_owning_value());
       }
@@ -1623,7 +1627,7 @@ void MongodbClient::RecoverNewClusterAggregations_(bool hour_done,
                             kvp("aggregated_at",
                                 bsoncxx::types::b_date{system_clock::now()}))));
 
-      auto result = task_coll.update_many(batch_filter.view(), update.view());
+      auto result = job_coll.update_many(batch_filter.view(), update.view());
       if (result) {
         total_marked += result->modified_count();
       }
@@ -1648,7 +1652,7 @@ void MongodbClient::RecoverNewClusterAggregations_(bool hour_done,
     CRANE_INFO("Hour aggregation: from {} to {}", hour_start, now);
 
     bool success =
-        AggregateJobSummaryByHour_(hour_start, now, m_task_collection_name_);
+        AggregateJobSummaryByHour_(hour_start, now, m_job_collection_name_);
 
     if (success) {
       UpdateJobSummaryLastSuccessTime_(JobSummary::Type::HOUR, now);
@@ -1762,7 +1766,7 @@ void MongodbClient::RecoverNewClusterAggregations_(bool hour_done,
   CRANE_INFO("New cluster aggregation recovery completed");
 }
 
-// Recovery for existing cluster: iterate unaggregated tasks and append
+// Recovery for existing cluster: iterate unaggregated jobs and append
 void MongodbClient::RecoverExistingClusterAggregations_() {
   using bsoncxx::builder::basic::kvp;
   using bsoncxx::builder::basic::make_array;
@@ -1779,23 +1783,23 @@ void MongodbClient::RecoverExistingClusterAggregations_() {
           make_document(kvp(
               "$in",
               make_array(
-                  static_cast<int64_t>(crane::grpc::TaskStatus::Cancelled),
-                  static_cast<int64_t>(crane::grpc::TaskStatus::Completed),
-                  static_cast<int64_t>(crane::grpc::TaskStatus::OutOfMemory),
+                  static_cast<int64_t>(crane::grpc::JobStatus::Cancelled),
+                  static_cast<int64_t>(crane::grpc::JobStatus::Completed),
+                  static_cast<int64_t>(crane::grpc::JobStatus::OutOfMemory),
                   static_cast<int64_t>(
-                      crane::grpc::TaskStatus::ExceedTimeLimit),
-                  static_cast<int64_t>(crane::grpc::TaskStatus::Failed))))));
+                      crane::grpc::JobStatus::ExceedTimeLimit),
+                  static_cast<int64_t>(crane::grpc::JobStatus::Failed))))));
 
   auto cursor =
-      (*client)[m_db_name_][m_task_collection_name_].find(filter.view());
+      (*client)[m_db_name_][m_job_collection_name_].find(filter.view());
 
   int count = 0;
-  for (auto&& task_doc : cursor) {
+  for (auto&& job_doc : cursor) {
     bool success =
-        CommitTransaction([this, &task_doc](mongocxx::client_session* session) {
-          AppendToAccUsageTable(task_doc, session);
-          MarkTaskAsAggregated(
-              ViewGetArithmeticValue_<int32_t>(task_doc["task_id"]), session);
+        CommitTransaction([this, &job_doc](mongocxx::client_session* session) {
+          AppendToAccUsageTable(job_doc, session);
+          MarkJobAsAggregated(
+              ViewGetArithmeticValue_<int32_t>(job_doc["job_id"]), session);
         });
     if (!success) {
       CRANE_ERROR("Failed to append job to acc usage table.");
@@ -1803,12 +1807,12 @@ void MongodbClient::RecoverExistingClusterAggregations_() {
     count++;
 
     if (count % 1000 == 0) {
-      CRANE_INFO("Recovered {} unaggregated tasks...", count);
+      CRANE_INFO("Recovered {} unaggregated jobs...", count);
     }
   }
 
   CRANE_INFO(
-      "Existing cluster aggregation recovery completed, {} tasks recovered",
+      "Existing cluster aggregation recovery completed, {} jobs recovered",
       count);
 }
 
@@ -1820,7 +1824,7 @@ void MongodbClient::RecoverMissingAggregations_() {
   bool month_done = GetInitialAggregationCompleted_(JobSummary::Type::MONTH);
 
   if (hour_done && day_done && month_done) {
-    // Initial aggregation completed, use append for new unaggregated tasks
+    // Initial aggregation completed, use append for new unaggregated jobs
     RecoverExistingClusterAggregations_();
   } else {
     // New cluster or interrupted: use batch aggregation
@@ -1967,7 +1971,7 @@ bool MongodbClient::QueryJobSizeSummary(
   int64_t result_count = 0;
   try {
     auto cursor =
-        (*GetClient_())[m_db_name_][m_task_collection_name_].aggregate(
+        (*GetClient_())[m_db_name_][m_job_collection_name_].aggregate(
             pipeline);
     for (auto doc : cursor) {
       auto id = doc["_id"].get_document().view();
@@ -2418,7 +2422,7 @@ void MongodbClient::SetInitialAggregationCompleted_(JobSummary::Type type,
 
 std::chrono::sys_seconds MongodbClient::GetJobMinStartTime_() {
   try {
-    auto task_coll = (*GetClient_())[m_db_name_][m_task_collection_name_];
+    auto job_coll = (*GetClient_())[m_db_name_][m_job_collection_name_];
 
     using bsoncxx::builder::basic::make_document;
     auto sort_doc = make_document(kvp("time_start", 1));
@@ -2428,7 +2432,7 @@ std::chrono::sys_seconds MongodbClient::GetJobMinStartTime_() {
     auto filter =
         make_document(kvp("time_start", make_document(kvp("$ne", 0))));
 
-    auto doc_opt = task_coll.find_one(filter.view(), options);
+    auto doc_opt = job_coll.find_one(filter.view(), options);
     if (!doc_opt) {
       CRANE_INFO("No jobs found when getting min start time.");
       return std::chrono::sys_seconds{std::chrono::seconds{0}};
@@ -2446,7 +2450,7 @@ std::chrono::sys_seconds MongodbClient::GetJobMinStartTime_() {
 // Worker function to aggregate a single hour (executed in thread pool)
 std::optional<int64_t> MongodbClient::AggregateJobSummaryForSingleHour_(
     std::chrono::sys_seconds hour_start, std::chrono::sys_seconds hour_end,
-    const std::string& task_collection_name, int64_t cached_min_start) {
+    const std::string& job_collection_name, int64_t cached_min_start) {
   using namespace std::chrono;
   using bsoncxx::builder::basic::kvp;
   using bsoncxx::builder::basic::make_array;
@@ -2457,7 +2461,7 @@ std::optional<int64_t> MongodbClient::AggregateJobSummaryForSingleHour_(
 
   try {
     mongocxx::client* client = GetClient_();
-    auto jobs = (*client)[m_db_name_][task_collection_name];
+    auto jobs = (*client)[m_db_name_][job_collection_name];
 
     auto cur_start =
         duration_cast<seconds>(hour_start.time_since_epoch()).count();
@@ -2477,15 +2481,15 @@ std::optional<int64_t> MongodbClient::AggregateJobSummaryForSingleHour_(
                                         kvp("$lt", cur_end), kvp("$ne", 0)))),
         find_opts);
 
-    bool has_task = false;
+    bool has_job = false;
     for (auto&& doc : probe_cursor) {
       discovered_min_start =
           ViewGetArithmeticValue_<int64_t>(doc["time_start"]);
-      has_task = true;
+      has_job = true;
     }
 
-    if (!has_task) {
-      CRANE_LOGGER_TRACE(m_logger_, "Hour [{}, {}) skipped: no active tasks",
+    if (!has_job) {
+      CRANE_LOGGER_TRACE(m_logger_, "Hour [{}, {}) skipped: no active jobs",
                          hour_start, hour_end);
       return discovered_min_start;
     }
@@ -2578,7 +2582,7 @@ std::optional<int64_t> MongodbClient::AggregateJobSummaryForSingleHour_(
 
 bool MongodbClient::AggregateJobSummaryByHour_(
     std::chrono::sys_seconds start_sec, std::chrono::sys_seconds end_sec,
-    const std::string& task_collection_name) {
+    const std::string& job_collection_name) {
   CRANE_LOGGER_INFO(m_logger_, "AggregateJobSummaryByHour from {} to {}",
                     start_sec, end_sec);
   using namespace std::chrono;
@@ -2611,7 +2615,7 @@ bool MongodbClient::AggregateJobSummaryByHour_(
       for (const auto& hour_start : batch_hours) {
         futures.push_back(std::async(std::launch::async, [&, hour_start]() {
           return AggregateJobSummaryForSingleHour_(
-              hour_start, hour_start + hours{1}, task_collection_name,
+              hour_start, hour_start + hours{1}, job_collection_name,
               cached_min_start);
         }));
       }
@@ -3293,7 +3297,7 @@ void MongodbClient::DocumentAppendItem_(document& doc, const std::string& key,
 
 void MongodbClient::DocumentAppendItem_(
     document& doc, const std::string& key,
-    const std::optional<ContainerMetaInTask>& value) {
+    const std::optional<ContainerMetaInJob>& value) {
   if (!value.has_value()) {
     doc.append(kvp(key, bsoncxx::types::b_null{}));
     return;
@@ -3360,7 +3364,7 @@ void MongodbClient::DocumentAppendItem_(
 
 void MongodbClient::DocumentAppendItem_(
     document& doc, const std::string& key,
-    const std::optional<PodMetaInTask>& value) {
+    const std::optional<PodMetaInJob>& value) {
   if (!value.has_value()) {
     doc.append(kvp(key, bsoncxx::types::b_null{}));
     return;
@@ -3684,8 +3688,8 @@ void MongodbClient::ViewToQos_(const bsoncxx::document::view& qos_view,
         qos_view[Qos::FieldStringOfMaxSubmitJobsPerAccount()],
         int64_t(std::numeric_limits<
                 decltype(qos->max_submit_jobs_per_account)>::max()));
-    qos->max_time_limit_per_task = absl::Seconds(
-        qos_view[Qos::FieldStringOfMaxTimeLimitPerTask()].get_int64().value);
+    qos->max_time_limit_per_job = absl::Seconds(
+        qos_view[Qos::FieldStringOfMaxTimeLimitPerJob()].get_int64().value);
     qos->max_jobs = ViewValueOr_(
         qos_view[Qos::FieldStringOfMaxJobs()],
         int64_t(std::numeric_limits<decltype(qos->max_jobs)>::max()));
@@ -3718,7 +3722,7 @@ bsoncxx::builder::basic::document MongodbClient::QosToDocument_(
       Qos::FieldStringOfPriority(),
       Qos::FieldStringOfMaxJobsPerUser(),
       Qos::FieldStringOfMaxCpusPerUser(),
-      Qos::FieldStringOfMaxTimeLimitPerTask(),
+      Qos::FieldStringOfMaxTimeLimitPerJob(),
       Qos::FieldStringOfMaxJobsPerAccount(),
       Qos::FieldStringOfMaxSubmitJobsPerUser(),
       Qos::FieldStringOfMaxSubmitJobsPerAccount(),
@@ -3739,7 +3743,7 @@ bsoncxx::builder::basic::document MongodbClient::QosToDocument_(
              qos.priority,
              qos.max_jobs_per_user,
              qos.max_cpus_per_user,
-             absl::ToInt64Seconds(qos.max_time_limit_per_task),
+             absl::ToInt64Seconds(qos.max_time_limit_per_job),
              qos.max_jobs_per_account,
              qos.max_submit_jobs_per_user,
              qos.max_submit_jobs_per_account,
@@ -3951,16 +3955,16 @@ ResourceV2 MongodbClient::BsonToResourceV2(const bsoncxx::document::view& doc) {
   return res;
 }
 
-ContainerMetaInTask MongodbClient::BsonToContainerMeta(
+ContainerMetaInJob MongodbClient::BsonToContainerMeta(
     const bsoncxx::document::view& doc) {
-  ContainerMetaInTask result;
+  ContainerMetaInJob result;
 
   try {
     auto container_elem = doc["meta_container"];
     if (!container_elem || container_elem.type() != bsoncxx::type::k_document) {
       CRANE_LOGGER_ERROR(m_logger_,
                          "Error in reading container metadata for a container "
-                         "task: Unexpected document type.");
+                         "job: Unexpected document type.");
       return result;
     }
 
@@ -4057,8 +4061,8 @@ ContainerMetaInTask MongodbClient::BsonToContainerMeta(
   return result;
 }
 
-PodMetaInTask MongodbClient::BsonToPodMeta(const bsoncxx::document::view& doc) {
-  PodMetaInTask result;
+PodMetaInJob MongodbClient::BsonToPodMeta(const bsoncxx::document::view& doc) {
+  PodMetaInJob result;
   try {
     auto pod_elem = doc["meta_pod"];
     if (!pod_elem || pod_elem.type() != bsoncxx::type::k_document) {
@@ -4091,17 +4095,17 @@ PodMetaInTask MongodbClient::BsonToPodMeta(const bsoncxx::document::view& doc) {
       auto ns_doc = ns_elem.get_document().view();
       if (auto network_elem = ns_doc["network"]) {
         result.namespace_option.network =
-            static_cast<crane::grpc::PodTaskAdditionalMeta::NamespaceMode>(
+            static_cast<crane::grpc::PodJobAdditionalMeta::NamespaceMode>(
                 network_elem.get_int32().value);
       }
       if (auto pid_elem = ns_doc["pid"]) {
         result.namespace_option.pid =
-            static_cast<crane::grpc::PodTaskAdditionalMeta::NamespaceMode>(
+            static_cast<crane::grpc::PodJobAdditionalMeta::NamespaceMode>(
                 pid_elem.get_int32().value);
       }
       if (auto ipc_elem = ns_doc["ipc"]) {
         result.namespace_option.ipc =
-            static_cast<crane::grpc::PodTaskAdditionalMeta::NamespaceMode>(
+            static_cast<crane::grpc::PodJobAdditionalMeta::NamespaceMode>(
                 ipc_elem.get_int32().value);
       }
       if (auto target_id_elem = ns_doc["target_id"]) {
@@ -4126,10 +4130,10 @@ PodMetaInTask MongodbClient::BsonToPodMeta(const bsoncxx::document::view& doc) {
       for (const auto& port_val : ports_elem.get_array().value) {
         if (port_val.type() != bsoncxx::type::k_document) continue;
         auto ports_doc = port_val.get_document().view();
-        PodMetaInTask::PortMapping mapping{};
+        PodMetaInJob::PortMapping mapping{};
         if (auto proto_elem = ports_doc["protocol"]) {
           mapping.protocol = static_cast<
-              crane::grpc::PodTaskAdditionalMeta::PortMapping::Protocol>(
+              crane::grpc::PodJobAdditionalMeta::PortMapping::Protocol>(
               proto_elem.get_int32().value);
         }
         if (auto container_port_elem = ports_doc["container_port"]) {
@@ -4145,11 +4149,11 @@ PodMetaInTask MongodbClient::BsonToPodMeta(const bsoncxx::document::view& doc) {
       }
     } else if (ports_elem && ports_elem.type() == bsoncxx::type::k_document) {
       // Backward compatibility with single-port schema.
-      PodMetaInTask::PortMapping mapping{};
+      PodMetaInJob::PortMapping mapping{};
       auto ports_doc = ports_elem.get_document().view();
       if (auto proto_elem = ports_doc["protocol"]) {
         mapping.protocol = static_cast<
-            crane::grpc::PodTaskAdditionalMeta::PortMapping::Protocol>(
+            crane::grpc::PodJobAdditionalMeta::PortMapping::Protocol>(
             proto_elem.get_int32().value);
       }
       if (auto container_port_elem = ports_doc["container_port"]) {
@@ -4181,17 +4185,17 @@ PodMetaInTask MongodbClient::BsonToPodMeta(const bsoncxx::document::view& doc) {
   return result;
 }
 
-MongodbClient::document MongodbClient::TaskInEmbeddedDbToDocument_(
-    const crane::grpc::TaskInEmbeddedDb& task) {
-  auto const& task_to_ctld = task.task_to_ctld();
-  auto const& runtime_attr = task.runtime_attr();
+MongodbClient::document MongodbClient::JobInEmbeddedDbToDocument_(
+    const crane::grpc::JobInEmbeddedDb& job_in_db) {
+  auto const& job_to_ctld = job_in_db.job_to_ctld();
+  auto const& runtime_attr = job_in_db.runtime_attr();
 
-  std::optional<PodMetaInTask> pod_meta{std::nullopt};
-  std::optional<ContainerMetaInTask> container_meta{std::nullopt};
-  if (task_to_ctld.type() == crane::grpc::TaskType::Container) {
-    pod_meta = static_cast<PodMetaInTask>(task_to_ctld.pod_meta());
+  std::optional<PodMetaInJob> pod_meta{std::nullopt};
+  std::optional<ContainerMetaInJob> container_meta{std::nullopt};
+  if (job_to_ctld.type() == crane::grpc::JobType::Container) {
+    pod_meta = static_cast<PodMetaInJob>(job_to_ctld.pod_meta());
     container_meta =
-        static_cast<ContainerMetaInTask>(task_to_ctld.container_meta());
+        static_cast<ContainerMetaInJob>(job_to_ctld.container_meta());
   }
 
   auto resources = static_cast<ResourceV2>(runtime_attr.allocated_res());
@@ -4202,26 +4206,26 @@ MongodbClient::document MongodbClient::TaskInEmbeddedDbToDocument_(
   double cpus_req = 0.0;
   int64_t mem_req = 0;
 
-  if (task_to_ctld.has_cpus_per_task()) {
-    cpus_req = task_to_ctld.cpus_per_task() * task_to_ctld.ntasks();
+  if (job_to_ctld.has_cpus_per_task()) {
+    cpus_req = job_to_ctld.cpus_per_task() * job_to_ctld.ntasks();
   }
 
-  if (task_to_ctld.has_mem_per_node()) {
-    mem_req += task_to_ctld.mem_per_node() * task_to_ctld.node_num();
+  if (job_to_ctld.has_mem_per_node()) {
+    mem_req += job_to_ctld.mem_per_node() * job_to_ctld.node_num();
   }
-  if (task_to_ctld.has_cpus_per_task() && task_to_ctld.has_mem_per_cpu()) {
-    mem_req += static_cast<int64_t>(task_to_ctld.cpus_per_task() *
-                                    task_to_ctld.mem_per_cpu() *
-                                    task_to_ctld.ntasks());
+  if (job_to_ctld.has_cpus_per_task() && job_to_ctld.has_mem_per_cpu()) {
+    mem_req += static_cast<int64_t>(job_to_ctld.cpus_per_task() *
+                                    job_to_ctld.mem_per_cpu() *
+                                    job_to_ctld.ntasks());
   }
 
   bool using_default_wckey = false;
-  if (g_config.WckeyValid && task_to_ctld.wckey().empty()) {
+  if (g_config.WckeyValid && job_to_ctld.wckey().empty()) {
     using_default_wckey = true;
   }
 
   document env_doc;
-  for (const auto& entry : task_to_ctld.env()) {
+  for (const auto& entry : job_to_ctld.env()) {
     env_doc.append(kvp(entry.first, entry.second));
   }
 
@@ -4233,25 +4237,25 @@ MongodbClient::document MongodbClient::TaskInEmbeddedDbToDocument_(
   }
 
   std::list<std::string> req_node_list;
-  util::ParseHostList(task.task_to_ctld().nodelist(), &req_node_list);
+  util::ParseHostList(job_to_ctld.nodelist(), &req_node_list);
   std::list<std::string> exclude_node_list;
-  util::ParseHostList(task.task_to_ctld().excludes(), &exclude_node_list);
+  util::ParseHostList(job_to_ctld.excludes(), &exclude_node_list);
 
   std::vector<CranedId> execution_nodes;
-  if (task_to_ctld.type() == crane::grpc::TaskType::Batch) {
+  if (job_to_ctld.type() == crane::grpc::JobType::Batch) {
     execution_nodes.push_back(runtime_attr.craned_ids(0));
-  } else if (task_to_ctld.type() == crane::grpc::TaskType::Interactive) {
-    const auto& ia_meta = task_to_ctld.interactive_meta();
+  } else if (job_to_ctld.type() == crane::grpc::JobType::Interactive) {
+    const auto& ia_meta = job_to_ctld.interactive_meta();
     if (ia_meta.interactive_type() ==
-        crane::grpc::InteractiveTaskType::Calloc) {
+        crane::grpc::InteractiveJobType::Calloc) {
       execution_nodes.push_back(runtime_attr.craned_ids(0));
     } else if (ia_meta.pty())
       execution_nodes.push_back(runtime_attr.craned_ids(0));
     else
       execution_nodes = std::vector(runtime_attr.craned_ids().begin(),
                                     runtime_attr.craned_ids().end());
-  } else if (task_to_ctld.type() == crane::grpc::TaskType::Container) {
-    if (task_to_ctld.has_container_meta()) {
+  } else if (job_to_ctld.type() == crane::grpc::JobType::Container) {
+    if (job_to_ctld.has_container_meta()) {
       execution_nodes = std::vector(runtime_attr.craned_ids().begin(),
                                     runtime_attr.craned_ids().end());
     } else {
@@ -4259,8 +4263,8 @@ MongodbClient::document MongodbClient::TaskInEmbeddedDbToDocument_(
     }
   }
 
-  // 0  task_id       task_db_id     mod_time       deleted       account
-  // 5  cpus_req      mem_req        task_name      env           id_user
+  // 0  job_id        job_db_id      mod_time       deleted       account
+  // 5  cpus_req      mem_req        job_name       env           id_user
   // 10 id_group      nodelist       nodes_alloc   node_inx    partition_name
   // 15 priority      time_eligible  time_start    time_end    time_suspended
   // 20 script        state          timelimit     time_submit work_dir
@@ -4272,9 +4276,9 @@ MongodbClient::document MongodbClient::TaskInEmbeddedDbToDocument_(
   // clang-format off
   std::array<std::string, 49> fields{
     // 0 - 4
-    "task_id",  "task_db_id", "mod_time",    "deleted",  "account",
+    "job_id",  "job_db_id", "mod_time",    "deleted",  "account",
     // 5 - 9
-    "cpus_req", "mem_req",    "task_name",   "env",      "id_user",
+    "cpus_req", "mem_req",    "job_name",   "env",      "id_user",
     // 10 - 14
     "id_group", "nodelist",   "nodes_alloc", "node_inx", "partition_name",
     // 15 - 19
@@ -4294,45 +4298,45 @@ MongodbClient::document MongodbClient::TaskInEmbeddedDbToDocument_(
   };
   // clang-format on
 
-  std::tuple<int32_t, task_db_id_t, int64_t, bool, std::string,     /*0-4*/
+  std::tuple<int32_t, job_db_id_t, int64_t, bool, std::string,     /*0-4*/
              double, int64_t, std::string, std::string, int32_t,    /*5-9*/
              int32_t, std::string, int32_t, int32_t, std::string,   /*10-14*/
              int64_t, int64_t, int64_t, int64_t, int64_t,           /*15-19*/
              std::string, int32_t, int64_t, int64_t, std::string,   /*20-24*/
              std::string, int32_t, std::string, std::string, bool,  /*25-29*/
              int32_t, std::string, std::string, bool, double,       /*30-34*/
-             int64_t, DeviceMap, std::optional<PodMetaInTask>,      /*35-37*/
-             std::optional<ContainerMetaInTask>, bool,              /*38-39*/
+             int64_t, DeviceMap, std::optional<PodMetaInJob>,      /*35-37*/
+             std::optional<ContainerMetaInJob>, bool,              /*38-39*/
              std::unordered_map<std::string, uint32_t>,             /*40*/
              bsoncxx::array::value, std::string, bool, std::string, /*41-44*/
              std::string, std::list<CranedId>, std::list<CranedId>, /*45-46*/
              std::vector<CranedId>>                                 /*45-49*/
       values{                                                       // 0-4
-             static_cast<int32_t>(runtime_attr.task_id()),
-             runtime_attr.task_db_id(), absl::ToUnixSeconds(absl::Now()), false,
-             task_to_ctld.account(),
+             static_cast<int32_t>(runtime_attr.job_id()),
+             runtime_attr.job_db_id(), absl::ToUnixSeconds(absl::Now()), false,
+             job_to_ctld.account(),
              // 5-9
-             cpus_req, mem_req, task_to_ctld.name(), env_str,
-             static_cast<int32_t>(task_to_ctld.uid()),
+             cpus_req, mem_req, job_to_ctld.name(), env_str,
+             static_cast<int32_t>(job_to_ctld.uid()),
              // 10-14
-             static_cast<int32_t>(task_to_ctld.gid()),
+             static_cast<int32_t>(job_to_ctld.gid()),
              util::HostNameListToStr(runtime_attr.craned_ids()),
-             runtime_attr.craned_ids().size(), 0, task_to_ctld.partition_name(),
+             runtime_attr.craned_ids().size(), 0, job_to_ctld.partition_name(),
              // 15-19
              runtime_attr.cached_priority(), 0,
              runtime_attr.start_time().seconds(),
              runtime_attr.end_time().seconds(), 0,
              // 20-24
-             task_to_ctld.batch_meta().sh_script(), runtime_attr.status(),
-             task_to_ctld.time_limit().seconds(),
-             runtime_attr.submit_time().seconds(), task_to_ctld.cwd(),
+             job_to_ctld.batch_meta().sh_script(), runtime_attr.status(),
+             job_to_ctld.time_limit().seconds(),
+             runtime_attr.submit_time().seconds(), job_to_ctld.cwd(),
              // 25-29
-             task_to_ctld.cmd_line(), runtime_attr.exit_code(),
-             runtime_attr.username(), task_to_ctld.qos(),
-             task_to_ctld.get_user_env(),
+             job_to_ctld.cmd_line(), runtime_attr.exit_code(),
+             runtime_attr.username(), job_to_ctld.qos(),
+             job_to_ctld.get_user_env(),
              // 30-34
-             task_to_ctld.type(), task_to_ctld.extra_attr(),
-             task_to_ctld.reservation(), task_to_ctld.exclusive(),
+             job_to_ctld.type(), job_to_ctld.extra_attr(),
+             job_to_ctld.reservation(), job_to_ctld.exclusive(),
              allocated_res_view.CpuCount(),
              // 35-39
              static_cast<int64_t>(allocated_res_view.MemoryBytes()),
@@ -4343,10 +4347,10 @@ MongodbClient::document MongodbClient::TaskInEmbeddedDbToDocument_(
                  runtime_attr.actual_licenses().begin(),
                  runtime_attr.actual_licenses().end()},
              bsoncxx::array::value{nodename_list_array.view()},
-             task_to_ctld.wckey(), using_default_wckey,
+             job_to_ctld.wckey(), using_default_wckey,
              g_config.CraneClusterName,
              // 45-48
-             task_to_ctld.submit_hostname(), req_node_list, exclude_node_list,
+             job_to_ctld.submit_hostname(), req_node_list, exclude_node_list,
              execution_nodes};
 
   return DocumentConstructor_(fields, values);
@@ -4384,37 +4388,37 @@ void MongodbClient::QosResourceViewFromDb_(
   }
 }
 
-MongodbClient::document MongodbClient::TaskInCtldToDocument_(TaskInCtld* task) {
+MongodbClient::document MongodbClient::JobInCtldToDocument_(JobInCtld* job) {
   std::string script;
-  std::optional<ContainerMetaInTask> container_meta{std::nullopt};
-  std::optional<PodMetaInTask> pod_meta{std::nullopt};
+  std::optional<ContainerMetaInJob> container_meta{std::nullopt};
+  std::optional<PodMetaInJob> pod_meta{std::nullopt};
 
-  if (task->type == crane::grpc::Batch)
-    script = task->TaskToCtld().batch_meta().sh_script();
-  else if (task->type == crane::grpc::Container) {
+  if (job->type == crane::grpc::Batch)
+    script = job->JobToCtld().batch_meta().sh_script();
+  else if (job->type == crane::grpc::Container) {
     // All container job has pod_meta
-    pod_meta = task->pod_meta;
+    pod_meta = job->pod_meta;
 
     // Jobs from ccon has container_meta
-    if (std::holds_alternative<ContainerMetaInTask>(task->meta))
-      container_meta = std::get<ContainerMetaInTask>(task->meta);
+    if (std::holds_alternative<ContainerMetaInJob>(job->meta))
+      container_meta = std::get<ContainerMetaInJob>(job->meta);
 
     // Jobs from cbatch has batch_meta
-    if (task->TaskToCtld().has_batch_meta())
-      script = task->TaskToCtld().batch_meta().sh_script();
+    if (job->JobToCtld().has_batch_meta())
+      script = job->JobToCtld().batch_meta().sh_script();
   }
 
   // TODO: Interactive meta?
 
   document env_doc;
-  for (const auto& entry : task->env) {
+  for (const auto& entry : job->env) {
     env_doc.append(kvp(entry.first, entry.second));
   }
 
   std::string env_str = bsoncxx::to_json(env_doc.view());
 
-  // 0  task_id       task_db_id     mod_time       deleted       account
-  // 5  cpus_req      mem_req        task_name      env           id_user
+  // 0  job_id        job_db_id      mod_time       deleted       account
+  // 5  cpus_req      mem_req        job_name       env           id_user
   // 10 id_group      nodelist       nodes_alloc   node_inx    partition_name
   // 15 priority      time_eligible  time_start    time_end    time_suspended
   // 20 script        state          timelimit     time_submit work_dir
@@ -4427,9 +4431,9 @@ MongodbClient::document MongodbClient::TaskInCtldToDocument_(TaskInCtld* task) {
   // clang-format off
   std::array<std::string, 49> fields{
       // 0 - 4
-      "task_id",  "task_db_id", "mod_time",    "deleted",  "account",
+      "job_id",  "job_db_id", "mod_time",    "deleted",  "account",
       // 5 - 9
-      "cpus_req", "mem_req",    "task_name",   "env",      "id_user",
+      "cpus_req", "mem_req",    "job_name",   "env",      "id_user",
       // 10 - 14
       "id_group", "nodelist",   "nodes_alloc", "node_inx", "partition_name",
       // 15 - 19
@@ -4449,52 +4453,52 @@ MongodbClient::document MongodbClient::TaskInCtldToDocument_(TaskInCtld* task) {
   };
   // clang-format on
 
-  std::tuple<int32_t, task_db_id_t, int64_t, bool, std::string,     /*0-4*/
+  std::tuple<int32_t, job_db_id_t, int64_t, bool, std::string,     /*0-4*/
              double, int64_t, std::string, std::string, int32_t,    /*5-9*/
              int32_t, std::string, int32_t, int32_t, std::string,   /*10-14*/
              int64_t, int64_t, int64_t, int64_t, int64_t,           /*15-19*/
              std::string, int32_t, int64_t, int64_t, std::string,   /*20-24*/
              std::string, int32_t, std::string, std::string, bool,  /*25-29*/
              int32_t, std::string, std::string, bool, double,       /*30-34*/
-             int64_t, DeviceMap, std::optional<PodMetaInTask>,      /*35-37*/
-             std::optional<ContainerMetaInTask>, bool,              /*38-39*/
+             int64_t, DeviceMap, std::optional<PodMetaInJob>,      /*35-37*/
+             std::optional<ContainerMetaInJob>, bool,              /*38-39*/
              std::unordered_map<std::string, uint32_t>,             /*40*/
              std::vector<CranedId>, std::string, bool, std::string, /*41-44*/
              std::string, std::unordered_set<CranedId>,             /*45-49*/
              std::unordered_set<CranedId>, std::vector<CranedId>>   /*45-49*/
       values{                                                       // 0-4
-             static_cast<int32_t>(task->TaskId()), task->TaskDbId(),
-             absl::ToUnixSeconds(absl::Now()), false, task->account,
+             static_cast<int32_t>(job->JobId()), job->JobDbId(),
+             absl::ToUnixSeconds(absl::Now()), false, job->account,
              // 5-9
-             task->req_total_res_view.CpuCount(),
-             static_cast<int64_t>(task->req_total_res_view.MemoryBytes()),
-             task->name, env_str, static_cast<int32_t>(task->uid),
+             job->req_total_res_view.CpuCount(),
+             static_cast<int64_t>(job->req_total_res_view.MemoryBytes()),
+             job->name, env_str, static_cast<int32_t>(job->uid),
              // 10-14
-             static_cast<int32_t>(task->gid), task->allocated_craneds_regex,
-             static_cast<int32_t>(task->nodes_alloc), 0, task->partition_id,
+             static_cast<int32_t>(job->gid), job->allocated_craneds_regex,
+             static_cast<int32_t>(job->nodes_alloc), 0, job->partition_id,
              // 15-19
-             static_cast<int64_t>(task->CachedPriority()), 0,
-             task->StartTimeInUnixSecond(), task->EndTimeInUnixSecond(), 0,
+             static_cast<int64_t>(job->CachedPriority()), 0,
+             job->StartTimeInUnixSecond(), job->EndTimeInUnixSecond(), 0,
              // 20-24
-             script, task->Status(), absl::ToInt64Seconds(task->time_limit),
-             task->SubmitTimeInUnixSecond(), task->cwd,
+             script, job->Status(), absl::ToInt64Seconds(job->time_limit),
+             job->SubmitTimeInUnixSecond(), job->cwd,
              // 25-29
-             task->cmd_line, task->ExitCode(), task->Username(), task->qos,
-             task->get_user_env,
+             job->cmd_line, job->ExitCode(), job->Username(), job->qos,
+             job->get_user_env,
              // 30-34
-             task->type, task->extra_attr, task->reservation,
-             task->TaskToCtld().exclusive(),
-             task->allocated_res_view.CpuCount(),
+             job->type, job->extra_attr, job->reservation,
+             job->JobToCtld().exclusive(),
+             job->allocated_res_view.CpuCount(),
              // 35-39
-             static_cast<int64_t>(task->allocated_res_view.MemoryBytes()),
-             task->allocated_res_view.GetDeviceMap(), pod_meta, container_meta,
+             static_cast<int64_t>(job->allocated_res_view.MemoryBytes()),
+             job->allocated_res_view.GetDeviceMap(), pod_meta, container_meta,
              true /* Mark the document having complete job info */,
              // 40-44
-             task->licenses_count, task->CranedIds(), task->wckey,
-             task->using_default_wckey, g_config.CraneClusterName,
+             job->licenses_count, job->CranedIds(), job->wckey,
+             job->using_default_wckey, g_config.CraneClusterName,
              // 45-49
-             task->submit_hostname, task->included_nodes, task->excluded_nodes,
-             task->executing_craned_ids};
+             job->submit_hostname, job->included_nodes, job->excluded_nodes,
+             job->executing_craned_ids};
 
   return DocumentConstructor_(fields, values);
 }
@@ -4508,8 +4512,8 @@ MongodbClient::document MongodbClient::StepInCtldToDocument_(StepInCtld* step) {
     // Container job primary step submitted via cbatch --pod
     script = step->StepToCtld().batch_meta().sh_script();
 
-  std::optional<PodMetaInTask> pod_meta{std::nullopt};
-  std::optional<ContainerMetaInTask> container_meta{std::nullopt};
+  std::optional<PodMetaInJob> pod_meta{std::nullopt};
+  std::optional<ContainerMetaInJob> container_meta{std::nullopt};
   if (step->pod_meta.has_value()) pod_meta = step->pod_meta;
   if (step->container_meta.has_value()) container_meta = step->container_meta;
 
@@ -4554,8 +4558,8 @@ MongodbClient::document MongodbClient::StepInCtldToDocument_(StepInCtld* step) {
              int64_t, std::string, int32_t, int64_t, int64_t,  /*15-19*/
              std::string, std::string, int32_t, bool, int32_t, /*20-24*/
              std::string, ResourceV2, int32_t,                 /*25-27*/
-             std::optional<PodMetaInTask>,                     /*28*/
-             std::optional<ContainerMetaInTask>,               /*29*/
+             std::optional<PodMetaInJob>,                      /*28*/
+             std::optional<ContainerMetaInJob>,                /*29*/
              std::unordered_set<std::string>,                  /*30*/
              std::unordered_set<std::string>,                  /*31*/
              std::unordered_set<std::string>>                  /*32*/
@@ -4598,12 +4602,12 @@ MongodbClient::document MongodbClient::StepInEmbeddedDbToDocument_(
            step_to_ctld.has_batch_meta())
     script = step_to_ctld.batch_meta().sh_script();
 
-  std::optional<PodMetaInTask> pod_meta{std::nullopt};
-  std::optional<ContainerMetaInTask> container_meta{std::nullopt};
+  std::optional<PodMetaInJob> pod_meta{std::nullopt};
+  std::optional<ContainerMetaInJob> container_meta{std::nullopt};
   if (step_to_ctld.type() == crane::grpc::Container) {
     if (step_to_ctld.has_container_meta()) {
       container_meta =
-          static_cast<ContainerMetaInTask>(step_to_ctld.container_meta());
+          static_cast<ContainerMetaInJob>(step_to_ctld.container_meta());
     }
   }
 
@@ -4668,8 +4672,8 @@ MongodbClient::document MongodbClient::StepInEmbeddedDbToDocument_(
              int64_t, std::string, int32_t, int64_t, int64_t,  /*15-19*/
              std::string, std::string, int32_t, bool, int32_t, /*20-24*/
              std::string, ResourceV2, int32_t,
-             std::optional<PodMetaInTask>,                   /*25-28*/
-             std::optional<ContainerMetaInTask>,             /*29-29*/
+             std::optional<PodMetaInJob>,                    /*25-28*/
+             std::optional<ContainerMetaInJob>,              /*29-29*/
              std::list<std::string>, std::list<std::string>, /*30-31*/
              decltype(runtime_attr.execution_nodes())>       /*32*/
 
@@ -4764,7 +4768,7 @@ void MongodbClient::ViewToStepInfo_(const bsoncxx::document::view& view,
       view["time_end"].get_int64().value);
 
   step_info->set_status(
-      static_cast<crane::grpc::TaskStatus>(view["state"].get_int32().value));
+      static_cast<crane::grpc::JobStatus>(view["state"].get_int32().value));
   step_info->mutable_time_limit()->set_seconds(
       view["timelimit"].get_int64().value);
   step_info->mutable_submit_time()->set_seconds(
@@ -4776,7 +4780,7 @@ void MongodbClient::ViewToStepInfo_(const bsoncxx::document::view& view,
   step_info->set_exit_code(view["exit_code"].get_int32().value);
 
   step_info->set_type(
-      static_cast<crane::grpc::TaskType>(view["type"].get_int32().value));
+      static_cast<crane::grpc::JobType>(view["type"].get_int32().value));
 
   step_info->set_extra_attr(view["extra_attr"].get_string().value.data());
   *step_info->mutable_allocated_res_view() =
@@ -4791,7 +4795,7 @@ void MongodbClient::ViewToStepInfo_(const bsoncxx::document::view& view,
     auto* meta_info = step_info->mutable_container_meta();
     auto container_meta = BsonToContainerMeta(view);
     *meta_info = std::move(
-        static_cast<crane::grpc::ContainerTaskAdditionalMeta>(container_meta));
+        static_cast<crane::grpc::ContainerJobAdditionalMeta>(container_meta));
   }
   if (view["req_nodes"])
     for (auto&& req_node : view["req_nodes"].get_array().value) {
@@ -4830,19 +4834,19 @@ bool MongodbClient::InitTableIndexes() {
   try {
     CRANE_LOGGER_DEBUG(m_logger_, "Initializing database indexes...");
 
-    // Create indexes for the raw task table
-    CRANE_LOGGER_DEBUG(m_logger_, "Creating indexes for task_table...");
+    // Create indexes for the raw job table
+    CRANE_LOGGER_DEBUG(m_logger_, "Creating indexes for job_table...");
     auto client = m_connect_pool_->acquire();
-    auto raw_table = client[m_db_name_][m_task_collection_name_];
+    auto raw_table = client[m_db_name_][m_job_collection_name_];
     CreateCollectionIndex(raw_table, {"time_start", "time_end"}, false);
-    // Indexes for jobsize queries (direct task_table scan)
+    // Indexes for jobsize queries (direct job_table scan)
     CreateCollectionIndex(
         raw_table, {"time_start", "time_end", "account", "username"}, false);
     CreateCollectionIndex(raw_table, {"time_start", "time_end", "cpus_alloc"},
                           false);
-    // task_table: add index for aggregated field (recovery optimization)
+    // job_table: add index for aggregated field (recovery optimization)
     CRANE_LOGGER_DEBUG(m_logger_,
-                       "Creating aggregation recovery index on task_table...");
+                       "Creating aggregation recovery index on job_table...");
     CreateCollectionIndex(raw_table, {"aggregated", "status"}, false);
 
     auto acc_hour_coll = client[m_db_name_][m_acc_usage_hour_collection_name_];

--- a/src/CraneCtld/DbClient.h
+++ b/src/CraneCtld/DbClient.h
@@ -93,7 +93,7 @@ class MongodbClient {
     enum class Type : std::uint8_t { HOUR, DAY, MONTH };
   };
 
-  // Task aggregation information for acc_usage tables
+  // Job aggregation information for acc_usage tables
   struct JobAggregationInfo {
     std::string account;
     std::string username;
@@ -134,25 +134,25 @@ class MongodbClient {
 
   /* ----- Method of operating the job table ----------- */
   bool InsertRecoveredJob(
-      crane::grpc::TaskInEmbeddedDb const& task_in_embedded_db);
-  bool InsertJob(TaskInCtld* task);
-  bool InsertJobs(const std::unordered_set<TaskInCtld*>& tasks);
+      crane::grpc::JobInEmbeddedDb const& job_in_embedded_db);
+  bool InsertJob(JobInCtld* job);
+  bool InsertJobs(const std::unordered_set<JobInCtld*>& jobs);
 
   bool FetchJobRecords(
-      const crane::grpc::QueryTasksInfoRequest* request,
-      std::unordered_map<job_id_t, crane::grpc::TaskInfo>* job_info_map,
+      const crane::grpc::QueryJobsInfoRequest* request,
+      std::unordered_map<job_id_t, crane::grpc::JobInfo>* job_info_map,
       size_t limit);
 
   bool FetchJobStepRecords(
-      const crane::grpc::QueryTasksInfoRequest* request,
-      std::unordered_map<job_id_t, crane::grpc::TaskInfo>* job_info_map);
+      const crane::grpc::QueryJobsInfoRequest* request,
+      std::unordered_map<job_id_t, crane::grpc::JobInfo>* job_info_map);
 
-  bool CheckTaskDbIdExisted(int64_t task_db_id);
+  bool CheckJobDbIdExisted(int64_t job_db_id);
 
   // Fetch job status (state, exit_code, time_end, time_start)
-  std::unordered_map<task_id_t, std::tuple<crane::grpc::TaskStatus, uint32_t,
+  std::unordered_map<job_id_t, std::tuple<crane::grpc::JobStatus, uint32_t,
                                            int64_t, int64_t>>
-  FetchJobStatus(const std::unordered_set<task_id_t>& job_ids);
+  FetchJobStatus(const std::unordered_set<job_id_t>& job_ids);
 
   /* ----- Method of operating the step table ----------- */
   bool InsertRecoveredStep(
@@ -167,14 +167,14 @@ class MongodbClient {
       const crane::grpc::QueryJobSummaryRequest* request,
       grpc::ServerWriter<::crane::grpc::QueryJobSummaryReply>* stream);
 
-  // Real-time aggregation: append task to acc_usage tables
-  void AppendToAccUsageTable(const bsoncxx::document::view& task_doc,
+  // Real-time aggregation: append job to acc_usage tables
+  void AppendToAccUsageTable(const bsoncxx::document::view& job_doc,
                              mongocxx::client_session* session = nullptr);
-  void AppendToAccUsageTable(const TaskInCtld* task,
+  void AppendToAccUsageTable(const JobInCtld* job,
                              mongocxx::client_session* session = nullptr);
 
-  // Mark task as aggregated in task_table
-  void MarkTaskAsAggregated(job_id_t job_id,
+  // Mark job as aggregated in job_table
+  void MarkJobAsAggregated(job_id_t job_id,
                             mongocxx::client_session* session = nullptr);
 
   // Recovery functions for startup
@@ -203,12 +203,12 @@ class MongodbClient {
   // Returns: discovered min_start on success, std::nullopt on failure
   std::optional<int64_t> AggregateJobSummaryForSingleHour_(
       std::chrono::sys_seconds hour_start, std::chrono::sys_seconds hour_end,
-      const std::string& task_collection_name, int64_t cached_min_start);
+      const std::string& job_collection_name, int64_t cached_min_start);
 
   // (For new cluster initialization only)
   bool AggregateJobSummaryByHour_(std::chrono::sys_seconds start_sec,
                                   std::chrono::sys_seconds end_sec,
-                                  const std::string& task_collection_name);
+                                  const std::string& job_collection_name);
 
   // (For new cluster initialization only)
   bool AggregateJobSummaryByDayOrMonth_(
@@ -513,10 +513,10 @@ class MongodbClient {
   void DocumentAppendItem_(document& doc, const std::string& key,
                            const ResourceV2& value);
   void DocumentAppendItem_(document& doc, const std::string& key,
-                           const std::optional<ContainerMetaInTask>& value);
+                           const std::optional<ContainerMetaInJob>& value);
 
   void DocumentAppendItem_(document& doc, const std::string& key,
-                           const std::optional<PodMetaInTask>& value);
+                           const std::optional<PodMetaInJob>& value);
 
   void DocumentAppendItem_(
       document& doc, const std::string& key,
@@ -626,9 +626,9 @@ class MongodbClient {
                               LicenseResourceInDb* resource);
   document LicenseResourceToDocument_(const LicenseResourceInDb& resource);
 
-  document TaskInCtldToDocument_(TaskInCtld* task);
-  document TaskInEmbeddedDbToDocument_(
-      crane::grpc::TaskInEmbeddedDb const& task);
+  document JobInCtldToDocument_(JobInCtld* job);
+  document JobInEmbeddedDbToDocument_(
+      crane::grpc::JobInEmbeddedDb const& job_in_db);
 
   document StepInCtldToDocument_(StepInCtld* step);
   document StepInEmbeddedDbToDocument_(
@@ -641,14 +641,18 @@ class MongodbClient {
       const bsoncxx::document::view& doc);
   ResourceInNode BsonToResourceInNode(const bsoncxx::document::view& doc);
   ResourceV2 BsonToResourceV2(const bsoncxx::document::view& doc);
-  PodMetaInTask BsonToPodMeta(const bsoncxx::document::view& doc);
-  ContainerMetaInTask BsonToContainerMeta(const bsoncxx::document::view& doc);
+  PodMetaInJob BsonToPodMeta(const bsoncxx::document::view& doc);
+  ContainerMetaInJob BsonToContainerMeta(const bsoncxx::document::view& doc);
 
   void QosResourceViewFromDb_(const bsoncxx::document::view& qos_view,
                               const std::string& field, ResourceView* resource);
 
   std::string m_db_name_, m_connect_uri_;
-  const std::string m_task_collection_name_{"task_table"};
+  // TODO: Renaming from "task_table" to "job_table" requires a database
+  // migration for existing deployments. A migration script should rename the
+  // MongoDB collection (db.task_table.renameCollection("job_table")) and be
+  // integrated into the upgrade procedure before this change is released.
+  const std::string m_job_collection_name_{"job_table"};
   const std::string m_account_collection_name_{"acct_table"};
   const std::string m_user_collection_name_{"user_table"};
   const std::string m_qos_collection_name_{"qos_table"};

--- a/src/CraneCtld/DbClient.h
+++ b/src/CraneCtld/DbClient.h
@@ -150,8 +150,8 @@ class MongodbClient {
   bool CheckJobDbIdExisted(int64_t job_db_id);
 
   // Fetch job status (state, exit_code, time_end, time_start)
-  std::unordered_map<job_id_t, std::tuple<crane::grpc::JobStatus, uint32_t,
-                                           int64_t, int64_t>>
+  std::unordered_map<
+      job_id_t, std::tuple<crane::grpc::JobStatus, uint32_t, int64_t, int64_t>>
   FetchJobStatus(const std::unordered_set<job_id_t>& job_ids);
 
   /* ----- Method of operating the step table ----------- */
@@ -175,7 +175,7 @@ class MongodbClient {
 
   // Mark job as aggregated in job_table
   void MarkJobAsAggregated(job_id_t job_id,
-                            mongocxx::client_session* session = nullptr);
+                           mongocxx::client_session* session = nullptr);
 
   // Recovery functions for startup
   void RecoverMissingAggregations_();

--- a/src/CraneCtld/EmbeddedDbClient.cpp
+++ b/src/CraneCtld/EmbeddedDbClient.cpp
@@ -586,7 +586,7 @@ bool EmbeddedDbClient::Init(const std::string& db_path) {
 }
 
 bool EmbeddedDbClient::ResetNextJobId(job_id_t next_job_id,
-                                       db_id_t next_job_db_id) {
+                                      db_id_t next_job_db_id) {
   txn_id_t txn_id;
   std::expected<void, DbErrorCode> result;
 
@@ -819,39 +819,39 @@ bool EmbeddedDbClient::RetrieveLastSnapshot(DbSnapshot* snapshot) {
     return false;
   }
 
-  result = m_fixed_db_->IterateAllKv(
-      [&](std::string&& key, std::vector<uint8_t>&& value) {
-        job_db_id_t id = ExtractDbIdFromEntry_(key);
+  result = m_fixed_db_->IterateAllKv([&](std::string&& key,
+                                         std::vector<uint8_t>&& value) {
+    job_db_id_t id = ExtractDbIdFromEntry_(key);
 
-        // Delete incomplete job fixed data,
-        // where fixed data are stored but variable data are missing.
-        auto runtime_attr_it = db_id_runtime_attr_map.find(id);
-        if (runtime_attr_it == db_id_runtime_attr_map.end()) return false;
+    // Delete incomplete job fixed data,
+    // where fixed data are stored but variable data are missing.
+    auto runtime_attr_it = db_id_runtime_attr_map.find(id);
+    if (runtime_attr_it == db_id_runtime_attr_map.end()) return false;
 
-        JobStatus status = runtime_attr_it->second.status();
+    JobStatus status = runtime_attr_it->second.status();
 
-        // Assemble JobInEmbeddedDb here.
-        JobInEmbeddedDb job_data;
-        *job_data.mutable_runtime_attr() = std::move(runtime_attr_it->second);
-        job_data.mutable_job_to_ctld()->ParseFromArray(value.data(), value.size());
+    // Assemble JobInEmbeddedDb here.
+    JobInEmbeddedDb job_data;
+    *job_data.mutable_runtime_attr() = std::move(runtime_attr_it->second);
+    job_data.mutable_job_to_ctld()->ParseFromArray(value.data(), value.size());
 
-        // Dispatch to different queues by status.
-        switch (status) {
-        case crane::grpc::Pending:
-          snapshot->pending_queue.emplace(id, std::move(job_data));
-          break;
-        case crane::grpc::Running:
-        case crane::grpc::Starting:
-        case crane::grpc::Configuring:
-        case crane::grpc::Completing:
-          snapshot->running_queue.emplace(id, std::move(job_data));
-          break;
-        default:
-          snapshot->final_queue.emplace(id, std::move(job_data));
-          break;
-        }
-        return true;
-      });
+    // Dispatch to different queues by status.
+    switch (status) {
+    case crane::grpc::Pending:
+      snapshot->pending_queue.emplace(id, std::move(job_data));
+      break;
+    case crane::grpc::Running:
+    case crane::grpc::Starting:
+    case crane::grpc::Configuring:
+    case crane::grpc::Completing:
+      snapshot->running_queue.emplace(id, std::move(job_data));
+      break;
+    default:
+      snapshot->final_queue.emplace(id, std::move(job_data));
+      break;
+    }
+    return true;
+  });
 
   if (!result) {
     CRANE_ERROR("Failed to restore fixed data into queues!");
@@ -1013,8 +1013,8 @@ bool EmbeddedDbClient::AppendJobsToPendingAndAdvanceJobIds(
     return false;
   }
 
-  result = StoreTypeIntoDb_(m_variable_db_.get(), txn_id,
-                            s_next_job_db_id_str_, &job_db_id);
+  result = StoreTypeIntoDb_(m_variable_db_.get(), txn_id, s_next_job_db_id_str_,
+                            &job_db_id);
   if (!result) {
     CRANE_ERROR("Failed to store next_job_db_id.");
     return false;

--- a/src/CraneCtld/EmbeddedDbClient.cpp
+++ b/src/CraneCtld/EmbeddedDbClient.cpp
@@ -566,11 +566,11 @@ bool EmbeddedDbClient::Init(const std::string& db_path) {
   // There is no race during Init stage.
   // No lock is needed.
   ok = FetchTypeFromDbOrInitWithValueNoLockAndTxn_(
-      0, m_variable_db_.get(), s_next_task_id_str_, &s_next_task_id_, 1u);
+      0, m_variable_db_.get(), s_next_job_id_str_, &s_next_job_id_, 1u);
   if (!ok) return false;
 
   ok = FetchTypeFromDbOrInitWithValueNoLockAndTxn_(
-      0, m_variable_db_.get(), s_next_task_db_id_str_, &s_next_task_db_id_, 1L);
+      0, m_variable_db_.get(), s_next_job_db_id_str_, &s_next_job_db_id_, 1L);
   if (!ok) return false;
 
   ok = FetchTypeFromDbOrInitWithValueNoLockAndTxn_(
@@ -585,38 +585,38 @@ bool EmbeddedDbClient::Init(const std::string& db_path) {
   return true;
 }
 
-bool EmbeddedDbClient::ResetNextTaskId(task_id_t next_task_id,
-                                       db_id_t next_task_db_id) {
+bool EmbeddedDbClient::ResetNextJobId(job_id_t next_job_id,
+                                       db_id_t next_job_db_id) {
   txn_id_t txn_id;
   std::expected<void, DbErrorCode> result;
 
-  absl::MutexLock lock_ids(&s_task_id_and_db_id_mtx_);
+  absl::MutexLock lock_ids(&s_job_id_and_db_id_mtx_);
 
-  // Reset task ID counters in variable_db (0 = skip, >0 = reset to value)
+  // Reset job ID counters in variable_db (0 = skip, >0 = reset to value)
   if (!BeginDbTransaction_(m_variable_db_.get(), &txn_id)) return false;
 
-  if (next_task_id > 0) {
-    result = StoreTypeIntoDb_(m_variable_db_.get(), txn_id, s_next_task_id_str_,
-                              &next_task_id);
+  if (next_job_id > 0) {
+    result = StoreTypeIntoDb_(m_variable_db_.get(), txn_id, s_next_job_id_str_,
+                              &next_job_id);
     if (!result) {
-      CRANE_ERROR("Failed to reset next_task_id.");
+      CRANE_ERROR("Failed to reset next_job_id.");
       return false;
     }
   }
 
-  if (next_task_db_id > 0) {
+  if (next_job_db_id > 0) {
     result = StoreTypeIntoDb_(m_variable_db_.get(), txn_id,
-                              s_next_task_db_id_str_, &next_task_db_id);
+                              s_next_job_db_id_str_, &next_job_db_id);
     if (!result) {
-      CRANE_ERROR("Failed to reset next_task_db_id.");
+      CRANE_ERROR("Failed to reset next_job_db_id.");
       return false;
     }
   }
 
   if (!CommitDbTransaction_(m_variable_db_.get(), txn_id)) return false;
 
-  // Also reset step counters when task IDs are reset
-  if (next_task_id > 0) {
+  // Also reset step counters when job IDs are reset
+  if (next_job_id > 0) {
     absl::MutexLock lock_steps(&s_step_id_mtx_);
 
     if (!BeginDbTransaction_(m_step_var_db_.get(), &txn_id)) return false;
@@ -644,11 +644,11 @@ bool EmbeddedDbClient::ResetNextTaskId(task_id_t next_task_id,
   }
 
   // Update in-memory values
-  if (next_task_id > 0) s_next_task_id_ = next_task_id;
-  if (next_task_db_id > 0) s_next_task_db_id_ = next_task_db_id;
+  if (next_job_id > 0) s_next_job_id_ = next_job_id;
+  if (next_job_db_id > 0) s_next_job_db_id_ = next_job_db_id;
 
-  CRANE_INFO("Task ID counters reset: next_task_id={}, next_task_db_id={}.",
-             s_next_task_id_, s_next_task_db_id_);
+  CRANE_INFO("Job ID counters reset: next_job_id={}, next_job_db_id={}.",
+             s_next_job_id_, s_next_job_db_id_);
   return true;
 }
 
@@ -685,15 +685,15 @@ bool EmbeddedDbClient::ResetNextStepDbId() {
   return true;
 }
 
-bool EmbeddedDbClient::PurgeAllTaskHistory() {
+bool EmbeddedDbClient::PurgeAllJobHistory() {
   txn_id_t txn_id;
   std::expected<void, DbErrorCode> res;
 
-  // Collect all task data keys from variable_db (keys ending with 'S')
+  // Collect all job data keys from variable_db (keys ending with 'S')
   std::vector<std::string> var_keys;
   res = m_variable_db_->IterateAllKv(
       [&](std::string&& key, std::vector<uint8_t>&&) {
-        if (IsVariableDbTaskDataEntry_(key)) var_keys.push_back(key);
+        if (IsVariableDbJobDataEntry_(key)) var_keys.push_back(key);
         return true;
       });
   if (!res) {
@@ -714,7 +714,7 @@ bool EmbeddedDbClient::PurgeAllTaskHistory() {
     if (!CommitDbTransaction_(m_variable_db_.get(), txn_id)) return false;
   }
 
-  // Collect all task data keys from fixed_db (keys ending with 'T')
+  // Collect all job data keys from fixed_db (keys ending with 'T')
   std::vector<std::string> fixed_keys;
   res =
       m_fixed_db_->IterateAllKv([&](std::string&& key, std::vector<uint8_t>&&) {
@@ -786,13 +786,13 @@ bool EmbeddedDbClient::PurgeAllTaskHistory() {
     if (!CommitDbTransaction_(m_step_fixed_db_.get(), txn_id)) return false;
   }
 
-  CRANE_INFO("All task/step history purged from embedded DB.");
+  CRANE_INFO("All job/step history purged from embedded DB.");
   return true;
 }
 
 bool EmbeddedDbClient::RetrieveLastSnapshot(DbSnapshot* snapshot) {
-  using TaskStatus = crane::grpc::TaskStatus;
-  using RuntimeAttr = crane::grpc::RuntimeAttrOfTask;
+  using JobStatus = crane::grpc::JobStatus;
+  using RuntimeAttr = crane::grpc::RuntimeAttrOfJob;
 
   std::expected<void, DbErrorCode> result;
   std::unordered_map<db_id_t, RuntimeAttr> db_id_runtime_attr_map;
@@ -800,16 +800,16 @@ bool EmbeddedDbClient::RetrieveLastSnapshot(DbSnapshot* snapshot) {
   result = m_variable_db_->IterateAllKv(
       [&](std::string&& key, std::vector<uint8_t>&& value) {
         // Skip if not RuntimeAttr
-        if (!IsVariableDbTaskDataEntry_(key)) return true;
+        if (!IsVariableDbJobDataEntry_(key)) return true;
 
-        task_db_id_t id = ExtractDbIdFromEntry_(key);
+        job_db_id_t id = ExtractDbIdFromEntry_(key);
 
         RuntimeAttr runtime_attr;
         runtime_attr.ParseFromArray(value.data(), value.size());
 
         db_id_runtime_attr_map.emplace(id, std::move(runtime_attr));
 
-        // Record all task_id here and don't delete any key,
+        // Record all job_id here and don't delete any key,
         // so true is returned.
         return true;
       });
@@ -821,33 +821,33 @@ bool EmbeddedDbClient::RetrieveLastSnapshot(DbSnapshot* snapshot) {
 
   result = m_fixed_db_->IterateAllKv(
       [&](std::string&& key, std::vector<uint8_t>&& value) {
-        task_db_id_t id = ExtractDbIdFromEntry_(key);
+        job_db_id_t id = ExtractDbIdFromEntry_(key);
 
-        // Delete incomplete task fixed data,
+        // Delete incomplete job fixed data,
         // where fixed data are stored but variable data are missing.
         auto runtime_attr_it = db_id_runtime_attr_map.find(id);
         if (runtime_attr_it == db_id_runtime_attr_map.end()) return false;
 
-        TaskStatus status = runtime_attr_it->second.status();
+        JobStatus status = runtime_attr_it->second.status();
 
-        // Assemble TaskInEmbeddedDb here.
-        TaskInEmbeddedDb task;
-        *task.mutable_runtime_attr() = std::move(runtime_attr_it->second);
-        task.mutable_task_to_ctld()->ParseFromArray(value.data(), value.size());
+        // Assemble JobInEmbeddedDb here.
+        JobInEmbeddedDb job_data;
+        *job_data.mutable_runtime_attr() = std::move(runtime_attr_it->second);
+        job_data.mutable_job_to_ctld()->ParseFromArray(value.data(), value.size());
 
         // Dispatch to different queues by status.
         switch (status) {
         case crane::grpc::Pending:
-          snapshot->pending_queue.emplace(id, std::move(task));
+          snapshot->pending_queue.emplace(id, std::move(job_data));
           break;
         case crane::grpc::Running:
         case crane::grpc::Starting:
         case crane::grpc::Configuring:
         case crane::grpc::Completing:
-          snapshot->running_queue.emplace(id, std::move(task));
+          snapshot->running_queue.emplace(id, std::move(job_data));
           break;
         default:
-          snapshot->final_queue.emplace(id, std::move(task));
+          snapshot->final_queue.emplace(id, std::move(job_data));
           break;
         }
         return true;
@@ -862,7 +862,7 @@ bool EmbeddedDbClient::RetrieveLastSnapshot(DbSnapshot* snapshot) {
 }
 
 bool EmbeddedDbClient::RetrieveStepInfo(StepDbSnapshot* snapshot) {
-  using TaskStatus = crane::grpc::TaskStatus;
+  using JobStatus = crane::grpc::JobStatus;
   using RuntimeAttr = crane::grpc::RuntimeAttrOfStep;
 
   std::expected<void, DbErrorCode> result;
@@ -880,7 +880,7 @@ bool EmbeddedDbClient::RetrieveStepInfo(StepDbSnapshot* snapshot) {
 
         db_id_runtime_attr_map.emplace(id, std::move(runtime_attr));
 
-        // Record all task_id here and don't delete any key,
+        // Record all job_id here and don't delete any key,
         // so true is returned.
         return true;
       });
@@ -894,14 +894,14 @@ bool EmbeddedDbClient::RetrieveStepInfo(StepDbSnapshot* snapshot) {
                                               std::vector<uint8_t>&& value) {
     step_db_id_t id = ExtractStepDbIdFromEntry_(key);
 
-    // Delete incomplete task fixed data,
+    // Delete incomplete job fixed data,
     // where fixed data are stored but variable data are missing.
     auto runtime_attr_it = db_id_runtime_attr_map.find(id);
     if (runtime_attr_it == db_id_runtime_attr_map.end()) return false;
 
-    TaskStatus status = runtime_attr_it->second.status();
+    JobStatus status = runtime_attr_it->second.status();
 
-    // Assemble TaskInEmbeddedDb here.
+    // Assemble JobInEmbeddedDb here.
     StepInEmbeddedDb step;
     *step.mutable_runtime_attr() = std::move(runtime_attr_it->second);
     step.mutable_step_to_ctld()->ParseFromArray(value.data(), value.size());
@@ -956,8 +956,8 @@ bool EmbeddedDbClient::RetrieveReservationInfo(
   return true;
 }
 
-bool EmbeddedDbClient::AppendTasksToPendingAndAdvanceTaskIds(
-    const std::vector<TaskInCtld*>& tasks) {
+bool EmbeddedDbClient::AppendJobsToPendingAndAdvanceJobIds(
+    const std::vector<JobInCtld*>& jobs) {
   txn_id_t txn_id;
   std::expected<void, DbErrorCode> result;
 
@@ -965,24 +965,24 @@ bool EmbeddedDbClient::AppendTasksToPendingAndAdvanceTaskIds(
   // one single thread and the lock here is actually useless.
   // However, it costs little and prevents race condition,
   // so we just leave it here.
-  absl::MutexLock lock_ids(&s_task_id_and_db_id_mtx_);
+  absl::MutexLock lock_ids(&s_job_id_and_db_id_mtx_);
 
-  uint32_t task_id{s_next_task_id_};
-  db_id_t task_db_id{s_next_task_db_id_};
+  uint32_t job_id{s_next_job_id_};
+  db_id_t job_db_id{s_next_job_db_id_};
 
   if (!BeginDbTransaction_(m_fixed_db_.get(), &txn_id)) return false;
 
-  for (const auto& task : tasks) {
-    task->SetTaskId(task_id++);
-    task->SetTaskDbId(task_db_id++);
+  for (const auto& job : jobs) {
+    job->SetJobId(job_id++);
+    job->SetJobDbId(job_db_id++);
 
     result = StoreTypeIntoDb_(m_fixed_db_.get(), txn_id,
-                              GetFixedDbEntryName_(task->TaskDbId()),
-                              &task->TaskToCtld());
+                              GetFixedDbEntryName_(job->JobDbId()),
+                              &job->JobToCtld());
     if (!result) {
       CRANE_ERROR(
-          "Failed to store the fixed data of task id: {} / task db id: {}.",
-          task->TaskId(), task->TaskDbId());
+          "Failed to store the fixed data of job id: {} / job db id: {}.",
+          job->JobId(), job->JobDbId());
 
       // Just drop this batch if any of them failed.
       return false;
@@ -993,46 +993,46 @@ bool EmbeddedDbClient::AppendTasksToPendingAndAdvanceTaskIds(
 
   if (!BeginDbTransaction_(m_variable_db_.get(), &txn_id)) return false;
 
-  for (const auto& task : tasks) {
+  for (const auto& job : jobs) {
     result = StoreTypeIntoDb_(m_variable_db_.get(), txn_id,
-                              GetVariableDbEntryName_(task->TaskDbId()),
-                              &task->RuntimeAttr());
+                              GetVariableDbEntryName_(job->JobDbId()),
+                              &job->RuntimeAttr());
     if (!result) {
       CRANE_ERROR(
           "Failed to store the variable data of "
-          "task id: {} / task db id: {}.",
-          task->TaskId(), task->TaskDbId());
+          "job id: {} / job db id: {}.",
+          job->JobId(), job->JobDbId());
       return false;
     }
   }
 
-  result = StoreTypeIntoDb_(m_variable_db_.get(), txn_id, s_next_task_id_str_,
-                            &task_id);
+  result = StoreTypeIntoDb_(m_variable_db_.get(), txn_id, s_next_job_id_str_,
+                            &job_id);
   if (!result) {
-    CRANE_ERROR("Failed to store next_task_id.");
+    CRANE_ERROR("Failed to store next_job_id.");
     return false;
   }
 
   result = StoreTypeIntoDb_(m_variable_db_.get(), txn_id,
-                            s_next_task_db_id_str_, &task_db_id);
+                            s_next_job_db_id_str_, &job_db_id);
   if (!result) {
-    CRANE_ERROR("Failed to store next_task_db_id.");
+    CRANE_ERROR("Failed to store next_job_db_id.");
     return false;
   }
   if (!CommitDbTransaction_(m_variable_db_.get(), txn_id)) return false;
 
-  s_next_task_id_ = task_id;
-  s_next_task_db_id_ = task_db_id;
+  s_next_job_id_ = job_id;
+  s_next_job_db_id_ = job_db_id;
 
   return true;
 }
 
-bool EmbeddedDbClient::PurgeEndedTasks(
-    const std::unordered_map<job_id_t, task_db_id_t>& job_ids) {
+bool EmbeddedDbClient::PurgeEndedJobs(
+    const std::unordered_map<job_id_t, job_db_id_t>& job_ids) {
   // To ensure consistency of both fixed data db and variable data db under
   // failure, we must ensure that:
-  // 1. when inserting task data, fixed data db is written before variable db;
-  // 2. when erasing task data, fixed data db is erased after variable db;
+  // 1. when inserting job data, fixed data db is written before variable db;
+  // 2. when erasing job data, fixed data db is erased after variable db;
 
   txn_id_t txn_id;
   std::expected<void, DbErrorCode> res;

--- a/src/CraneCtld/EmbeddedDbClient.h
+++ b/src/CraneCtld/EmbeddedDbClient.h
@@ -240,11 +240,9 @@ class EmbeddedDbClient {
   // Note: All operations in transaction will abort or rollback automatically if
   // some operation fails, so we don't need anything like AbortTransaction here!
 
-  bool AppendJobsToPendingAndAdvanceJobIds(
-      const std::vector<JobInCtld*>& jobs);
+  bool AppendJobsToPendingAndAdvanceJobIds(const std::vector<JobInCtld*>& jobs);
 
-  bool PurgeEndedJobs(
-      const std::unordered_map<job_id_t, job_db_id_t>& job_ids);
+  bool PurgeEndedJobs(const std::unordered_map<job_id_t, job_db_id_t>& job_ids);
 
   bool UpdateRuntimeAttrOfJob(
       txn_id_t txn_id, db_id_t db_id,
@@ -255,7 +253,7 @@ class EmbeddedDbClient {
   }
 
   bool UpdateJobToCtld(txn_id_t txn_id, db_id_t db_id,
-                        crane::grpc::JobToCtld const& job_to_ctld_ref) {
+                       crane::grpc::JobToCtld const& job_to_ctld_ref) {
     return StoreTypeIntoDb_(m_fixed_db_.get(), txn_id,
                             GetFixedDbEntryName_(db_id), &job_to_ctld_ref)
         .has_value();
@@ -271,14 +269,15 @@ class EmbeddedDbClient {
   }
 
   bool UpdateJobToCtldIfExists(txn_id_t txn_id, db_id_t db_id,
-                                crane::grpc::JobToCtld const& job_to_ctld_ref) {
+                               crane::grpc::JobToCtld const& job_to_ctld_ref) {
     return StoreTypeIntoDbIfExists_(m_fixed_db_.get(), txn_id,
-                                    GetFixedDbEntryName_(db_id), &job_to_ctld_ref)
+                                    GetFixedDbEntryName_(db_id),
+                                    &job_to_ctld_ref)
         .has_value();
   }
 
   bool FetchJobDataInDb(txn_id_t txn_id, db_id_t db_id,
-                         JobInEmbeddedDb* job_in_db) {  // Only used in test
+                        JobInEmbeddedDb* job_in_db) {  // Only used in test
     return FetchJobDataInDbAtomic_(txn_id, db_id, job_in_db).has_value();
   }
 

--- a/src/CraneCtld/EmbeddedDbClient.h
+++ b/src/CraneCtld/EmbeddedDbClient.h
@@ -163,15 +163,15 @@ class BerkeleyDb : public IEmbeddedDb {
 
 class EmbeddedDbClient {
  private:
-  using db_id_t = task_db_id_t;
-  using TaskInEmbeddedDb = crane::grpc::TaskInEmbeddedDb;
+  using db_id_t = job_db_id_t;
+  using JobInEmbeddedDb = crane::grpc::JobInEmbeddedDb;
   using StepInEmbeddedDb = crane::grpc::StepInEmbeddedDb;
 
  public:
   struct DbSnapshot {
-    std::unordered_map<db_id_t, TaskInEmbeddedDb> pending_queue;
-    std::unordered_map<db_id_t, TaskInEmbeddedDb> running_queue;
-    std::unordered_map<db_id_t, TaskInEmbeddedDb> final_queue;
+    std::unordered_map<db_id_t, JobInEmbeddedDb> pending_queue;
+    std::unordered_map<db_id_t, JobInEmbeddedDb> running_queue;
+    std::unordered_map<db_id_t, JobInEmbeddedDb> final_queue;
   };
 
   struct StepDbSnapshot {
@@ -183,11 +183,11 @@ class EmbeddedDbClient {
 
   bool Init(std::string const& db_path);
 
-  bool ResetNextTaskId(task_id_t next_task_id, db_id_t next_task_db_id);
+  bool ResetNextJobId(job_id_t next_job_id, db_id_t next_job_db_id);
 
   bool ResetNextStepDbId();
 
-  bool PurgeAllTaskHistory();
+  bool PurgeAllJobHistory();
 
   bool RetrieveLastSnapshot(DbSnapshot* snapshot);
 
@@ -240,46 +240,46 @@ class EmbeddedDbClient {
   // Note: All operations in transaction will abort or rollback automatically if
   // some operation fails, so we don't need anything like AbortTransaction here!
 
-  bool AppendTasksToPendingAndAdvanceTaskIds(
-      const std::vector<TaskInCtld*>& tasks);
+  bool AppendJobsToPendingAndAdvanceJobIds(
+      const std::vector<JobInCtld*>& jobs);
 
-  bool PurgeEndedTasks(
-      const std::unordered_map<job_id_t, task_db_id_t>& job_ids);
+  bool PurgeEndedJobs(
+      const std::unordered_map<job_id_t, job_db_id_t>& job_ids);
 
-  bool UpdateRuntimeAttrOfTask(
+  bool UpdateRuntimeAttrOfJob(
       txn_id_t txn_id, db_id_t db_id,
-      crane::grpc::RuntimeAttrOfTask const& runtime_attr) {
+      crane::grpc::RuntimeAttrOfJob const& runtime_attr) {
     return StoreTypeIntoDb_(m_variable_db_.get(), txn_id,
                             GetVariableDbEntryName_(db_id), &runtime_attr)
         .has_value();
   }
 
-  bool UpdateTaskToCtld(txn_id_t txn_id, db_id_t db_id,
-                        crane::grpc::TaskToCtld const& task_to_ctld) {
+  bool UpdateJobToCtld(txn_id_t txn_id, db_id_t db_id,
+                        crane::grpc::JobToCtld const& job_to_ctld_ref) {
     return StoreTypeIntoDb_(m_fixed_db_.get(), txn_id,
-                            GetFixedDbEntryName_(db_id), &task_to_ctld)
+                            GetFixedDbEntryName_(db_id), &job_to_ctld_ref)
         .has_value();
   }
 
-  bool UpdateRuntimeAttrOfTaskIfExists(
+  bool UpdateRuntimeAttrOfJobIfExists(
       txn_id_t txn_id, db_id_t db_id,
-      crane::grpc::RuntimeAttrOfTask const& runtime_attr) {
+      crane::grpc::RuntimeAttrOfJob const& runtime_attr) {
     return StoreTypeIntoDbIfExists_(m_variable_db_.get(), txn_id,
                                     GetVariableDbEntryName_(db_id),
                                     &runtime_attr)
         .has_value();
   }
 
-  bool UpdateTaskToCtldIfExists(txn_id_t txn_id, db_id_t db_id,
-                                crane::grpc::TaskToCtld const& task_to_ctld) {
+  bool UpdateJobToCtldIfExists(txn_id_t txn_id, db_id_t db_id,
+                                crane::grpc::JobToCtld const& job_to_ctld_ref) {
     return StoreTypeIntoDbIfExists_(m_fixed_db_.get(), txn_id,
-                                    GetFixedDbEntryName_(db_id), &task_to_ctld)
+                                    GetFixedDbEntryName_(db_id), &job_to_ctld_ref)
         .has_value();
   }
 
-  bool FetchTaskDataInDb(txn_id_t txn_id, db_id_t db_id,
-                         TaskInEmbeddedDb* task_in_db) {  // Only used in test
-    return FetchTaskDataInDbAtomic_(txn_id, db_id, task_in_db).has_value();
+  bool FetchJobDataInDb(txn_id_t txn_id, db_id_t db_id,
+                         JobInEmbeddedDb* job_in_db) {  // Only used in test
+    return FetchJobDataInDbAtomic_(txn_id, db_id, job_in_db).has_value();
   }
 
   bool AppendSteps(const std::vector<StepInCtld*>& steps);
@@ -343,11 +343,11 @@ class EmbeddedDbClient {
     return fmt::format("{}S", db_id);
   }
 
-  inline static bool IsVariableDbTaskDataEntry_(std::string const& key) {
+  inline static bool IsVariableDbJobDataEntry_(std::string const& key) {
     return key.back() == 'S';
   }
 
-  inline static task_db_id_t ExtractDbIdFromEntry_(std::string const& key) {
+  inline static job_db_id_t ExtractDbIdFromEntry_(std::string const& key) {
     return std::stol(key.substr(0, key.size() - 1));
   }
 
@@ -391,16 +391,16 @@ class EmbeddedDbClient {
 
   // Helper functions for basic embedded db operations
 
-  inline std::expected<size_t, DbErrorCode> FetchTaskDataInDbAtomic_(
-      txn_id_t txn_id, db_id_t db_id, TaskInEmbeddedDb* task_in_db) {
+  inline std::expected<size_t, DbErrorCode> FetchJobDataInDbAtomic_(
+      txn_id_t txn_id, db_id_t db_id, JobInEmbeddedDb* job_in_db) {
     auto result =
         FetchTypeFromDb_(m_fixed_db_.get(), txn_id, GetFixedDbEntryName_(db_id),
-                         task_in_db->mutable_task_to_ctld());
+                         job_in_db->mutable_job_to_ctld());
     if (!result) return result;
 
     return FetchTypeFromDb_(m_variable_db_.get(), txn_id,
                             GetVariableDbEntryName_(db_id),
-                            task_in_db->mutable_runtime_attr());
+                            job_in_db->mutable_runtime_attr());
   }
 
   inline std::expected<size_t, DbErrorCode> FetchStepDataInDbAtomic_(
@@ -625,14 +625,14 @@ class EmbeddedDbClient {
 
   // -----------
 
-  inline static std::string const s_next_task_db_id_str_{"NDI"};
-  inline static std::string const s_next_task_id_str_{"NI"};
+  inline static std::string const s_next_job_db_id_str_{"NDI"};
+  inline static std::string const s_next_job_id_str_{"NI"};
 
-  inline static absl::Mutex s_task_id_and_db_id_mtx_;
-  inline static task_id_t s_next_task_id_
-      ABSL_GUARDED_BY(s_task_id_and_db_id_mtx_);
-  inline static db_id_t s_next_task_db_id_
-      ABSL_GUARDED_BY(s_task_id_and_db_id_mtx_);
+  inline static absl::Mutex s_job_id_and_db_id_mtx_;
+  inline static job_id_t s_next_job_id_
+      ABSL_GUARDED_BY(s_job_id_and_db_id_mtx_);
+  inline static db_id_t s_next_job_db_id_
+      ABSL_GUARDED_BY(s_job_id_and_db_id_mtx_);
 
   std::unique_ptr<IEmbeddedDb> m_variable_db_;
   std::unique_ptr<IEmbeddedDb> m_fixed_db_;

--- a/src/CraneCtld/JobScheduler.cpp
+++ b/src/CraneCtld/JobScheduler.cpp
@@ -16,7 +16,7 @@
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 
-#include "TaskScheduler.h"
+#include "JobScheduler.h"
 
 #include <absl/time/internal/cctz/src/time_zone_if.h>
 #include <google/protobuf/util/time_util.h>
@@ -36,7 +36,7 @@
 namespace Ctld {
 using namespace std::chrono_literals;
 
-TaskScheduler::TaskScheduler() {
+JobScheduler::JobScheduler() {
   if (g_config.PriorityConfig.Type == Config::Priority::Basic) {
     CRANE_INFO("basic priority sorter is selected.");
     m_priority_sorter_ = std::make_unique<BasicPriority>();
@@ -52,23 +52,23 @@ TaskScheduler::TaskScheduler() {
       [] { util::SetCurrentThreadName("SchedRpcWorker"); });
 }
 
-TaskScheduler::~TaskScheduler() {
+JobScheduler::~JobScheduler() {
   m_thread_stop_ = true;
   if (m_schedule_thread_.joinable()) m_schedule_thread_.join();
   if (m_step_schedule_thread_.joinable()) m_step_schedule_thread_.join();
-  if (m_task_release_thread_.joinable()) m_task_release_thread_.join();
-  if (m_task_cancel_thread_.joinable()) m_task_cancel_thread_.join();
-  if (m_task_submit_thread_.joinable()) m_task_submit_thread_.join();
+  if (m_job_release_thread_.joinable()) m_job_release_thread_.join();
+  if (m_job_cancel_thread_.joinable()) m_job_cancel_thread_.join();
+  if (m_job_submit_thread_.joinable()) m_job_submit_thread_.join();
   if (m_step_submit_thread_.joinable()) m_step_submit_thread_.join();
-  if (m_task_status_change_thread_.joinable())
-    m_task_status_change_thread_.join();
+  if (m_job_status_change_thread_.joinable())
+    m_job_status_change_thread_.join();
   if (m_resv_clean_thread_.joinable()) m_resv_clean_thread_.join();
   m_rpc_worker_pool_->wait();
   m_rpc_worker_pool_.reset();
 }
 
-bool TaskScheduler::Init() {
-  using crane::grpc::TaskInEmbeddedDb;
+bool JobScheduler::Init() {
+  using crane::grpc::JobInEmbeddedDb;
 
   bool ok;
   CraneErrCode err;
@@ -81,179 +81,179 @@ bool TaskScheduler::Init() {
   }
 
   auto& running_queue = snapshot.running_queue;
-  std::unordered_map<job_id_t, std::unique_ptr<TaskInCtld>>
-      recovered_running_tasks;
+  std::unordered_map<job_id_t, std::unique_ptr<JobInCtld>>
+      recovered_running_jobs;
   if (!running_queue.empty()) {
-    CRANE_INFO("{} running task(s) recovered.", running_queue.size());
+    CRANE_INFO("{} running job(s) recovered.", running_queue.size());
 
-    for (auto&& [task_db_id, task_in_embedded_db] : running_queue) {
-      auto task = std::make_unique<TaskInCtld>();
-      task->SetFieldsByTaskToCtld(task_in_embedded_db.task_to_ctld());
-      // Must be called after SetFieldsByTaskToCtld!
-      task->SetFieldsByRuntimeAttr(task_in_embedded_db.runtime_attr());
-      task_id_t task_id = task->TaskId();
+    for (auto&& [job_db_id, job_in_embedded_db] : running_queue) {
+      auto job = std::make_unique<JobInCtld>();
+      job->SetFieldsByJobToCtld(job_in_embedded_db.job_to_ctld());
+      // Must be called after SetFieldsByJobToCtld!
+      job->SetFieldsByRuntimeAttrOfJob(job_in_embedded_db.runtime_attr());
+      job_id_t job_id = job->JobId();
 
-      CRANE_TRACE("Restore task #{} from embedded running queue.",
-                  task->TaskId());
-      auto result = AcquireTaskAttributes(task.get());
-      if (!result || task->type == crane::grpc::Interactive) {
-        task->SetStatus(crane::grpc::Failed);
-        ok = g_embedded_db_client->UpdateRuntimeAttrOfTask(0, task_db_id,
-                                                           task->RuntimeAttr());
+      CRANE_TRACE("Restore job #{} from embedded running queue.",
+                  job->JobId());
+      auto result = AcquireJobAttributes(job.get());
+      if (!result || job->type == crane::grpc::Interactive) {
+        job->SetStatus(crane::grpc::Failed);
+        ok = g_embedded_db_client->UpdateRuntimeAttrOfJob(0, job_db_id,
+                                                           job->RuntimeAttr());
         if (!ok) {
           CRANE_ERROR(
-              "UpdateRuntimeAttrOfTask failed for task #{} when "
-              "mark the task as FAILED.",
-              task_id);
+              "UpdateRuntimeAttrOfJob failed for job #{} when "
+              "mark the job as FAILED.",
+              job_id);
         }
         if (!result)
           CRANE_INFO(
-              "Failed to acquire task attributes for restored running task "
+              "Failed to acquire job attributes for restored running job "
               "#{}. "
               "Error Code: {}. "
               "Mark it as FAILED and move it to the ended queue.",
-              task_id, CraneErrStr(result.error()));
+              job_id, CraneErrStr(result.error()));
         else {
-          CRANE_INFO("Mark running interactive task {} as FAILED.", task_id);
+          CRANE_INFO("Mark running interactive job {} as FAILED.", job_id);
 
-          ok = g_db_client->InsertJob(task.get());
+          ok = g_db_client->InsertJob(job.get());
           if (!ok) {
             CRANE_ERROR(
-                "InsertJob failed for task #{} "
+                "InsertJob failed for job #{} "
                 "when recovering running queue.",
-                task->TaskId());
+                job->JobId());
           }
 
-          ok = g_embedded_db_client->PurgeEndedTasks(
-              {{task->TaskId(), task_db_id}});
+          ok = g_embedded_db_client->PurgeEndedJobs(
+              {{job->JobId(), job_db_id}});
           if (!ok) {
             CRANE_ERROR(
-                "PurgeEndedTasks failed for task #{} when recovering "
+                "PurgeEndedJobs failed for job #{} when recovering "
                 "running queue.",
-                task->TaskId());
+                job->JobId());
           }
         }
 
-        // Move this problematic task into ended queue and
-        // process next task.
+        // Move this problematic job into ended queue and
+        // process next job.
         continue;
       }
-      recovered_running_tasks.emplace(task_id, std::move(task));
+      recovered_running_jobs.emplace(job_id, std::move(job));
     }
   }
 
-  // Process the pending tasks in the embedded pending queue.
+  // Process the pending jobs in the embedded pending queue.
   auto& pending_queue = snapshot.pending_queue;
   if (!pending_queue.empty()) {
-    CRANE_INFO("{} pending task(s) recovered.", pending_queue.size());
+    CRANE_INFO("{} pending job(s) recovered.", pending_queue.size());
 
     absl::Time recovery_time = absl::Now();
-    for (auto&& [task_db_id, task_in_embedded_db] : pending_queue) {
-      auto task = std::make_unique<TaskInCtld>();
-      task->SetFieldsByTaskToCtld(task_in_embedded_db.task_to_ctld());
-      // Must be called after SetFieldsByTaskToCtld!
-      task->SetFieldsByRuntimeAttr(task_in_embedded_db.runtime_attr());
+    for (auto&& [job_db_id, job_in_embedded_db] : pending_queue) {
+      auto job = std::make_unique<JobInCtld>();
+      job->SetFieldsByJobToCtld(job_in_embedded_db.job_to_ctld());
+      // Must be called after SetFieldsByJobToCtld!
+      job->SetFieldsByRuntimeAttrOfJob(job_in_embedded_db.runtime_attr());
 
-      task_id_t task_id = task->TaskId();
+      job_id_t job_id = job->JobId();
 
-      CRANE_TRACE("Restore task #{} from embedded pending queue.",
-                  task->TaskId());
+      CRANE_TRACE("Restore job #{} from embedded pending queue.",
+                  job->JobId());
 
-      bool mark_task_as_failed = false;
+      bool mark_job_as_failed = false;
 
-      if (task->type == crane::grpc::Interactive) {
-        CRANE_INFO("Mark interactive task #{} as FAILED", task_id);
-        mark_task_as_failed = true;
+      if (job->type == crane::grpc::Interactive) {
+        CRANE_INFO("Mark interactive job #{} as FAILED", job_id);
+        mark_job_as_failed = true;
       }
 
-      if (!mark_task_as_failed && !(AcquireTaskAttributes(task.get()))) {
-        CRANE_ERROR("AcquireTaskAttributes failed for task #{}", task_id);
-        mark_task_as_failed = true;
+      if (!mark_job_as_failed && !(AcquireJobAttributes(job.get()))) {
+        CRANE_ERROR("AcquireJobAttributes failed for job #{}", job_id);
+        mark_job_as_failed = true;
       }
 
-      if (!mark_task_as_failed && !CheckTaskValidity(task.get())) {
-        CRANE_ERROR("CheckTaskValidity failed for task #{}", task_id);
-        mark_task_as_failed = true;
+      if (!mark_job_as_failed && !CheckJobValidity(job.get())) {
+        CRANE_ERROR("CheckJobValidity failed for job #{}", job_id);
+        mark_job_as_failed = true;
       }
 
-      if (!mark_task_as_failed) {
+      if (!mark_job_as_failed) {
         const auto& user_ptr =
-            g_account_manager->GetExistedUserInfo(task->Username());
+            g_account_manager->GetExistedUserInfo(job->Username());
         if (!user_ptr) {
           CRANE_ERROR(
               "The current user {} is not in the user list when submitting the "
-              "task",
-              task->Username());
-          mark_task_as_failed = true;
+              "job",
+              job->Username());
+          mark_job_as_failed = true;
         } else
-          g_account_meta_container->UserAddTask(task->Username());
+          g_account_meta_container->UserAddJob(job->Username());
       }
 
-      if (!mark_task_as_failed) {
-        RequeueRecoveredTaskIntoPendingQueueLock_(std::move(task));
+      if (!mark_job_as_failed) {
+        RequeueRecoveredJobIntoPendingQueueLock_(std::move(job));
       } else {
-        // If a batch task failed to requeue the task into pending queue due to
-        // insufficient resource or other reasons or the task is an interactive
-        // task , Mark it as FAILED and move it to the ended queue.
+        // If a batch job failed to requeue the job into pending queue due to
+        // insufficient resource or other reasons or the job is an interactive
+        // job , Mark it as FAILED and move it to the ended queue.
         CRANE_INFO(
-            "Failed to requeue task #{}. Mark it as FAILED and "
+            "Failed to requeue job #{}. Mark it as FAILED and "
             "move it to the ended queue.",
-            task_id);
-        task->SetStatus(crane::grpc::Failed);
-        task->SetStartTime(recovery_time);
-        task->SetEndTime(recovery_time);
-        ok = g_embedded_db_client->UpdateRuntimeAttrOfTask(0, task_db_id,
-                                                           task->RuntimeAttr());
+            job_id);
+        job->SetStatus(crane::grpc::Failed);
+        job->SetStartTime(recovery_time);
+        job->SetEndTime(recovery_time);
+        ok = g_embedded_db_client->UpdateRuntimeAttrOfJob(0, job_db_id,
+                                                           job->RuntimeAttr());
         if (!ok) {
           CRANE_ERROR(
-              "UpdateRuntimeAttrOfTask failed for task #{} when "
-              "mark the task as FAILED.",
-              task_id);
+              "UpdateRuntimeAttrOfJob failed for job #{} when "
+              "mark the job as FAILED.",
+              job_id);
         }
 
-        ok = g_db_client->InsertJob(task.get());
+        ok = g_db_client->InsertJob(job.get());
         if (!ok) {
           CRANE_ERROR(
-              "InsertJob failed for task #{} when recovering pending "
+              "InsertJob failed for job #{} when recovering pending "
               "queue.",
-              task->TaskId());
+              job->JobId());
         }
 
-        ok = g_embedded_db_client->PurgeEndedTasks(
-            {{task->TaskId(), task->TaskDbId()}});
+        ok = g_embedded_db_client->PurgeEndedJobs(
+            {{job->JobId(), job->JobDbId()}});
         if (!ok) {
           CRANE_ERROR(
-              "PurgeEndedTasks failed for task #{} when recovering "
+              "PurgeEndedJobs failed for job #{} when recovering "
               "pending queue.",
-              task->TaskId());
+              job->JobId());
         }
       }
     }
   }
 
   if (!snapshot.final_queue.empty()) {
-    CRANE_INFO("{} final task(s) might not have been put to mongodb.",
+    CRANE_INFO("{} final job(s) might not have been put to mongodb.",
                snapshot.final_queue.size());
 
-    std::unordered_map<job_id_t, task_db_id_t> db_ids;
-    for (auto& [db_id, task_in_embedded_db] : snapshot.final_queue) {
-      task_id_t task_id = task_in_embedded_db.runtime_attr().task_id();
-      ok = g_db_client->CheckTaskDbIdExisted(db_id);
+    std::unordered_map<job_id_t, job_db_id_t> db_ids;
+    for (auto& [db_id, job_in_embedded_db] : snapshot.final_queue) {
+      job_id_t job_id = job_in_embedded_db.runtime_attr().job_id();
+      ok = g_db_client->CheckJobDbIdExisted(db_id);
       if (!ok) {
-        if (!g_db_client->InsertRecoveredJob(task_in_embedded_db)) {
+        if (!g_db_client->InsertRecoveredJob(job_in_embedded_db)) {
           CRANE_ERROR(
               "Failed to call g_db_client->InsertRecoveredJob() "
-              "for task #{}",
-              task_id);
+              "for job #{}",
+              job_id);
         }
       }
 
-      db_ids[task_id] = db_id;
+      db_ids[job_id] = db_id;
     }
 
-    ok = g_embedded_db_client->PurgeEndedTasks(db_ids);
+    ok = g_embedded_db_client->PurgeEndedJobs(db_ids);
     if (!ok) {
-      CRANE_ERROR("Failed to call g_embedded_db_client->PurgeEndedTasks()");
+      CRANE_ERROR("Failed to call g_embedded_db_client->PurgeEndedJobs()");
     }
   }
 
@@ -273,22 +273,22 @@ bool TaskScheduler::Init() {
       invalid_steps;
   std::vector<crane::grpc::StepInEmbeddedDb> completed_steps;
   const std::unordered_set completed_step_status{
-      crane::grpc::TaskStatus::Completed,
-      crane::grpc::TaskStatus::Failed,
-      crane::grpc::TaskStatus::ExceedTimeLimit,
-      crane::grpc::TaskStatus::Cancelled,
-      crane::grpc::TaskStatus::OutOfMemory,
+      crane::grpc::JobStatus::Completed,
+      crane::grpc::JobStatus::Failed,
+      crane::grpc::JobStatus::ExceedTimeLimit,
+      crane::grpc::JobStatus::Cancelled,
+      crane::grpc::JobStatus::OutOfMemory,
   };
-  auto mark_job_invalid = [&recovered_running_tasks](TaskInCtld* job) {
-    job_id_t job_id = job->TaskId();
+  auto mark_job_invalid = [&recovered_running_jobs](JobInCtld* job) {
+    job_id_t job_id = job->JobId();
     CRANE_ERROR("[Job #{}] Running job without step, mark the job as FAILED!",
                 job_id);
     job->SetStatus(crane::grpc::Failed);
-    auto ok = g_embedded_db_client->UpdateRuntimeAttrOfTask(0, job->TaskDbId(),
+    auto ok = g_embedded_db_client->UpdateRuntimeAttrOfJob(0, job->JobDbId(),
                                                             job->RuntimeAttr());
     if (!ok) {
       CRANE_ERROR(
-          "[Job #{}] UpdateRuntimeAttrOfTask failed when "
+          "[Job #{}] UpdateRuntimeAttrOfJob failed when "
           "mark the job as FAILED.",
           job_id);
     }
@@ -296,26 +296,26 @@ bool TaskScheduler::Init() {
     ok = g_db_client->InsertJob(job);
     if (!ok) {
       CRANE_ERROR(
-          "InsertJob failed for task #{} when recovering pending "
+          "InsertJob failed for job #{} when recovering pending "
           "queue.",
           job_id);
     }
 
-    ok = g_embedded_db_client->PurgeEndedTasks(
-        {{job->TaskId(), job->TaskDbId()}});
+    ok = g_embedded_db_client->PurgeEndedJobs(
+        {{job->JobId(), job->JobDbId()}});
     if (!ok) {
       CRANE_ERROR(
-          "PurgeEndedTasks failed for task #{} when recovering "
+          "PurgeEndedJobs failed for job #{} when recovering "
           "pending queue.",
           job_id);
     }
-    auto it = recovered_running_tasks.find(job_id);
-    return recovered_running_tasks.erase(it);
+    auto it = recovered_running_jobs.find(job_id);
+    return recovered_running_jobs.erase(it);
   };
   // When store, write/purge step info first, then job info.
   // When read, iterate by job.
-  for (auto job_it = recovered_running_tasks.begin();
-       job_it != recovered_running_tasks.end();) {
+  for (auto job_it = recovered_running_jobs.begin();
+       job_it != recovered_running_jobs.end();) {
     auto& [job_id, job] = *job_it;
     auto it = step_snapshot.steps.find(job_id);
     if (it == step_snapshot.steps.end()) {
@@ -366,7 +366,7 @@ bool TaskScheduler::Init() {
         continue;
       }
 
-      if (step_status == crane::grpc::TaskStatus::Pending) {
+      if (step_status == crane::grpc::JobStatus::Pending) {
         // Not support to recover pending step now. All pending steps are crun
         // which can not recover now.
         step.reset();
@@ -378,16 +378,16 @@ bool TaskScheduler::Init() {
         job->SetDaemonStep(std::unique_ptr<DaemonStepInCtld>(
             static_cast<DaemonStepInCtld*>(step.release())));
 
-        CRANE_INFO("Daemon step recovered for job #{}", job->TaskId());
+        CRANE_INFO("Daemon step recovered for job #{}", job->JobId());
 
       } else if (step_type == crane::grpc::StepType::PRIMARY) {
-        CRANE_INFO("Primary step recovered for job #{}", job->TaskId());
+        CRANE_INFO("Primary step recovered for job #{}", job->JobId());
 
         job->SetPrimaryStep(std::unique_ptr<CommonStepInCtld>(
             static_cast<CommonStepInCtld*>(step.release())));
       } else {
         CRANE_INFO("Common step {} recovered for job #{}", step->StepId(),
-                   job->TaskId());
+                   job->JobId());
         job->AddStep(std::unique_ptr<CommonStepInCtld>(
             static_cast<CommonStepInCtld*>(step.release())));
       }
@@ -409,33 +409,33 @@ bool TaskScheduler::Init() {
       invalid_steps[job_id].emplace_back(std::move(step_info));
     }
   }
-  for (auto& [job_id, job] : recovered_running_tasks)
-    PutRecoveredTaskIntoRunningQueueLock_(std::move(job));
+  for (auto& [job_id, job] : recovered_running_jobs)
+    PutRecoveredJobIntoRunningQueueLock_(std::move(job));
 
   {
     std::unordered_map<
-        task_id_t,
-        std::vector<std::pair<task_id_t, crane::grpc::DependencyType>>>
+        job_id_t,
+        std::vector<std::pair<job_id_t, crane::grpc::DependencyType>>>
         dependee_to_dependents;
 
-    for (const auto& [job_id, job] : m_pending_task_map_) {
+    for (const auto& [job_id, job] : m_pending_job_map_) {
       for (const auto& [dep_id, dep_info] : job->Dependencies().deps) {
         const auto& [dep_type, delay_seconds] = dep_info;
         dependee_to_dependents[dep_id].emplace_back(job_id, dep_type);
       }
     }
 
-    std::unordered_set<task_id_t> missing_dependee_ids;
+    std::unordered_set<job_id_t> missing_dependee_ids;
 
     for (const auto& [dependee_id, dependents] : dependee_to_dependents) {
-      if (m_pending_task_map_.contains(dependee_id)) {
+      if (m_pending_job_map_.contains(dependee_id)) {
         for (const auto& dep_info : dependents) {
-          m_pending_task_map_.at(dependee_id)
+          m_pending_job_map_.at(dependee_id)
               ->AddDependent(dep_info.second, dep_info.first);
         }
-      } else if (m_running_task_map_.contains(dependee_id)) {
+      } else if (m_running_job_map_.contains(dependee_id)) {
         for (const auto& dep_info : dependents) {
-          m_running_task_map_.at(dependee_id)
+          m_running_job_map_.at(dependee_id)
               ->AddDependent(dep_info.second, dep_info.first);
         }
         continue;
@@ -451,7 +451,7 @@ bool TaskScheduler::Init() {
       auto dependee_status_map =
           g_db_client->FetchJobStatus(missing_dependee_ids);
 
-      for (auto& [job_id, job] : m_pending_task_map_) {
+      for (auto& [job_id, job] : m_pending_job_map_) {
         for (const auto& [dep_id, dep_info] : job->Dependencies().deps) {
           if (!missing_dependee_ids.contains(dep_id)) continue;
 
@@ -519,82 +519,82 @@ bool TaskScheduler::Init() {
   g_embedded_db_client->PurgeEndedSteps(purged_step_db_ids);
 
   std::shared_ptr<uvw::loop> uvw_release_loop = uvw::loop::create();
-  m_task_timer_handle_ = uvw_release_loop->resource<uvw::timer_handle>();
-  m_task_timer_handle_->on<uvw::timer_event>(
+  m_job_timer_handle_ = uvw_release_loop->resource<uvw::timer_handle>();
+  m_job_timer_handle_->on<uvw::timer_event>(
       [this](const uvw::timer_event&, uvw::timer_handle&) {
-        CleanTaskTimerCb_();
+        CleanJobTimerCb_();
       });
-  m_task_timer_handle_->start(
-      std::chrono::milliseconds(kTaskHoldTimerTimeoutMs * 3),
-      std::chrono::milliseconds(kTaskHoldTimerTimeoutMs));
+  m_job_timer_handle_->start(
+      std::chrono::milliseconds(kJobHoldTimerTimeoutMs * 3),
+      std::chrono::milliseconds(kJobHoldTimerTimeoutMs));
 
-  m_task_timeout_async_handle_ =
+  m_job_timeout_async_handle_ =
       uvw_release_loop->resource<uvw::async_handle>();
-  m_task_timeout_async_handle_->on<uvw::async_event>(
+  m_job_timeout_async_handle_->on<uvw::async_event>(
       [this](const uvw::async_event&, uvw::async_handle&) {
-        TaskTimerAsyncCb_();
+        JobTimerAsyncCb_();
       });
 
-  m_clean_task_timer_queue_handle_ =
+  m_clean_job_timer_queue_handle_ =
       uvw_release_loop->resource<uvw::async_handle>();
-  m_clean_task_timer_queue_handle_->on<uvw::async_event>(
+  m_clean_job_timer_queue_handle_->on<uvw::async_event>(
       [this, loop = uvw_release_loop](const uvw::async_event&,
                                       uvw::async_handle&) {
-        CleanTaskTimerQueueCb_(loop);
+        CleanJobTimerQueueCb_(loop);
       });
 
-  m_task_release_thread_ = std::thread(
-      [this, loop = uvw_release_loop]() { ReleaseTaskThread_(loop); });
+  m_job_release_thread_ = std::thread(
+      [this, loop = uvw_release_loop]() { ReleaseJobThread_(loop); });
 
   std::shared_ptr<uvw::loop> uvw_cancel_loop = uvw::loop::create();
-  m_cancel_task_timer_handle_ = uvw_cancel_loop->resource<uvw::timer_handle>();
-  m_cancel_task_timer_handle_->on<uvw::timer_event>(
+  m_cancel_job_timer_handle_ = uvw_cancel_loop->resource<uvw::timer_handle>();
+  m_cancel_job_timer_handle_->on<uvw::timer_event>(
       [this](const uvw::timer_event&, uvw::timer_handle&) {
-        CancelTaskTimerCb_();
+        CancelJobTimerCb_();
       });
-  m_cancel_task_timer_handle_->start(
-      std::chrono::milliseconds(kCancelTaskTimeoutMs * 3),
-      std::chrono::milliseconds(kCancelTaskTimeoutMs));
+  m_cancel_job_timer_handle_->start(
+      std::chrono::milliseconds(kCancelJobTimeoutMs * 3),
+      std::chrono::milliseconds(kCancelJobTimeoutMs));
 
-  m_cancel_task_async_handle_ = uvw_cancel_loop->resource<uvw::async_handle>();
-  m_cancel_task_async_handle_->on<uvw::async_event>(
+  m_cancel_job_async_handle_ = uvw_cancel_loop->resource<uvw::async_handle>();
+  m_cancel_job_async_handle_->on<uvw::async_event>(
       [this](const uvw::async_event&, uvw::async_handle&) {
-        CancelTaskAsyncCb_();
+        CancelJobAsyncCb_();
       });
 
-  m_clean_cancel_queue_handle_ = uvw_cancel_loop->resource<uvw::async_handle>();
-  m_clean_cancel_queue_handle_->on<uvw::async_event>(
+  m_clean_cancel_job_queue_handle_ = uvw_cancel_loop->resource<uvw::async_handle>();
+  m_clean_cancel_job_queue_handle_->on<uvw::async_event>(
       [this](const uvw::async_event&, uvw::async_handle&) {
-        CleanCancelQueueCb_();
+        CleanCancelJobQueueCb_();
       });
 
-  m_task_cancel_thread_ = std::thread(
-      [this, loop = std::move(uvw_cancel_loop)]() { CancelTaskThread_(loop); });
+  m_job_cancel_thread_ = std::thread(
+      [this, loop = std::move(uvw_cancel_loop)]() { CancelJobThread_(loop); });
 
   std::shared_ptr<uvw::loop> uvw_submit_loop = uvw::loop::create();
-  m_submit_task_timer_handle_ = uvw_submit_loop->resource<uvw::timer_handle>();
-  m_submit_task_timer_handle_->on<uvw::timer_event>(
+  m_submit_job_timer_handle_ = uvw_submit_loop->resource<uvw::timer_handle>();
+  m_submit_job_timer_handle_->on<uvw::timer_event>(
       [this](const uvw::timer_event&, uvw::timer_handle&) {
-        SubmitTaskTimerCb_();
+        SubmitJobTimerCb_();
       });
-  m_submit_task_timer_handle_->start(
-      std::chrono::milliseconds(kSubmitTaskTimeoutMs * 3),
-      std::chrono::milliseconds(kSubmitTaskTimeoutMs));
+  m_submit_job_timer_handle_->start(
+      std::chrono::milliseconds(kSubmitJobTimeoutMs * 3),
+      std::chrono::milliseconds(kSubmitJobTimeoutMs));
 
-  m_submit_task_async_handle_ = uvw_submit_loop->resource<uvw::async_handle>();
-  m_submit_task_async_handle_->on<uvw::async_event>(
+  m_submit_job_async_handle_ = uvw_submit_loop->resource<uvw::async_handle>();
+  m_submit_job_async_handle_->on<uvw::async_event>(
       [this](const uvw::async_event&, uvw::async_handle&) {
-        SubmitTaskAsyncCb_();
+        SubmitJobAsyncCb_();
       });
 
-  m_clean_submit_queue_handle_ = uvw_submit_loop->resource<uvw::async_handle>();
-  m_clean_submit_queue_handle_->on<uvw::async_event>(
+  m_clean_submit_job_queue_handle_ = uvw_submit_loop->resource<uvw::async_handle>();
+  m_clean_submit_job_queue_handle_->on<uvw::async_event>(
       [this](const uvw::async_event&, uvw::async_handle&) {
-        CleanSubmitQueueCb_();
+        CleanSubmitJobQueueCb_();
       });
 
-  m_task_submit_thread_ = std::thread(
-      [this, loop = std::move(uvw_submit_loop)]() { SubmitTaskThread_(loop); });
+  m_job_submit_thread_ = std::thread(
+      [this, loop = std::move(uvw_submit_loop)]() { SubmitJobThread_(loop); });
 
   std::shared_ptr<uvw::loop> uvw_submit_step_loop = uvw::loop::create();
   m_submit_step_timer_handle_ =
@@ -604,8 +604,8 @@ bool TaskScheduler::Init() {
         SubmitStepTimerCb_();
       });
   m_submit_step_timer_handle_->start(
-      std::chrono::milliseconds(kSubmitTaskTimeoutMs * 3),
-      std::chrono::milliseconds(kSubmitTaskTimeoutMs));
+      std::chrono::milliseconds(kSubmitJobTimeoutMs * 3),
+      std::chrono::milliseconds(kSubmitJobTimeoutMs));
 
   m_submit_step_async_handle_ =
       uvw_submit_step_loop->resource<uvw::async_handle>();
@@ -626,34 +626,34 @@ bool TaskScheduler::Init() {
         StepSubmitThread_(loop);
       });
 
-  std::shared_ptr<uvw::loop> uvw_task_status_change_loop = uvw::loop::create();
-  m_task_status_change_timer_handle_ =
-      uvw_task_status_change_loop->resource<uvw::timer_handle>();
-  m_task_status_change_timer_handle_->on<uvw::timer_event>(
+  std::shared_ptr<uvw::loop> uvw_job_status_change_loop = uvw::loop::create();
+  m_job_status_change_timer_handle_ =
+      uvw_job_status_change_loop->resource<uvw::timer_handle>();
+  m_job_status_change_timer_handle_->on<uvw::timer_event>(
       [this](const uvw::timer_event&, uvw::timer_handle&) {
-        TaskStatusChangeTimerCb_();
+        JobStatusChangeTimerCb_();
       });
-  m_task_status_change_timer_handle_->start(
-      std::chrono::milliseconds(kTaskStatusChangeTimeoutMS * 3),
-      std::chrono::milliseconds(kTaskStatusChangeTimeoutMS));
+  m_job_status_change_timer_handle_->start(
+      std::chrono::milliseconds(kJobStatusChangeTimeoutMS * 3),
+      std::chrono::milliseconds(kJobStatusChangeTimeoutMS));
 
-  m_task_status_change_async_handle_ =
-      uvw_task_status_change_loop->resource<uvw::async_handle>();
-  m_task_status_change_async_handle_->on<uvw::async_event>(
+  m_job_status_change_async_handle_ =
+      uvw_job_status_change_loop->resource<uvw::async_handle>();
+  m_job_status_change_async_handle_->on<uvw::async_event>(
       [this](const uvw::async_event&, uvw::async_handle&) {
-        TaskStatusChangeAsyncCb_();
+        JobStatusChangeAsyncCb_();
       });
 
-  m_clean_task_status_change_handle_ =
-      uvw_task_status_change_loop->resource<uvw::async_handle>();
-  m_clean_task_status_change_handle_->on<uvw::async_event>(
+  m_clean_job_status_change_handle_ =
+      uvw_job_status_change_loop->resource<uvw::async_handle>();
+  m_clean_job_status_change_handle_->on<uvw::async_event>(
       [this](const uvw::async_event&, uvw::async_handle&) {
-        CleanTaskStatusChangeQueueCb_();
+        CleanJobStatusChangeQueueCb_();
       });
 
-  m_task_status_change_thread_ =
-      std::thread([this, loop = std::move(uvw_task_status_change_loop)]() {
-        TaskStatusChangeThread_(loop);
+  m_job_status_change_thread_ =
+      std::thread([this, loop = std::move(uvw_job_status_change_loop)]() {
+        JobStatusChangeThread_(loop);
       });
 
   std::shared_ptr<uvw::loop> uvw_reservation_loop = uvw::loop::create();
@@ -707,46 +707,46 @@ bool TaskScheduler::Init() {
   return true;
 }
 
-void TaskScheduler::RequeueRecoveredTaskIntoPendingQueueLock_(
-    std::unique_ptr<TaskInCtld> task) {
-  // The newly modified QoS resource limits do not apply to tasks that have
+void JobScheduler::RequeueRecoveredJobIntoPendingQueueLock_(
+    std::unique_ptr<JobInCtld> job) {
+  // The newly modified QoS resource limits do not apply to jobs that have
   // already been evaluated, which is the same as before the restart.
-  g_account_meta_container->MallocQosSubmitResource(*task);
+  g_account_meta_container->MallocQosSubmitResource(*job);
 
   // The order of LockGuards matters.
-  LockGuard pending_guard(&m_pending_task_map_mtx_);
-  m_pending_task_map_.emplace(task->TaskId(), std::move(task));
+  LockGuard pending_guard(&m_pending_job_map_mtx_);
+  m_pending_job_map_.emplace(job->JobId(), std::move(job));
 }
 
-void TaskScheduler::PutRecoveredTaskIntoRunningQueueLock_(
-    std::unique_ptr<TaskInCtld> task) {
-  // The newly modified QoS resource limits do not apply to tasks that have
+void JobScheduler::PutRecoveredJobIntoRunningQueueLock_(
+    std::unique_ptr<JobInCtld> job) {
+  // The newly modified QoS resource limits do not apply to jobs that have
   // already been evaluated, which is the same as before the restart.
-  g_account_meta_container->MallocQosResourceToRecoveredRunningTask(*task);
+  g_account_meta_container->MallocQosResourceToRecoveredRunningJob(*job);
 
-  for (const CranedId& craned_id : task->CranedIds())
-    g_meta_container->MallocResourceFromNode(craned_id, task->TaskId(),
-                                             task->AllocatedRes());
-  if (!task->reservation.empty()) {
-    g_meta_container->MallocResourceFromResv(task->reservation, task->TaskId(),
-                                             task->AllocatedRes());
+  for (const CranedId& craned_id : job->CranedIds())
+    g_meta_container->MallocResourceFromNode(craned_id, job->JobId(),
+                                             job->AllocatedRes());
+  if (!job->reservation.empty()) {
+    g_meta_container->MallocResourceFromResv(job->reservation, job->JobId(),
+                                             job->AllocatedRes());
   }
-  if (!task->licenses_count.empty())
-    g_licenses_manager->MallocLicenseWhenRecoverRunning(task->licenses_count);
+  if (!job->licenses_count.empty())
+    g_licenses_manager->MallocLicenseWhenRecoverRunning(job->licenses_count);
 
   // The order of LockGuards matters.
-  LockGuard running_guard(&m_running_task_map_mtx_);
-  LockGuard indexes_guard(&m_task_indexes_mtx_);
+  LockGuard running_guard(&m_running_job_map_mtx_);
+  LockGuard indexes_guard(&m_job_indexes_mtx_);
 
-  for (const CranedId& craned_id : task->CranedIds())
-    m_node_to_tasks_map_[craned_id].emplace(task->TaskId());
+  for (const CranedId& craned_id : job->CranedIds())
+    m_node_to_jobs_map_[craned_id].emplace(job->JobId());
 
-  m_running_task_map_.emplace(task->TaskId(), std::move(task));
+  m_running_job_map_.emplace(job->JobId(), std::move(job));
 }
 
-void TaskScheduler::ReleaseTaskThread_(
+void JobScheduler::ReleaseJobThread_(
     const std::shared_ptr<uvw::loop>& uvw_loop) {
-  util::SetCurrentThreadName("ReleaseTaskThr");
+  util::SetCurrentThreadName("ReleaseJobThr");
 
   std::shared_ptr<uvw::idle_handle> idle_handle =
       uvw_loop->resource<uvw::idle_handle>();
@@ -766,9 +766,9 @@ void TaskScheduler::ReleaseTaskThread_(
   uvw_loop->run();
 }
 
-void TaskScheduler::CancelTaskThread_(
+void JobScheduler::CancelJobThread_(
     const std::shared_ptr<uvw::loop>& uvw_loop) {
-  util::SetCurrentThreadName("CancelTaskThr");
+  util::SetCurrentThreadName("CancelJobThr");
 
   std::shared_ptr<uvw::idle_handle> idle_handle =
       uvw_loop->resource<uvw::idle_handle>();
@@ -788,9 +788,9 @@ void TaskScheduler::CancelTaskThread_(
   uvw_loop->run();
 }
 
-void TaskScheduler::SubmitTaskThread_(
+void JobScheduler::SubmitJobThread_(
     const std::shared_ptr<uvw::loop>& uvw_loop) {
-  util::SetCurrentThreadName("SubmitTaskThr");
+  util::SetCurrentThreadName("SubmitJobThr");
 
   std::shared_ptr<uvw::idle_handle> idle_handle =
       uvw_loop->resource<uvw::idle_handle>();
@@ -810,7 +810,7 @@ void TaskScheduler::SubmitTaskThread_(
   uvw_loop->run();
 }
 
-void TaskScheduler::StepSubmitThread_(
+void JobScheduler::StepSubmitThread_(
     const std::shared_ptr<uvw::loop>& uvw_loop) {
   util::SetCurrentThreadName("SubmitStepThr");
 
@@ -832,9 +832,9 @@ void TaskScheduler::StepSubmitThread_(
   uvw_loop->run();
 }
 
-void TaskScheduler::TaskStatusChangeThread_(
+void JobScheduler::JobStatusChangeThread_(
     const std::shared_ptr<uvw::loop>& uvw_loop) {
-  util::SetCurrentThreadName("TaskStatChThr");
+  util::SetCurrentThreadName("JobStatChThr");
 
   std::shared_ptr<uvw::idle_handle> idle_handle =
       uvw_loop->resource<uvw::idle_handle>();
@@ -849,14 +849,14 @@ void TaskScheduler::TaskStatusChangeThread_(
 
   if (idle_handle->start() != 0) {
     CRANE_ERROR(
-        "Failed to start the idle event in TaskStatusChangeWithReasonAsync "
+        "Failed to start the idle event in JobStatusChangeWithReasonAsync "
         "loop.");
   }
 
   uvw_loop->run();
 }
 
-void TaskScheduler::CleanResvThread_(
+void JobScheduler::CleanResvThread_(
     const std::shared_ptr<uvw::loop>& uvw_loop) {
   util::SetCurrentThreadName("CleanResvThr");
 
@@ -879,26 +879,26 @@ void TaskScheduler::CleanResvThread_(
   uvw_loop->run();
 }
 
-void TaskScheduler::ScheduleThread_() {
+void JobScheduler::ScheduleThread_() {
   util::SetCurrentThreadName("ScheduleThread");
 
   std::chrono::steady_clock::time_point schedule_begin;
   std::chrono::steady_clock::time_point schedule_end;
-  size_t num_tasks_single_schedule;
-  size_t num_tasks_single_execution;
+  size_t num_jobs_single_schedule;
+  size_t num_jobs_single_execution;
 
   std::chrono::steady_clock::time_point begin;
   std::chrono::steady_clock::time_point end;
 
   while (!m_thread_stop_) {
     // Note: In other parts of code, we must avoid the happening of the
-    // situation where m_running_task_map_mtx is acquired and then
-    // m_pending_task_map_mtx_ needs to be acquired. Deadlock may happen under
+    // situation where m_running_job_map_mtx is acquired and then
+    // m_pending_job_map_mtx_ needs to be acquired. Deadlock may happen under
     // such a situation.
-    m_pending_task_map_mtx_.Lock();
-    if (!m_pending_task_map_.empty()) {  // all_part_metas is locked here.
+    m_pending_job_map_mtx_.Lock();
+    if (!m_pending_job_map_.empty()) {  // all_part_metas is locked here.
       // Running map must be locked before g_meta_container's lock.
-      // Otherwise, DEADLOCK may happen because TaskStatusChange() locks running
+      // Otherwise, DEADLOCK may happen because StepStatusChange() locks running
       // map first and then locks g_meta_container.
 
       // Truncated by 1s.
@@ -914,8 +914,8 @@ void TaskScheduler::ScheduleThread_() {
         dep_events.resize(actual_size);
 
         for (const auto& event : dep_events) {
-          auto it = m_pending_task_map_.find(event.dependent_job_id);
-          if (it != m_pending_task_map_.end()) {
+          auto it = m_pending_job_map_.find(event.dependent_job_id);
+          if (it != m_pending_job_map_.end()) {
             it->second->UpdateDependency(event.dependee_job_id,
                                          event.event_time);
           }
@@ -923,8 +923,8 @@ void TaskScheduler::ScheduleThread_() {
       }
 
       std::vector<std::unique_ptr<PdJobInScheduler>> pending_jobs;
-      pending_jobs.reserve(m_pending_task_map_.size());
-      for (auto& it : m_pending_task_map_) {
+      pending_jobs.reserve(m_pending_job_map_.size());
+      for (auto& it : m_pending_job_map_) {
         const auto& job = it.second;
         if (job->Held()) {
           job->pending_reason = "Held";
@@ -948,26 +948,26 @@ void TaskScheduler::ScheduleThread_() {
       }
 
       // ScheduleThread_ is the only thread move jobs from pending to
-      // running, so it's safe to release m_pending_task_map_mtx_ before
-      // locking m_running_task_map_mtx_.
-      m_pending_task_map_mtx_.Unlock();
+      // running, so it's safe to release m_pending_job_map_mtx_ before
+      // locking m_running_job_map_mtx_.
+      m_pending_job_map_mtx_.Unlock();
 
-      m_running_task_map_mtx_.Lock();
+      m_running_job_map_mtx_.Lock();
 
       std::vector<std::unique_ptr<RnJobInScheduler>> running_jobs;
-      running_jobs.reserve(m_running_task_map_.size());
-      for (auto& it : m_running_task_map_) {
+      running_jobs.reserve(m_running_job_map_.size());
+      for (auto& it : m_running_job_map_) {
         running_jobs.emplace_back(
             std::make_unique<RnJobInScheduler>(it.second.get()));
       }
 
       // ScheduleThread_ is the only thread start jobs, so it's safe to release
-      // m_running_task_map_mtx_ before monitoring resources on nodes.
-      m_running_task_map_mtx_.Unlock();
+      // m_running_job_map_mtx_ before monitoring resources on nodes.
+      m_running_job_map_mtx_.Unlock();
 
       schedule_begin = std::chrono::steady_clock::now();
-      num_tasks_single_schedule = std::min((size_t)g_config.ScheduledBatchSize,
-                                           m_pending_task_map_.size());
+      num_jobs_single_schedule = std::min((size_t)g_config.ScheduledBatchSize,
+                                           m_pending_job_map_.size());
 
       g_meta_container->StartLogging();
 
@@ -1020,13 +1020,13 @@ void TaskScheduler::ScheduleThread_() {
         }
       }
 
-      std::vector<std::unique_ptr<TaskInCtld>> jobs_to_run;
-      LockGuard pending_guard(&m_pending_task_map_mtx_);
-      LockGuard running_guard(&m_running_task_map_mtx_);
+      std::vector<std::unique_ptr<JobInCtld>> jobs_to_run;
+      LockGuard pending_guard(&m_pending_job_map_mtx_);
+      LockGuard running_guard(&m_running_job_map_mtx_);
 
       for (auto& job_in_scheduler : pending_jobs) {
-        auto it = m_pending_task_map_.find(job_in_scheduler->job_id);
-        if (it != m_pending_task_map_.end()) {
+        auto it = m_pending_job_map_.find(job_in_scheduler->job_id);
+        if (it != m_pending_job_map_.end()) {
           auto& job = it->second;
           job->SetCachedPriority(job_in_scheduler->priority);
           job->SetStartTime(job_in_scheduler->start_time);
@@ -1102,17 +1102,17 @@ void TaskScheduler::ScheduleThread_() {
           job->allocated_res_view += job->AllocatedRes();
           job->nodes_alloc = job->CranedIds().size();
 
-          job->SetStatus(crane::grpc::TaskStatus::Configuring);
+          job->SetStatus(crane::grpc::JobStatus::Configuring);
 
           job->allocated_craneds_regex =
               util::HostNameListToStr(job->CranedIds());
 
           for (CranedId const& craned_id : job->CranedIds())
-            g_meta_container->MallocResourceFromNode(craned_id, job->TaskId(),
+            g_meta_container->MallocResourceFromNode(craned_id, job->JobId(),
                                                      job->AllocatedRes());
           if (job->reservation != "") {
             g_meta_container->MallocResourceFromResv(
-                job->reservation, job->TaskId(), job->AllocatedRes());
+                job->reservation, job->JobId(), job->AllocatedRes());
           }
 
           if (job->ShouldLaunchOnAllNodes()) {
@@ -1123,7 +1123,7 @@ void TaskScheduler::ScheduleThread_() {
           }
 
           jobs_to_run.push_back(std::move(job));
-          m_pending_task_map_.erase(it);
+          m_pending_job_map_.erase(it);
         } else {
           CRANE_TRACE(
               "Pending job #{} not found in pending map, may has been "
@@ -1136,7 +1136,7 @@ void TaskScheduler::ScheduleThread_() {
       // allowed now.
       g_meta_container->StopLoggingAndUnlock();
 
-      num_tasks_single_execution = jobs_to_run.size();
+      num_jobs_single_execution = jobs_to_run.size();
 
       end = std::chrono::steady_clock::now();
       CRANE_TRACE(
@@ -1144,25 +1144,25 @@ void TaskScheduler::ScheduleThread_() {
           std::chrono::duration_cast<std::chrono::milliseconds>(end - begin)
               .count());
 
-      // Now we have the ownerships of to-run jobs in jobs_to_run. Add task
-      // ids to node maps immediately before CreateCgroupForTasks to ensure
+      // Now we have the ownerships of to-run jobs in jobs_to_run. Add job
+      // ids to node maps immediately before CreateCgroupForJobs to ensure
       // that if a CraneD crash, the callback of CranedKeeper can call
-      // TerminateTasksOnCraned in which m_node_to_tasks_map_ will be searched
-      // and send TerminateTasksOnCraned to appropriate CraneD to release the
+      // TerminateJobsOnCraned in which m_node_to_jobs_map_ will be searched
+      // and send TerminateJobsOnCraned to appropriate CraneD to release the
       // cgroups.
 
       // NOTE: If unlock pending_map here, jobs may be unable to be find
       // before transferring to running_map or DB.
 
-      m_task_indexes_mtx_.Lock();
+      m_job_indexes_mtx_.Lock();
       for (auto& job : jobs_to_run) {
         for (CranedId const& craned_id : job->CranedIds())
-          m_node_to_tasks_map_[craned_id].emplace(job->TaskId());
+          m_node_to_jobs_map_[craned_id].emplace(job->JobId());
       }
-      m_task_indexes_mtx_.Unlock();
+      m_job_indexes_mtx_.Unlock();
 
       Mutex thread_pool_mtx;
-      HashSet<task_id_t> failed_job_id_set;
+      HashSet<job_id_t> failed_job_id_set;
 
       // RPC is time-consuming. Clustering rpc to one craned for performance.
 
@@ -1174,22 +1174,22 @@ void TaskScheduler::ScheduleThread_() {
 
       std::vector<StepInCtld*> step_in_ctld_vec;
 
-      std::vector<std::unique_ptr<TaskInCtld>> jobs_failed;
+      std::vector<std::unique_ptr<JobInCtld>> jobs_failed;
 
       // Move jobs into running queue.
       txn_id_t txn_id{0};
       bool ok = g_embedded_db_client->BeginVariableDbTransaction(&txn_id);
       if (!ok) {
         CRANE_ERROR(
-            "TaskScheduler failed to start transaction when scheduling.");
+            "JobScheduler failed to start transaction when scheduling.");
         jobs_failed = std::move(jobs_to_run);
       }
 
       for (auto& job : jobs_to_run) {
-        // IMPORTANT: job must be put into running_task_map before any
-        // time-consuming operation, otherwise TaskStatusChange RPC will come
-        // earlier before job is put into running_task_map.
-        g_embedded_db_client->UpdateRuntimeAttrOfTask(txn_id, job->TaskDbId(),
+        // IMPORTANT: job must be put into running_job_map before any
+        // time-consuming operation, otherwise StepStatusChange RPC will come
+        // earlier before job is put into running_job_map.
+        g_embedded_db_client->UpdateRuntimeAttrOfJob(txn_id, job->JobDbId(),
                                                       job->RuntimeAttr());
       }
 
@@ -1200,7 +1200,7 @@ void TaskScheduler::ScheduleThread_() {
       }
 
       for (auto& job : jobs_to_run) {
-        job->SetPrimaryStepStatus(crane::grpc::TaskStatus::Invalid);
+        job->SetPrimaryStepStatus(crane::grpc::JobStatus::Invalid);
         std::unique_ptr daemon_step = std::make_unique<DaemonStepInCtld>();
         daemon_step->InitFromJob(*job);
         step_in_ctld_vec.push_back(daemon_step.get());
@@ -1241,7 +1241,7 @@ void TaskScheduler::ScheduleThread_() {
 
         m_rpc_worker_pool_->detach_task([&] {
           auto stub = g_craned_keeper->GetCranedStub(craned_id);
-          CRANE_TRACE("Send AllocJobs for {} tasks to {}", jobs.size(),
+          CRANE_TRACE("Send AllocJobs for {} jobs to {}", jobs.size(),
                       craned_id);
           if (stub == nullptr || stub->Invalid()) {
             CRANE_TRACE(
@@ -1330,12 +1330,12 @@ void TaskScheduler::ScheduleThread_() {
             failed_job_id_set.emplace(step_to_d.job_id());
           thread_pool_mtx.Unlock();
 
-          // If tasks in task_uid_pairs failed to start,
-          // they will be moved to the completed tasks and do the following
+          // If jobs in job_uid_pairs failed to start,
+          // they will be moved to the completed jobs and do the following
           // steps:
-          // 1. call g_meta_container->FreeResources() for the failed tasks.
-          // 2. Release all cgroups related to these failed tasks.
-          // 3. Move these tasks to the completed queue.
+          // 1. call g_meta_container->FreeResources() for the failed jobs.
+          // 2. Release all cgroups related to these failed jobs.
+          // 3. Move these jobs to the completed queue.
           CRANE_ERROR("Craned #{} failed when AllocSteps.", craned_id);
 
           alloc_step_latch.count_down();
@@ -1348,9 +1348,9 @@ void TaskScheduler::ScheduleThread_() {
           std::chrono::duration_cast<std::chrono::milliseconds>(end - begin)
               .count());
 
-      std::vector<std::unique_ptr<TaskInCtld>> jobs_created;
+      std::vector<std::unique_ptr<JobInCtld>> jobs_created;
       for (auto& job : jobs_to_run) {
-        if (failed_job_id_set.contains(job->TaskId())) {
+        if (failed_job_id_set.contains(job->JobId())) {
           jobs_failed.emplace_back(std::move(job));
         } else {
           jobs_created.emplace_back(std::move(job));
@@ -1361,24 +1361,24 @@ void TaskScheduler::ScheduleThread_() {
 
       // Now we have the ownerships of succeeded jobs in `jobs_created` and
       // the ownerships of failed jobs in `jobs_failed`.
-      // For successfully created jobs, add them to m_node_to_tasks_map_.
+      // For successfully created jobs, add them to m_node_to_jobs_map_.
       // For failed jobs, free all the resource and move them to the completed
       // queue.
 
-      // Set succeed tasks status and do callbacks.
+      // Set succeed jobs status and do callbacks.
       for (auto& job : jobs_created) {
         job->TriggerDependencyEvents(crane::grpc::DependencyType::AFTER,
                                      job->StartTime());
         // Start CraneCtld prolog before transferring ownership.
         // Sets m_ctld_prolog_pending_ on DaemonStep if prolog is configured.
         StartCraneCtldPrologThread(job.get());
-        // The ownership of TaskInCtld is transferred to the running queue.
-        m_running_task_map_.emplace(job->TaskId(), std::move(job));
+        // The ownership of JobInCtld is transferred to the running queue.
+        m_running_job_map_.emplace(job->JobId(), std::move(job));
       }
 
       end = std::chrono::steady_clock::now();
       CRANE_TRACE(
-          "Move tasks into running queue costed {} ms",
+          "Move jobs into running queue costed {} ms",
           std::chrono::duration_cast<std::chrono::milliseconds>(end - begin)
               .count());
 
@@ -1393,8 +1393,8 @@ void TaskScheduler::ScheduleThread_() {
 
       schedule_end = end;
       CRANE_TRACE(
-          "Scheduling {} pending tasks. {} get scheduled. Time elapsed: {}ms",
-          num_tasks_single_schedule, num_tasks_single_execution,
+          "Scheduling {} pending jobs. {} get scheduled. Time elapsed: {}ms",
+          num_jobs_single_schedule, num_jobs_single_execution,
           std::chrono::duration_cast<std::chrono::milliseconds>(schedule_end -
                                                                 schedule_begin)
               .count());
@@ -1402,30 +1402,30 @@ void TaskScheduler::ScheduleThread_() {
       // Note: If unlock pending_map here, jobs may be unable to be find
       // before transferring to DB.
       if (!jobs_failed.empty()) {
-        // Then handle failed tasks in `jobs_failed_to_create_cg` if there's
+        // Then handle failed jobs in `jobs_failed_to_create_cg` if there's
         // any.
         begin = std::chrono::steady_clock::now();
 
         for (auto& job : jobs_failed) {
           for (CranedId const& craned_id : job->CranedIds())
-            g_meta_container->FreeResourceFromNode(craned_id, job->TaskId());
+            g_meta_container->FreeResourceFromNode(craned_id, job->JobId());
           if (job->reservation != "")
             g_meta_container->FreeResourceFromResv(job->reservation,
-                                                   job->TaskId());
+                                                   job->JobId());
           g_account_meta_container->FreeQosResource(*job);
           if (!job->licenses_count.empty())
             g_licenses_manager->FreeLicense(job->licenses_count);
-          LockGuard indexes_guard(&m_task_indexes_mtx_);
+          LockGuard indexes_guard(&m_job_indexes_mtx_);
           for (const CranedId& craned_id : job->CranedIds()) {
-            m_node_to_tasks_map_[craned_id].erase(job->TaskId());
-            if (m_node_to_tasks_map_[craned_id].empty()) {
-              m_node_to_tasks_map_.erase(craned_id);
+            m_node_to_jobs_map_[craned_id].erase(job->JobId());
+            if (m_node_to_jobs_map_[craned_id].empty()) {
+              m_node_to_jobs_map_.erase(craned_id);
             }
           }
         }
 
         // Move failed jobs to the completed queue.
-        std::unordered_set<TaskInCtld*> failed_job_raw_ptrs;
+        std::unordered_set<JobInCtld*> failed_job_raw_ptrs;
         for (auto& job : jobs_failed) {
           failed_job_raw_ptrs.emplace(job.get());
 
@@ -1433,7 +1433,7 @@ void TaskScheduler::ScheduleThread_() {
           job->SetExitCode(ExitCode::EC_CGROUP_ERR);
           job->SetEndTime(absl::Now());
         }
-        ProcessFinalTasks_(failed_job_raw_ptrs);
+        ProcessFinalJobs_(failed_job_raw_ptrs);
 
         // Failed jobs have been handled properly. Free them explicitly.
         jobs_failed.clear();
@@ -1445,29 +1445,29 @@ void TaskScheduler::ScheduleThread_() {
                 .count());
       }
     } else {
-      m_pending_map_cached_size_.store(m_pending_task_map_.size(),
+      m_pending_map_cached_size_.store(m_pending_job_map_.size(),
                                        std::memory_order::release);
-      m_pending_task_map_mtx_.Unlock();
+      m_pending_job_map_mtx_.Unlock();
     }
 
     std::this_thread::sleep_for(
-        std::chrono::milliseconds(kTaskScheduleIntervalMs));
+        std::chrono::milliseconds(kJobScheduleIntervalMs));
   }
 }
 
-void TaskScheduler::StepScheduleThread_() {
+void JobScheduler::StepScheduleThread_() {
   util::SetCurrentThreadName("StepSchedThread");
   while (!m_thread_stop_) {
     {
-      absl::MutexLock running_lk(&m_running_task_map_mtx_);
+      absl::MutexLock running_lk(&m_running_job_map_mtx_);
       absl::MutexLock step_lk(&m_step_num_mutex_);
       if (!m_job_pending_step_num_map_.empty()) {
         std::vector<job_id_t> jobs_to_remove;
         std::vector<CommonStepInCtld*> scheduled_steps;
         for (auto& [job_id, step_num] : m_job_pending_step_num_map_) {
           // TODO: schedule here
-          auto rn_iter = m_running_task_map_.find(job_id);
-          if (rn_iter != m_running_task_map_.end()) {
+          auto rn_iter = m_running_job_map_.find(job_id);
+          if (rn_iter != m_running_job_map_.end()) {
             auto& job = rn_iter->second;
             auto popped_cnt = job->SchedulePendingSteps(&scheduled_steps);
             if ((m_job_pending_step_num_map_[job_id] -= popped_cnt) == 0) {
@@ -1492,7 +1492,7 @@ void TaskScheduler::StepScheduleThread_() {
                   0, step->StepDbId(), step->RuntimeAttr())) {
             CRANE_ERROR("Failed to update steps to embedded database.");
             StepStatusChangeAsync(step->job_id, step->StepId(), "",
-                                  crane::grpc::TaskStatus::Failed, 0,
+                                  crane::grpc::JobStatus::Failed, 0,
                                   "DbUpdateError", now);
           }
         }
@@ -1519,7 +1519,7 @@ void TaskScheduler::StepScheduleThread_() {
               thread_pool_mtx.Lock();
               for (const auto& step : steps)
                 StepStatusChangeAsync(step.job_id(), step.step_id(), craned_id,
-                                      crane::grpc::TaskStatus::Failed, 0,
+                                      crane::grpc::JobStatus::Failed, 0,
                                       "CranedDown", now);
 
               thread_pool_mtx.Unlock();
@@ -1543,7 +1543,7 @@ void TaskScheduler::StepScheduleThread_() {
             thread_pool_mtx.Lock();
             for (const auto& step : steps)
               StepStatusChangeAsync(step.job_id(), step.step_id(), craned_id,
-                                    crane::grpc::TaskStatus::Failed, 0,
+                                    crane::grpc::JobStatus::Failed, 0,
                                     "AllocRpcError", now);
             thread_pool_mtx.Unlock();
             CRANE_ERROR("Craned #{} failed when AllocSteps.", craned_id);
@@ -1558,18 +1558,18 @@ void TaskScheduler::StepScheduleThread_() {
   }
 }
 
-std::future<CraneExpected<task_id_t>> TaskScheduler::SubmitTaskAsync(
-    std::unique_ptr<TaskInCtld> task) {
-  std::promise<CraneExpected<task_id_t>> promise;
-  std::future<CraneExpected<task_id_t>> future = promise.get_future();
+std::future<CraneExpected<job_id_t>> JobScheduler::SubmitJobAsync(
+    std::unique_ptr<JobInCtld> job) {
+  std::promise<CraneExpected<job_id_t>> promise;
+  std::future<CraneExpected<job_id_t>> future = promise.get_future();
 
-  m_submit_task_queue_.enqueue({std::move(task), std::move(promise)});
-  m_submit_task_async_handle_->send();
+  m_submit_job_queue_.enqueue({std::move(job), std::move(promise)});
+  m_submit_job_async_handle_->send();
 
   return std::move(future);
 }
 
-std::future<CraneExpected<step_id_t>> TaskScheduler::SubmitStepAsync(
+std::future<CraneExpected<step_id_t>> JobScheduler::SubmitStepAsync(
     std::unique_ptr<CommonStepInCtld> step) {
   std::promise<CraneExpected<step_id_t>> promise;
   std::future<CraneExpected<step_id_t>> future = promise.get_future();
@@ -1580,58 +1580,58 @@ std::future<CraneExpected<step_id_t>> TaskScheduler::SubmitStepAsync(
   return std::move(future);
 }
 
-std::future<CraneErrCode> TaskScheduler::HoldReleaseTaskAsync(task_id_t task_id,
+std::future<CraneErrCode> JobScheduler::HoldReleaseJobAsync(job_id_t job_id,
                                                               int64_t secs) {
   std::promise<CraneErrCode> promise;
   std::future<CraneErrCode> future = promise.get_future();
 
-  m_task_timer_queue_.enqueue(
-      {std::make_pair(task_id, secs), std::move(promise)});
-  m_task_timeout_async_handle_->send();
+  m_job_timer_queue_.enqueue(
+      {std::make_pair(job_id, secs), std::move(promise)});
+  m_job_timeout_async_handle_->send();
 
   return std::move(future);
 }
 
-CraneErrCode TaskScheduler::ChangeTaskTimeLimit(task_id_t task_id,
+CraneErrCode JobScheduler::ChangeJobTimeLimit(job_id_t job_id,
                                                 int64_t secs) {
   if (!CheckIfTimeLimitSecIsValid(secs)) return CraneErrCode::ERR_INVALID_PARAM;
 
   std::vector<CranedId> craned_ids;
 
   {
-    LockGuard pending_guard(&m_pending_task_map_mtx_);
-    LockGuard running_guard(&m_running_task_map_mtx_);
+    LockGuard pending_guard(&m_pending_job_map_mtx_);
+    LockGuard running_guard(&m_running_job_map_mtx_);
 
-    TaskInCtld* task;
+    JobInCtld* job;
     bool found = false;
 
-    auto pd_iter = m_pending_task_map_.find(task_id);
-    if (pd_iter != m_pending_task_map_.end()) {
-      found = true, task = pd_iter->second.get();
+    auto pd_iter = m_pending_job_map_.find(job_id);
+    if (pd_iter != m_pending_job_map_.end()) {
+      found = true, job = pd_iter->second.get();
 
-      if (task->reservation != "") {
+      if (job->reservation != "") {
         auto resv_end_time =
-            g_meta_container->GetResvMetaPtr(task->reservation)->end_time;
+            g_meta_container->GetResvMetaPtr(job->reservation)->end_time;
         if (resv_end_time <= absl::Now() + absl::Seconds(secs)) {
-          CRANE_DEBUG("Task #{}'s time limit exceeds reservation end time",
-                      task_id);
+          CRANE_DEBUG("Job #{}'s time limit exceeds reservation end time",
+                      job_id);
           return CraneErrCode::ERR_INVALID_PARAM;
         }
       }
     }
     if (!found) {
-      auto rn_iter = m_running_task_map_.find(task_id);
-      if (rn_iter != m_running_task_map_.end()) {
-        found = true, task = rn_iter->second.get();
-        craned_ids = task->executing_craned_ids;
+      auto rn_iter = m_running_job_map_.find(job_id);
+      if (rn_iter != m_running_job_map_.end()) {
+        found = true, job = rn_iter->second.get();
+        craned_ids = job->executing_craned_ids;
 
-        if (task->reservation != "") {
+        if (job->reservation != "") {
           const auto& reservation_meta =
-              g_meta_container->GetResvMetaPtr(task->reservation);
+              g_meta_container->GetResvMetaPtr(job->reservation);
           auto resv_end_time = reservation_meta->end_time;
-          if (resv_end_time <= task->StartTime() + absl::Seconds(secs)) {
-            CRANE_DEBUG("Task #{}'s time limit exceeds reservation end time",
-                        task_id);
+          if (resv_end_time <= job->StartTime() + absl::Seconds(secs)) {
+            CRANE_DEBUG("Job #{}'s time limit exceeds reservation end time",
+                        job_id);
             return CraneErrCode::ERR_INVALID_PARAM;
           }
         }
@@ -1639,25 +1639,25 @@ CraneErrCode TaskScheduler::ChangeTaskTimeLimit(task_id_t task_id,
     }
 
     if (!found) {
-      CRANE_DEBUG("Task #{} not in Pd/Rn queue for time limit change!",
-                  task_id);
+      CRANE_DEBUG("Job #{} not in Pd/Rn queue for time limit change!",
+                  job_id);
       return CraneErrCode::ERR_NON_EXISTENT;
     }
 
-    task->time_limit = absl::Seconds(secs);
-    task->MutableTaskToCtld()->mutable_time_limit()->set_seconds(secs);
-    g_embedded_db_client->UpdateTaskToCtldIfExists(0, task->TaskDbId(),
-                                                   task->TaskToCtld());
+    job->time_limit = absl::Seconds(secs);
+    job->MutableJobToCtld()->mutable_time_limit()->set_seconds(secs);
+    g_embedded_db_client->UpdateJobToCtldIfExists(0, job->JobDbId(),
+                                                   job->JobToCtld());
   }
 
   // Only send request to the executing node
   for (const CranedId& craned_id : craned_ids) {
     auto stub = g_craned_keeper->GetCranedStub(craned_id);
     if (stub && !stub->Invalid()) {
-      CraneErrCode err = stub->ChangeJobTimeLimit(task_id, secs);
+      CraneErrCode err = stub->ChangeJobTimeLimit(job_id, secs);
       if (err != CraneErrCode::SUCCESS) {
-        CRANE_ERROR("Failed to change time limit of task #{} on Node {}",
-                    task_id, craned_id);
+        CRANE_ERROR("Failed to change time limit of job #{} on Node {}",
+                    job_id, craned_id);
         return err;
       }
     }
@@ -1666,215 +1666,215 @@ CraneErrCode TaskScheduler::ChangeTaskTimeLimit(task_id_t task_id,
   return CraneErrCode::SUCCESS;
 }
 
-CraneErrCode TaskScheduler::ChangeTaskPriority(task_id_t task_id,
+CraneErrCode JobScheduler::ChangeJobPriority(job_id_t job_id,
                                                double priority) {
-  m_pending_task_map_mtx_.Lock();
+  m_pending_job_map_mtx_.Lock();
 
-  auto pd_iter = m_pending_task_map_.find(task_id);
-  if (pd_iter == m_pending_task_map_.end()) {
-    m_pending_task_map_mtx_.Unlock();
-    CRANE_TRACE("Task #{} not in Pd queue for priority change", task_id);
+  auto pd_iter = m_pending_job_map_.find(job_id);
+  if (pd_iter == m_pending_job_map_.end()) {
+    m_pending_job_map_mtx_.Unlock();
+    CRANE_TRACE("Job #{} not in Pd queue for priority change", job_id);
     return CraneErrCode::ERR_NON_EXISTENT;
   }
 
   pd_iter->second->mandated_priority = priority;
-  m_pending_task_map_mtx_.Unlock();
+  m_pending_job_map_mtx_.Unlock();
   return CraneErrCode::SUCCESS;
 }
 
-CraneErrCode TaskScheduler::ChangeTaskExtraAttrs(
-    task_id_t task_id, const std::string& new_extra_attr) {
-  LockGuard pending_guard(&m_pending_task_map_mtx_);
-  LockGuard running_guard(&m_running_task_map_mtx_);
+CraneErrCode JobScheduler::ChangeJobExtraAttrs(
+    job_id_t job_id, const std::string& new_extra_attr) {
+  LockGuard pending_guard(&m_pending_job_map_mtx_);
+  LockGuard running_guard(&m_running_job_map_mtx_);
 
-  TaskInCtld* task;
+  JobInCtld* job;
   bool found = false;
 
-  auto pd_iter = m_pending_task_map_.find(task_id);
-  if (pd_iter != m_pending_task_map_.end()) {
-    found = true, task = pd_iter->second.get();
+  auto pd_iter = m_pending_job_map_.find(job_id);
+  if (pd_iter != m_pending_job_map_.end()) {
+    found = true, job = pd_iter->second.get();
   }
   if (!found) {
-    auto rn_iter = m_running_task_map_.find(task_id);
-    if (rn_iter != m_running_task_map_.end()) {
-      found = true, task = rn_iter->second.get();
+    auto rn_iter = m_running_job_map_.find(job_id);
+    if (rn_iter != m_running_job_map_.end()) {
+      found = true, job = rn_iter->second.get();
     }
   }
 
   if (!found) {
-    CRANE_DEBUG("Task #{} not in Pd/Rn queue for extra attribute change!",
-                task_id);
+    CRANE_DEBUG("Job #{} not in Pd/Rn queue for extra attribute change!",
+                job_id);
     return CraneErrCode::ERR_NON_EXISTENT;
   }
 
-  task->extra_attr = new_extra_attr;
-  task->MutableTaskToCtld()->set_extra_attr(new_extra_attr);
-  g_embedded_db_client->UpdateTaskToCtldIfExists(0, task->TaskDbId(),
-                                                 task->TaskToCtld());
+  job->extra_attr = new_extra_attr;
+  job->MutableJobToCtld()->set_extra_attr(new_extra_attr);
+  g_embedded_db_client->UpdateJobToCtldIfExists(0, job->JobDbId(),
+                                                 job->JobToCtld());
   return CraneErrCode::SUCCESS;
 }
 
-std::optional<std::future<CraneRichError>> TaskScheduler::JobSubmitLuaCheck(
-    TaskInCtld* task) {
+std::optional<std::future<CraneRichError>> JobScheduler::JobSubmitLuaCheck(
+    JobInCtld* job) {
 #ifdef HAVE_LUA
   if (g_config.JobSubmitLuaScript.empty()) return std::nullopt;
-  return g_lua_pool->ExecuteLuaScript([task]() {
-    return LuaJobHandler::JobSubmit(g_config.JobSubmitLuaScript, task);
+  return g_lua_pool->ExecuteLuaScript([job]() {
+    return LuaJobHandler::JobSubmit(g_config.JobSubmitLuaScript, job);
   });
 #else
   return std::nullopt;
 #endif
 }
 
-void TaskScheduler::JobModifyLuaCheck(
-    const crane::grpc::ModifyTaskRequest& request,
-    crane::grpc::ModifyTaskReply* response, std::list<task_id_t>* task_ids) {
+void JobScheduler::JobModifyLuaCheck(
+    const crane::grpc::ModifyJobRequest& request,
+    crane::grpc::ModifyJobReply* response, std::list<job_id_t>* job_ids) {
 #ifdef HAVE_LUA
-  LockGuard pending_guard(&m_pending_task_map_mtx_);
-  LockGuard running_guard(&m_running_task_map_mtx_);
+  LockGuard pending_guard(&m_pending_job_map_mtx_);
+  LockGuard running_guard(&m_running_job_map_mtx_);
 
-  std::vector<std::pair<task_id_t, std::future<CraneRichError>>> futures;
-  futures.reserve(request.task_ids().size());
-  for (const auto task_id : request.task_ids()) {
-    auto pd_iter = m_pending_task_map_.find(task_id);
-    if (pd_iter != m_pending_task_map_.end()) {
+  std::vector<std::pair<job_id_t, std::future<CraneRichError>>> futures;
+  futures.reserve(request.job_ids().size());
+  for (const auto job_id : request.job_ids()) {
+    auto pd_iter = m_pending_job_map_.find(job_id);
+    if (pd_iter != m_pending_job_map_.end()) {
       auto fut = g_lua_pool->ExecuteLuaScript([pd_iter]() {
         return LuaJobHandler::JobModify(g_config.JobSubmitLuaScript,
                                         pd_iter->second.get());
       });
-      futures.emplace_back(task_id, std::move(fut));
+      futures.emplace_back(job_id, std::move(fut));
       continue;
     }
 
-    auto rn_iter = m_running_task_map_.find(task_id);
-    if (rn_iter != m_running_task_map_.end()) {
+    auto rn_iter = m_running_job_map_.find(job_id);
+    if (rn_iter != m_running_job_map_.end()) {
       auto fut = g_lua_pool->ExecuteLuaScript([rn_iter]() {
         return LuaJobHandler::JobModify(g_config.JobSubmitLuaScript,
                                         rn_iter->second.get());
       });
-      futures.emplace_back(task_id, std::move(fut));
+      futures.emplace_back(job_id, std::move(fut));
     }
   }
 
-  for (auto& [task_id, fut] : futures) {
+  for (auto& [job_id, fut] : futures) {
     auto rich_err = fut.get();
     if (rich_err.code() != CraneErrCode::SUCCESS) {
-      response->add_not_modified_tasks(task_id);
+      response->add_not_modified_jobs(job_id);
       if (rich_err.description().empty())
         response->add_not_modified_reasons(CraneErrStr(rich_err.code()));
       else
         response->add_not_modified_reasons(rich_err.description());
     } else {
-      task_ids->emplace_back(task_id);
+      job_ids->emplace_back(job_id);
     }
   }
 #endif
 }
 
-CraneExpected<std::future<CraneExpected<task_id_t>>>
-TaskScheduler::SubmitTaskToScheduler(std::unique_ptr<TaskInCtld> task) {
-  if (!task->password_entry->Valid()) {
-    CRANE_DEBUG("Uid {} not found on the controller node", task->uid);
+CraneExpected<std::future<CraneExpected<job_id_t>>>
+JobScheduler::SubmitJobToScheduler(std::unique_ptr<JobInCtld> job) {
+  if (!job->password_entry->Valid()) {
+    CRANE_DEBUG("Uid {} not found on the controller node", job->uid);
     return std::unexpected(CraneErrCode::ERR_INVALID_UID);
   }
-  task->SetUsername(task->password_entry->Username());
+  job->SetUsername(job->password_entry->Username());
 
   {  // Limit the lifecycle of user_scoped_ptr
     auto user_scoped_ptr =
-        g_account_manager->GetExistedUserInfo(task->Username());
+        g_account_manager->GetExistedUserInfo(job->Username());
     if (!user_scoped_ptr) {
       CRANE_DEBUG("User '{}' not found in the account database",
-                  task->Username());
+                  job->Username());
       return std::unexpected(CraneErrCode::ERR_INVALID_USER);
     }
 
-    if (task->account.empty()) {
-      task->account = user_scoped_ptr->default_account;
-      task->MutableTaskToCtld()->set_account(user_scoped_ptr->default_account);
+    if (job->account.empty()) {
+      job->account = user_scoped_ptr->default_account;
+      job->MutableJobToCtld()->set_account(user_scoped_ptr->default_account);
     } else {
-      if (!user_scoped_ptr->account_to_attrs_map.contains(task->account)) {
+      if (!user_scoped_ptr->account_to_attrs_map.contains(job->account)) {
         CRANE_DEBUG(
             "Account '{}' is not in the user account list when submitting the "
-            "task",
-            task->account);
+            "job",
+            job->account);
         return std::unexpected(CraneErrCode::ERR_USER_ACCOUNT_MISMATCH);
       }
     }
   }
 
   if (!g_account_manager->CheckUserPermissionToPartition(
-          task->Username(), task->account, task->partition_id)) {
+          job->Username(), job->account, job->partition_id)) {
     CRANE_DEBUG(
         "User '{}' doesn't have permission to use partition '{}' when using "
         "account '{}'",
-        task->Username(), task->partition_id, task->account);
+        job->Username(), job->partition_id, job->account);
     return std::unexpected(CraneErrCode::ERR_PARTITION_MISSING);
   }
 
   auto enable_res = g_account_manager->CheckIfUserOfAccountIsEnabled(
-      task->Username(), task->account);
+      job->Username(), job->account);
   if (!enable_res) {
     return std::unexpected(enable_res.error());
   }
 
   auto result = g_meta_container->CheckIfAccountIsAllowedInPartition(
-      task->partition_id, task->account);
+      job->partition_id, job->account);
   if (!result) return std::unexpected(result.error());
 
-  task->SetSubmitTime(absl::Now());
+  job->SetSubmitTime(absl::Now());
 
-  result = TaskScheduler::HandleUnsetOptionalInTaskToCtld(task.get());
-  if (result) result = TaskScheduler::AcquireTaskAttributes(task.get());
-  if (result) result = TaskScheduler::CheckTaskValidity(task.get());
+  result = JobScheduler::HandleUnsetOptionalInJobToCtld(job.get());
+  if (result) result = JobScheduler::AcquireJobAttributes(job.get());
+  if (result) result = JobScheduler::CheckJobValidity(job.get());
   if (result) {
     {
       const auto& user_ptr =
-          g_account_manager->GetExistedUserInfo(task->Username());
+          g_account_manager->GetExistedUserInfo(job->Username());
       if (!user_ptr) return std::unexpected(CraneErrCode::ERR_INVALID_USER);
 
-      auto res = g_account_meta_container->TryMallocQosSubmitResource(*task);
+      auto res = g_account_meta_container->TryMallocQosSubmitResource(*job);
       if (res != CraneErrCode::SUCCESS) {
         CRANE_DEBUG("The requested QoS resources have reached the limit.");
         return std::unexpected(res);
       }
-      g_account_meta_container->UserAddTask(user_ptr->name);
+      g_account_meta_container->UserAddJob(user_ptr->name);
     }
-    std::future<CraneExpected<task_id_t>> future =
-        g_task_scheduler->SubmitTaskAsync(std::move(task));
+    std::future<CraneExpected<job_id_t>> future =
+        g_job_scheduler->SubmitJobAsync(std::move(job));
     return {std::move(future)};
   }
 
   return std::unexpected(result.error());
 }
 
-CraneErrCode TaskScheduler::SetHoldForTaskInRamAndDb_(task_id_t task_id,
+CraneErrCode JobScheduler::SetHoldForJobInRamAndDb_(job_id_t job_id,
                                                       bool hold) {
-  m_pending_task_map_mtx_.Lock();
+  m_pending_job_map_mtx_.Lock();
 
-  auto pd_iter = m_pending_task_map_.find(task_id);
-  if (pd_iter == m_pending_task_map_.end()) {
-    m_pending_task_map_mtx_.Unlock();
-    CRANE_TRACE("Task #{} not in Pd queue for hold/release", task_id);
+  auto pd_iter = m_pending_job_map_.find(job_id);
+  if (pd_iter == m_pending_job_map_.end()) {
+    m_pending_job_map_mtx_.Unlock();
+    CRANE_TRACE("Job #{} not in Pd queue for hold/release", job_id);
     return CraneErrCode::ERR_NON_EXISTENT;
   }
 
-  TaskInCtld* task = pd_iter->second.get();
-  task->SetHeld(hold);
+  JobInCtld* job = pd_iter->second.get();
+  job->SetHeld(hold);
 
   // Copy persisted data to prevent inconsistency.
-  task_db_id_t db_id = task->TaskDbId();
-  auto runtime_attr = task->RuntimeAttr();
+  job_db_id_t db_id = job->JobDbId();
+  auto runtime_attr = job->RuntimeAttr();
 
-  m_pending_task_map_mtx_.Unlock();
+  m_pending_job_map_mtx_.Unlock();
 
-  if (!g_embedded_db_client->UpdateRuntimeAttrOfTaskIfExists(0, db_id,
+  if (!g_embedded_db_client->UpdateRuntimeAttrOfJobIfExists(0, db_id,
                                                              runtime_attr))
-    CRANE_ERROR("Failed to update runtime attr of task #{} to DB", task_id);
+    CRANE_ERROR("Failed to update runtime attr of job #{} to DB", job_id);
 
   return CraneErrCode::SUCCESS;
 }
 
-CraneErrCode TaskScheduler::TerminateRunningStepNoLock_(
+CraneErrCode JobScheduler::TerminateRunningStepNoLock_(
     CommonStepInCtld* step) {
   auto* common_step = static_cast<CommonStepInCtld*>(step);
   bool need_to_be_terminated = false;
@@ -1890,20 +1890,20 @@ CraneErrCode TaskScheduler::TerminateRunningStepNoLock_(
 
   if (need_to_be_terminated) {
     for (CranedId const& craned_id : step->ExecutionNodes()) {
-      m_cancel_task_queue_.enqueue(
-          CancelRunningTaskQueueElem{.job_id = step->job_id,
+      m_cancel_job_queue_.enqueue(
+          CancelRunningJobQueueElem{.job_id = step->job_id,
                                      .step_id = step->StepId(),
                                      .craned_id = craned_id});
-      m_cancel_task_async_handle_->send();
+      m_cancel_job_async_handle_->send();
     }
   }
 
   return CraneErrCode::SUCCESS;
 }
 
-crane::grpc::CancelTaskReply TaskScheduler::CancelPendingOrRunningTask(
-    const crane::grpc::CancelTaskRequest& request) {
-  crane::grpc::CancelTaskReply reply;
+crane::grpc::CancelJobReply JobScheduler::CancelPendingOrRunningJob(
+    const crane::grpc::CancelJobRequest& request) {
+  crane::grpc::CancelJobReply reply;
 
   uint32_t operator_uid = request.operator_uid();
 
@@ -1916,32 +1916,32 @@ crane::grpc::CancelTaskReply TaskScheduler::CancelPendingOrRunningTask(
     filter_uname = entry.Username();
   }
 
-  auto rng_filter_state = [&](TaskInCtld* task) {
+  auto rng_filter_state = [&](JobInCtld* job) {
     return request.filter_state() == crane::grpc::Invalid ||
-           task->Status() == request.filter_state();
+           job->Status() == request.filter_state();
   };
 
-  auto rng_filter_partition = [&](TaskInCtld* task) {
+  auto rng_filter_partition = [&](JobInCtld* job) {
     return request.filter_partition().empty() ||
-           task->partition_id == request.filter_partition();
+           job->partition_id == request.filter_partition();
   };
 
-  auto rng_filter_account = [&](TaskInCtld* task) {
+  auto rng_filter_account = [&](JobInCtld* job) {
     return request.filter_account().empty() ||
-           task->account == request.filter_account();
+           job->account == request.filter_account();
   };
 
-  auto rng_filter_task_name = [&](TaskInCtld* task) {
-    return request.filter_task_name().empty() ||
-           task->name == request.filter_task_name();
+  auto rng_filter_job_name = [&](JobInCtld* job) {
+    return request.filter_job_name().empty() ||
+           job->name == request.filter_job_name();
   };
 
-  auto rng_filter_user_name = [&](TaskInCtld* task) {
-    return filter_uname.empty() || task->Username() == filter_uname;
+  auto rng_filter_user_name = [&](JobInCtld* job) {
+    return filter_uname.empty() || job->Username() == filter_uname;
   };
 
-  ranges::any_view<TaskInCtld*, ranges::category::forward> pd_input_rng;
-  ranges::any_view<TaskInCtld*, ranges::category::forward> rn_input_rng;
+  ranges::any_view<JobInCtld*, ranges::category::forward> pd_input_rng;
+  ranges::any_view<JobInCtld*, ranges::category::forward> rn_input_rng;
   std::unordered_map<job_id_t, std::unordered_set<step_id_t>> filter_ids;
   for (auto& [job_id, step_ids] : request.filter_ids()) {
     filter_ids[job_id].insert(step_ids.steps().begin(), step_ids.steps().end());
@@ -1950,18 +1950,18 @@ crane::grpc::CancelTaskReply TaskScheduler::CancelPendingOrRunningTask(
       filter_ids | std::views::keys | std::ranges::to<std::unordered_set>();
   if (filter_ids.empty()) {
     auto get_raw_ptr = [](auto& ptr) { return ptr.get(); };
-    pd_input_rng = m_pending_task_map_ | ranges::views::values |
+    pd_input_rng = m_pending_job_map_ | ranges::views::values |
                    ranges::views::transform(get_raw_ptr);
-    rn_input_rng = m_running_task_map_ | ranges::views::values |
+    rn_input_rng = m_running_job_map_ | ranges::views::values |
                    ranges::views::transform(get_raw_ptr);
   } else {
     auto filter_nullptr = [](auto task_ptr) { return task_ptr != nullptr; };
     pd_input_rng = filter_ids |
                    ranges::views::transform(
-                       [this, &not_found_jobs](auto& it) -> TaskInCtld* {
+                       [this, &not_found_jobs](auto& it) -> JobInCtld* {
                          job_id_t job_id = it.first;
-                         auto pd_it = m_pending_task_map_.find(job_id);
-                         if (pd_it != m_pending_task_map_.end()) {
+                         auto pd_it = m_pending_job_map_.find(job_id);
+                         if (pd_it != m_pending_job_map_.end()) {
                            // Pending jobs have no steps, we just consider job
                            // existence here
                            not_found_jobs.erase(job_id);
@@ -1973,10 +1973,10 @@ crane::grpc::CancelTaskReply TaskScheduler::CancelPendingOrRunningTask(
 
     rn_input_rng = filter_ids |
                    ranges::views::transform(
-                       [this, &not_found_jobs](auto& it) -> TaskInCtld* {
+                       [this, &not_found_jobs](auto& it) -> JobInCtld* {
                          job_id_t job_id = it.first;
-                         auto rn_it = m_running_task_map_.find(job_id);
-                         if (rn_it != m_running_task_map_.end()) {
+                         auto rn_it = m_running_job_map_.find(job_id);
+                         if (rn_it != m_running_job_map_.end()) {
                            not_found_jobs.erase(job_id);
                            return rn_it->second.get();
                          }
@@ -1987,64 +1987,64 @@ crane::grpc::CancelTaskReply TaskScheduler::CancelPendingOrRunningTask(
 
   std::unordered_set<std::string> filter_nodes_set(
       std::begin(request.filter_nodes()), std::end(request.filter_nodes()));
-  auto rng_filter_nodes = [&](TaskInCtld* task) {
+  auto rng_filter_nodes = [&](JobInCtld* job) {
     if (request.filter_nodes().empty()) return true;
 
-    for (const auto& node : task->CranedIds())
+    for (const auto& node : job->CranedIds())
       if (filter_nodes_set.contains(node)) return true;
 
     return false;
   };
 
-  auto rng_get_job_id = [&](TaskInCtld* task) { return task->TaskId(); };
+  auto rng_get_job_id = [&](JobInCtld* job) { return job->JobId(); };
 
-  auto fn_cancel_pending_task = [&](job_id_t task_id) {
-    CRANE_TRACE("Cancelling pending task #{}", task_id);
+  auto fn_cancel_pending_job = [&](job_id_t job_id) {
+    CRANE_TRACE("Cancelling pending job #{}", job_id);
 
-    auto it = m_pending_task_map_.find(task_id);
-    CRANE_ASSERT(it != m_pending_task_map_.end());
+    auto it = m_pending_job_map_.find(job_id);
+    CRANE_ASSERT(it != m_pending_job_map_.end());
 
     auto result = g_account_manager->CheckIfUidHasPermOnUser(
         operator_uid, it->second->Username(), false);
     if (!result) {
       auto& not_cancelled_job =
-          (*reply.mutable_not_cancelled_job_steps())[task_id];
+          (*reply.mutable_not_cancelled_job_steps())[job_id];
       not_cancelled_job.set_reason("Permission Denied");
     } else {
       auto& cancelled_job_steps = *reply.mutable_cancelled_steps();
-      cancelled_job_steps[task_id] = crane::grpc::JobStepIds{};
+      cancelled_job_steps[job_id] = crane::grpc::JobStepIds{};
 
-      m_cancel_task_queue_.enqueue(
-          CancelPendingTaskQueueElem{std::move(it->second)});
-      m_cancel_task_async_handle_->send();
+      m_cancel_job_queue_.enqueue(
+          CancelPendingJobQueueElem{std::move(it->second)});
+      m_cancel_job_async_handle_->send();
 
-      m_pending_task_map_.erase(it);
+      m_pending_job_map_.erase(it);
     }
   };
 
-  auto fn_cancel_running_task = [&](TaskInCtld* task) {
-    task_id_t task_id = task->TaskId();
+  auto fn_cancel_running_job = [&](JobInCtld* job) {
+    job_id_t job_id = job->JobId();
 
-    CRANE_TRACE("Cancelling running task #{}", task_id);
+    CRANE_TRACE("Cancelling running job #{}", job_id);
 
     auto result = g_account_manager->CheckIfUidHasPermOnUser(
-        operator_uid, task->Username(), false);
+        operator_uid, job->Username(), false);
     if (!result) {
       auto& not_cancelled_job =
-          (*reply.mutable_not_cancelled_job_steps())[task_id];
+          (*reply.mutable_not_cancelled_job_steps())[job_id];
       not_cancelled_job.set_reason("Permission Denied");
     } else {
       // User specified job and step ids to cancel
-      if (filter_ids.contains(task_id) && !filter_ids[task_id].empty()) {
+      if (filter_ids.contains(job_id) && !filter_ids[job_id].empty()) {
         std::vector<CommonStepInCtld*> cancel_steps;
         // cancel step
-        for (step_id_t step_id : filter_ids[task_id]) {
-          StepInCtld* step = task->GetStep(step_id);
+        for (step_id_t step_id : filter_ids[job_id]) {
+          StepInCtld* step = job->GetStep(step_id);
           if (!step) {
             auto& not_found_job_steps =
                 *reply.mutable_not_cancelled_job_steps();
-            not_found_job_steps[task_id].mutable_step_ids()->Add(step_id);
-            not_found_job_steps[task_id].mutable_step_reasons()->Add(
+            not_found_job_steps[job_id].mutable_step_ids()->Add(step_id);
+            not_found_job_steps[job_id].mutable_step_reasons()->Add(
                 "Step not found");
           } else {
             cancel_steps.push_back(static_cast<CommonStepInCtld*>(step));
@@ -2062,36 +2062,36 @@ crane::grpc::CancelTaskReply TaskScheduler::CancelPendingOrRunningTask(
             TerminateRunningStepNoLock_(step);
           }
           auto& cancelled_job_steps = *reply.mutable_cancelled_steps();
-          auto& job_steps = cancelled_job_steps[task_id];
+          auto& job_steps = cancelled_job_steps[job_id];
           job_steps.add_steps(step->StepId());
         }
       } else {
-        if (task->Status() == crane::grpc::TaskStatus::Configuring) {
+        if (job->Status() == crane::grpc::JobStatus::Configuring) {
           // Daemon step is still being configured on Craned nodes.
           // Record the cancel intent; DaemonStepInCtld::StepStatusChange will
           // act on it once all nodes have reported their configuring status,
           // and the existing Configuring-failed path will handle frontend
           // notification for interactive jobs at that point.
-          task->SetCancelRequested(true);
+          job->SetCancelRequested(true);
 
           auto& cancelled_job_steps = *reply.mutable_cancelled_steps();
-          cancelled_job_steps[task_id] = crane::grpc::JobStepIds{};
+          cancelled_job_steps[job_id] = crane::grpc::JobStepIds{};
 
           CRANE_INFO(
               "[Job #{}] Cancel requested during Configuring state. "
               "Deferring until all nodes finish configuring.",
-              task_id);
+              job_id);
           return;
         }
         auto& cancelled_job_steps = *reply.mutable_cancelled_steps();
-        cancelled_job_steps[task_id] = crane::grpc::JobStepIds{};
+        cancelled_job_steps[job_id] = crane::grpc::JobStepIds{};
         // User cancel jobs with node/name... filter or cancel a job.
-        auto primary_step = task->PrimaryStep();
+        auto primary_step = job->PrimaryStep();
         if (!primary_step) {
           CRANE_DEBUG(
               "[Job #{}] Primary step not found when cancelling running job, "
               "maybe completing.",
-              task_id);
+              job_id);
           return;
         }
         TerminateRunningStepNoLock_(primary_step);
@@ -2102,23 +2102,23 @@ crane::grpc::CancelTaskReply TaskScheduler::CancelPendingOrRunningTask(
                         ranges::views::filter(rng_filter_partition) |
                         ranges::views::filter(rng_filter_account) |
                         ranges::views::filter(rng_filter_user_name) |
-                        ranges::views::filter(rng_filter_task_name) |
+                        ranges::views::filter(rng_filter_job_name) |
                         ranges::views::filter(rng_filter_nodes);
 
-  auto pending_task_id_rng =
+  auto pending_job_id_rng =
       pd_input_rng | joined_filters | ranges::views::transform(rng_get_job_id);
 
-  LockGuard pending_guard(&m_pending_task_map_mtx_);
-  LockGuard running_guard(&m_running_task_map_mtx_);
+  LockGuard pending_guard(&m_pending_job_map_mtx_);
+  LockGuard running_guard(&m_running_job_map_mtx_);
 
-  // Evaluate immediately. fn_cancel_pending_task will change the contents
-  // of m_pending_task_map_ and invalidate the end() of
+  // Evaluate immediately. fn_cancel_pending_job will change the contents
+  // of m_pending_job_map_ and invalidate the end() of
   // pending_task_rng.
-  ranges::for_each(pending_task_id_rng | ranges::to<std::vector<job_id_t>>(),
-                   fn_cancel_pending_task);
+  ranges::for_each(pending_job_id_rng | ranges::to<std::vector<job_id_t>>(),
+                   fn_cancel_pending_job);
 
-  auto running_task_rng = rn_input_rng | joined_filters;
-  ranges::for_each(running_task_rng, fn_cancel_running_task);
+  auto running_job_rng = rn_input_rng | joined_filters;
+  ranges::for_each(running_job_rng, fn_cancel_running_job);
   for (auto job_id : not_found_jobs) {
     auto& not_found_job_steps = *reply.mutable_not_cancelled_job_steps();
     not_found_job_steps[job_id].set_reason("Job not found");
@@ -2126,18 +2126,18 @@ crane::grpc::CancelTaskReply TaskScheduler::CancelPendingOrRunningTask(
   return reply;
 }
 
-crane::grpc::AttachContainerStepReply TaskScheduler::AttachContainerStep(
+crane::grpc::AttachContainerStepReply JobScheduler::AttachContainerStep(
     const crane::grpc::AttachContainerStepRequest& request) {
   crane::grpc::AttachContainerStepReply response;
 
   CranedId target_craned_id;
   {
-    LockGuard pending_guard(&m_pending_task_map_mtx_);
-    LockGuard running_guard(&m_running_task_map_mtx_);
+    LockGuard pending_guard(&m_pending_job_map_mtx_);
+    LockGuard running_guard(&m_running_job_map_mtx_);
 
-    task_id_t job_id = request.job_id();
-    auto pd_it = m_pending_task_map_.find(job_id);
-    if (pd_it != m_pending_task_map_.end()) {
+    job_id_t job_id = request.job_id();
+    auto pd_it = m_pending_job_map_.find(job_id);
+    if (pd_it != m_pending_job_map_.end()) {
       auto* err = response.mutable_status();
       err->set_code(CraneErrCode::ERR_CRI_CONTAINER_NOT_READY);
       err->set_description("Job is still pending. Try again later.");
@@ -2145,8 +2145,8 @@ crane::grpc::AttachContainerStepReply TaskScheduler::AttachContainerStep(
       return response;
     }
 
-    auto rn_it = m_running_task_map_.find(job_id);
-    if (rn_it == m_running_task_map_.end()) {
+    auto rn_it = m_running_job_map_.find(job_id);
+    if (rn_it == m_running_job_map_.end()) {
       auto* err = response.mutable_status();
       err->set_code(CraneErrCode::ERR_INVALID_PARAM);
       err->set_description("Requested job is not running.");
@@ -2154,8 +2154,8 @@ crane::grpc::AttachContainerStepReply TaskScheduler::AttachContainerStep(
       return response;
     }
 
-    TaskInCtld* task = rn_it->second.get();
-    if (!task->IsContainer()) {
+    JobInCtld* job = rn_it->second.get();
+    if (!job->IsContainer()) {
       auto* err = response.mutable_status();
       err->set_code(CraneErrCode::ERR_INVALID_PARAM);
       err->set_description("Requested job is not a container job.");
@@ -2163,7 +2163,7 @@ crane::grpc::AttachContainerStepReply TaskScheduler::AttachContainerStep(
       return response;
     }
 
-    auto* step = task->GetStep(request.step_id());
+    auto* step = job->GetStep(request.step_id());
     if (step == nullptr) {
       auto* err = response.mutable_status();
       err->set_code(CraneErrCode::ERR_INVALID_PARAM);
@@ -2172,7 +2172,7 @@ crane::grpc::AttachContainerStepReply TaskScheduler::AttachContainerStep(
       return response;
     }
 
-    if (step->type != crane::grpc::TaskType::Container ||
+    if (step->type != crane::grpc::JobType::Container ||
         !step->StepToCtld().has_container_meta() ||
         !step->container_meta.has_value()) {
       auto* err = response.mutable_status();
@@ -2184,8 +2184,8 @@ crane::grpc::AttachContainerStepReply TaskScheduler::AttachContainerStep(
 
     const auto& container_meta = step->container_meta.value();
 
-    if (step->Status() != crane::grpc::TaskStatus::Running &&
-        step->Status() != crane::grpc::TaskStatus::Starting) {
+    if (step->Status() != crane::grpc::JobStatus::Running &&
+        step->Status() != crane::grpc::JobStatus::Starting) {
       auto* err = response.mutable_status();
       err->set_code(CraneErrCode::ERR_CRI_CONTAINER_NOT_READY);
       err->set_description("Step is not running.");
@@ -2214,7 +2214,7 @@ crane::grpc::AttachContainerStepReply TaskScheduler::AttachContainerStep(
     }
 
     auto result = g_account_manager->CheckIfUidHasPermOnUser(
-        request.uid(), task->Username(), false);
+        request.uid(), job->Username(), false);
     if (!result) {
       auto* err = response.mutable_status();
       err->set_code(CraneErrCode::ERR_PERMISSION_USER);
@@ -2259,18 +2259,18 @@ crane::grpc::AttachContainerStepReply TaskScheduler::AttachContainerStep(
   return stub->AttachContainerStep(request);
 }
 
-crane::grpc::ExecInContainerStepReply TaskScheduler::ExecInContainerStep(
+crane::grpc::ExecInContainerStepReply JobScheduler::ExecInContainerStep(
     const crane::grpc::ExecInContainerStepRequest& request) {
   crane::grpc::ExecInContainerStepReply response;
 
   CranedId target_craned_id;
   {
-    LockGuard pending_guard(&m_pending_task_map_mtx_);
-    LockGuard running_guard(&m_running_task_map_mtx_);
+    LockGuard pending_guard(&m_pending_job_map_mtx_);
+    LockGuard running_guard(&m_running_job_map_mtx_);
 
-    task_id_t job_id = request.job_id();
-    auto pd_it = m_pending_task_map_.find(job_id);
-    if (pd_it != m_pending_task_map_.end()) {
+    job_id_t job_id = request.job_id();
+    auto pd_it = m_pending_job_map_.find(job_id);
+    if (pd_it != m_pending_job_map_.end()) {
       auto* err = response.mutable_status();
       err->set_code(CraneErrCode::ERR_CRI_CONTAINER_NOT_READY);
       err->set_description("Job is still pending. Try again later.");
@@ -2278,8 +2278,8 @@ crane::grpc::ExecInContainerStepReply TaskScheduler::ExecInContainerStep(
       return response;
     }
 
-    auto rn_it = m_running_task_map_.find(job_id);
-    if (rn_it == m_running_task_map_.end()) {
+    auto rn_it = m_running_job_map_.find(job_id);
+    if (rn_it == m_running_job_map_.end()) {
       auto* err = response.mutable_status();
       err->set_code(CraneErrCode::ERR_INVALID_PARAM);
       err->set_description("Requested job is not running.");
@@ -2287,8 +2287,8 @@ crane::grpc::ExecInContainerStepReply TaskScheduler::ExecInContainerStep(
       return response;
     }
 
-    TaskInCtld* task = rn_it->second.get();
-    if (!task->IsContainer()) {
+    JobInCtld* job = rn_it->second.get();
+    if (!job->IsContainer()) {
       auto* err = response.mutable_status();
       err->set_code(CraneErrCode::ERR_INVALID_PARAM);
       err->set_description("Requested job is not a container job.");
@@ -2296,7 +2296,7 @@ crane::grpc::ExecInContainerStepReply TaskScheduler::ExecInContainerStep(
       return response;
     }
 
-    auto* step = task->GetStep(request.step_id());
+    auto* step = job->GetStep(request.step_id());
     if (step == nullptr) {
       auto* err = response.mutable_status();
       err->set_code(CraneErrCode::ERR_INVALID_PARAM);
@@ -2305,7 +2305,7 @@ crane::grpc::ExecInContainerStepReply TaskScheduler::ExecInContainerStep(
       return response;
     }
 
-    if (step->type != crane::grpc::TaskType::Container ||
+    if (step->type != crane::grpc::JobType::Container ||
         !step->StepToCtld().has_container_meta() ||
         !step->container_meta.has_value()) {
       auto* err = response.mutable_status();
@@ -2326,8 +2326,8 @@ crane::grpc::ExecInContainerStepReply TaskScheduler::ExecInContainerStep(
 
     const auto& container_meta = step->container_meta.value();
 
-    if (step->Status() != crane::grpc::TaskStatus::Running &&
-        step->Status() != crane::grpc::TaskStatus::Starting) {
+    if (step->Status() != crane::grpc::JobStatus::Running &&
+        step->Status() != crane::grpc::JobStatus::Starting) {
       auto* err = response.mutable_status();
       err->set_code(CraneErrCode::ERR_CRI_CONTAINER_NOT_READY);
       err->set_description("Step is not running.");
@@ -2356,7 +2356,7 @@ crane::grpc::ExecInContainerStepReply TaskScheduler::ExecInContainerStep(
     }
 
     auto result = g_account_manager->CheckIfUidHasPermOnUser(
-        request.uid(), task->Username(), false);
+        request.uid(), job->Username(), false);
     if (!result) {
       auto* err = response.mutable_status();
       err->set_code(CraneErrCode::ERR_PERMISSION_USER);
@@ -2401,7 +2401,7 @@ crane::grpc::ExecInContainerStepReply TaskScheduler::ExecInContainerStep(
   return stub->ExecInContainerStep(request);
 }
 
-crane::grpc::CreateReservationReply TaskScheduler::CreateResv(
+crane::grpc::CreateReservationReply JobScheduler::CreateResv(
     const crane::grpc::CreateReservationRequest& request) {
   crane::grpc::CreateReservationReply reply;
 
@@ -2416,7 +2416,7 @@ crane::grpc::CreateReservationReply TaskScheduler::CreateResv(
   return reply;
 }
 
-std::expected<void, std::string> TaskScheduler::CreateResv_(
+std::expected<void, std::string> JobScheduler::CreateResv_(
     const crane::grpc::CreateReservationRequest& request) {
   std::vector<std::string> validation_errors;
 
@@ -2527,7 +2527,7 @@ std::expected<void, std::string> TaskScheduler::CreateResv_(
   std::vector<CranedMetaContainer::CranedMetaPtr> craned_meta_vec;
   ResourceV2 allocated_res;
   {
-    LockGuard running_guard(&m_running_task_map_mtx_);
+    LockGuard running_guard(&m_running_job_map_mtx_);
     std::vector<CranedId> nodes_not_found;
     std::vector<CranedId> nodes_conflicted;
 
@@ -2539,12 +2539,12 @@ std::expected<void, std::string> TaskScheduler::CreateResv_(
       }
 
       bool failed = false;
-      for (task_id_t task_id :
-           craned_meta->rn_task_res_map | std::views::keys) {
-        const auto& task = m_running_task_map_.at(task_id);
-        absl::Time task_end_time = task->StartTime() + task->time_limit;
+      for (job_id_t job_id :
+           craned_meta->rn_job_res_map | std::views::keys) {
+        const auto& job = m_running_job_map_.at(job_id);
+        absl::Time job_end_time = job->StartTime() + job->time_limit;
 
-        if (task_end_time > start_time) {
+        if (job_end_time > start_time) {
           nodes_conflicted.emplace_back(craned_id);
           failed = true;
           break;
@@ -2667,7 +2667,7 @@ std::expected<void, std::string> TaskScheduler::CreateResv_(
   return {};
 }
 
-crane::grpc::DeleteReservationReply TaskScheduler::DeleteResv(
+crane::grpc::DeleteReservationReply JobScheduler::DeleteResv(
     const crane::grpc::DeleteReservationRequest& request) {
   crane::grpc::DeleteReservationReply reply;
 
@@ -2684,7 +2684,7 @@ crane::grpc::DeleteReservationReply TaskScheduler::DeleteResv(
   return reply;
 }
 
-std::expected<void, std::string> TaskScheduler::DeleteResvMeta_(
+std::expected<void, std::string> JobScheduler::DeleteResvMeta_(
     const ResvId& resv_id) {
   g_meta_container->LockResReduceEvents();
   absl::flat_hash_set<CranedId> craned_ids;
@@ -2701,7 +2701,7 @@ std::expected<void, std::string> TaskScheduler::DeleteResvMeta_(
     if (!resv_meta->rn_job_res_map.empty()) {
       g_meta_container->UnlockResReduceEvents();
       return std::unexpected(fmt::format(
-          "Not allowed to delete reservation {} with running tasks", resv_id));
+          "Not allowed to delete reservation {} with running jobs", resv_id));
     }
 
     craned_ids = std::move(resv_meta->craned_ids);
@@ -2746,7 +2746,7 @@ std::expected<void, std::string> TaskScheduler::DeleteResvMeta_(
   return {};
 }
 
-crane::grpc::DeleteReservationReply TaskScheduler::PurgeAllReservations() {
+crane::grpc::DeleteReservationReply JobScheduler::PurgeAllReservations() {
   crane::grpc::DeleteReservationReply reply;
 
   // Collect all reservation names first
@@ -2776,73 +2776,73 @@ crane::grpc::DeleteReservationReply TaskScheduler::PurgeAllReservations() {
   return reply;
 }
 
-void TaskScheduler::CleanTaskTimerCb_() {
-  m_clean_task_timer_queue_handle_->send();
+void JobScheduler::CleanJobTimerCb_() {
+  m_clean_job_timer_queue_handle_->send();
 }
 
-void TaskScheduler::TaskTimerAsyncCb_() {
-  if (m_task_timer_queue_.size_approx() >= kTaskHoldTimerBatchNum) {
-    m_clean_task_timer_queue_handle_->send();
+void JobScheduler::JobTimerAsyncCb_() {
+  if (m_job_timer_queue_.size_approx() >= kJobHoldTimerBatchNum) {
+    m_clean_job_timer_queue_handle_->send();
   }
 }
 
-void TaskScheduler::CleanTaskTimerQueueCb_(
+void JobScheduler::CleanJobTimerQueueCb_(
     const std::shared_ptr<uvw::loop>& uvw_loop) {
   // It's ok to use an approximate size.
-  size_t approximate_size = m_task_timer_queue_.size_approx();
+  size_t approximate_size = m_job_timer_queue_.size_approx();
 
-  std::vector<TaskTimerQueueElem> timer_to_create;
+  std::vector<JobTimerQueueElem> timer_to_create;
   timer_to_create.resize(approximate_size);
 
-  size_t actual_size = m_task_timer_queue_.try_dequeue_bulk(
+  size_t actual_size = m_job_timer_queue_.try_dequeue_bulk(
       timer_to_create.begin(), approximate_size);
 
   timer_to_create.resize(actual_size);
 
   for (auto& [req, promise] : timer_to_create) {
-    const auto& [task_id, secs] = req;
+    const auto& [job_id, secs] = req;
 
-    // If any timer for the task exists, remove it.
-    auto timer_it = m_task_timer_handles_.find(task_id);
-    if (timer_it != m_task_timer_handles_.end()) {
+    // If any timer for the job exists, remove it.
+    auto timer_it = m_job_timer_handles_.find(job_id);
+    if (timer_it != m_job_timer_handles_.end()) {
       timer_it->second->close();
-      m_task_timer_handles_.erase(timer_it);
+      m_job_timer_handles_.erase(timer_it);
     }
 
     CraneErrCode err;
     if (secs == 0) {  // Remove timer
-      CRANE_TRACE("Remove hold constraint timer for task #{}.", task_id);
-      err = SetHoldForTaskInRamAndDb_(task_id, false);
+      CRANE_TRACE("Remove hold constraint timer for job #{}.", job_id);
+      err = SetHoldForJobInRamAndDb_(job_id, false);
     } else if (secs == std::numeric_limits<int64_t>::max()) {
-      CRANE_TRACE("Add a hold constraint for task #{} without timer.", task_id);
-      err = SetHoldForTaskInRamAndDb_(task_id, true);
+      CRANE_TRACE("Add a hold constraint for job #{} without timer.", job_id);
+      err = SetHoldForJobInRamAndDb_(job_id, true);
     } else {  // Set timer
-      CRANE_TRACE("Add a hold constraint for task #{} with {}s timer.", task_id,
+      CRANE_TRACE("Add a hold constraint for job #{} with {}s timer.", job_id,
                   secs);
 
-      auto on_timer_cb = [this, task_id](const uvw::timer_event&,
+      auto on_timer_cb = [this, job_id](const uvw::timer_event&,
                                          uvw::timer_handle& handle) {
-        CraneErrCode err = SetHoldForTaskInRamAndDb_(task_id, false);
+        CraneErrCode err = SetHoldForJobInRamAndDb_(job_id, false);
         if (err != CraneErrCode::SUCCESS)
-          CRANE_ERROR("Failed to release task #{} after hold.", task_id);
+          CRANE_ERROR("Failed to release job #{} after hold.", job_id);
 
         handle.close();
-        m_task_timer_handles_.erase(task_id);
+        m_job_timer_handles_.erase(job_id);
       };
 
-      err = SetHoldForTaskInRamAndDb_(task_id, true);
+      err = SetHoldForJobInRamAndDb_(job_id, true);
 
-      auto task_timer_handle_ = uvw_loop->resource<uvw::timer_handle>();
-      task_timer_handle_->on<uvw::timer_event>(std::move(on_timer_cb));
-      task_timer_handle_->start(std::chrono::seconds(secs), 0s);
-      m_task_timer_handles_[task_id] = std::move(task_timer_handle_);
+      auto job_timer_handle = uvw_loop->resource<uvw::timer_handle>();
+      job_timer_handle->on<uvw::timer_event>(std::move(on_timer_cb));
+      job_timer_handle->start(std::chrono::seconds(secs), 0s);
+      m_job_timer_handles_[job_id] = std::move(job_timer_handle);
     }
 
     promise.set_value(err);
   }
 }
 
-void TaskScheduler::CleanResvTimerQueueCb_(
+void JobScheduler::CleanResvTimerQueueCb_(
     const std::shared_ptr<uvw::loop>& uvw_loop) {
   // It's ok to use an approximate size.
   size_t approximate_size = m_resv_timer_queue_.size_approx();
@@ -2885,42 +2885,42 @@ void TaskScheduler::CleanResvTimerQueueCb_(
   }
 }
 
-void TaskScheduler::CancelTaskTimerCb_() {
-  m_clean_cancel_queue_handle_->send();
+void JobScheduler::CancelJobTimerCb_() {
+  m_clean_cancel_job_queue_handle_->send();
 }
 
-void TaskScheduler::CancelTaskAsyncCb_() {
-  if (m_cancel_task_queue_.size_approx() >= kCancelTaskBatchNum) {
-    m_clean_cancel_queue_handle_->send();
+void JobScheduler::CancelJobAsyncCb_() {
+  if (m_cancel_job_queue_.size_approx() >= kCancelJobBatchNum) {
+    m_clean_cancel_job_queue_handle_->send();
   }
 }
 
-void TaskScheduler::CleanCancelQueueCb_() {
+void JobScheduler::CleanCancelJobQueueCb_() {
   // It's ok to use an approximate size.
-  size_t approximate_size = m_cancel_task_queue_.size_approx();
-  std::vector<CancelTaskQueueElem> tasks_to_cancel;
-  tasks_to_cancel.resize(approximate_size);
+  size_t approximate_size = m_cancel_job_queue_.size_approx();
+  std::vector<CancelJobQueueElem> jobs_to_cancel;
+  jobs_to_cancel.resize(approximate_size);
 
-  // Carry the ownership of TaskInCtld for automatic destruction.
-  std::vector<std::unique_ptr<TaskInCtld>> pending_task_ptr_vec;
+  // Carry the ownership of JobInCtld for automatic destruction.
+  std::vector<std::unique_ptr<JobInCtld>> pending_job_ptr_vec;
   std::vector<std::unique_ptr<CommonStepInCtld>> pending_step_ptr_vec;
   HashMap<CranedId, std::unordered_map<job_id_t, std::set<step_id_t>>>
-      running_task_craned_id_map;
+      running_job_craned_id_map;
 
-  size_t actual_size = m_cancel_task_queue_.try_dequeue_bulk(
-      tasks_to_cancel.begin(), approximate_size);
+  size_t actual_size = m_cancel_job_queue_.try_dequeue_bulk(
+      jobs_to_cancel.begin(), approximate_size);
 
-  // To cancel a task, there is two cases:
-  // For pending task, we just need to set the task status to Cancelled.
-  // For running task, we need to send a TerminateTasks RPC to the craned.
-  for (auto& elem : tasks_to_cancel) {
+  // To cancel a job, there is two cases:
+  // For pending job, we just need to set the job status to Cancelled.
+  // For running job, we need to send a TerminateJobs RPC to the craned.
+  for (auto& elem : jobs_to_cancel) {
     std::visit(  //
         VariantVisitor{
-            [&](CancelPendingTaskQueueElem& pd_elem) {
-              pending_task_ptr_vec.emplace_back(std::move(pd_elem.task));
+            [&](CancelPendingJobQueueElem& pd_elem) {
+              pending_job_ptr_vec.emplace_back(std::move(pd_elem.job));
             },
-            [&](CancelRunningTaskQueueElem& rn_elem) {
-              running_task_craned_id_map[rn_elem.craned_id][rn_elem.job_id]
+            [&](CancelRunningJobQueueElem& rn_elem) {
+              running_job_craned_id_map[rn_elem.craned_id][rn_elem.job_id]
                   .insert(rn_elem.step_id);
             },
             [&](CancelPendingStepQueueElem& pd_step_elem) {
@@ -2935,25 +2935,25 @@ void TaskScheduler::CleanCancelQueueCb_() {
       absl::FromUnixSeconds(now.seconds()) + absl::Nanoseconds(now.nanos());
 
   // Process offline craned nodes with timeout check
-  for (auto&& [craned_id, steps] : running_task_craned_id_map) {
+  for (auto&& [craned_id, steps] : running_job_craned_id_map) {
     if (!g_meta_container->CheckCranedOnline(craned_id)) {
       for (auto [job_id, step_ids] : steps) {
-        // Check if the task has exceeded time limit
+        // Check if the job has exceeded time limit
         google::protobuf::Timestamp end_timestamp = now;
 
         {
-          LockGuard running_guard_for_cancel(&m_running_task_map_mtx_);
-          auto job_it = m_running_task_map_.find(job_id);
-          if (job_it != m_running_task_map_.end()) {
-            TaskInCtld* job = job_it->second.get();
+          LockGuard running_guard_for_cancel(&m_running_job_map_mtx_);
+          auto job_it = m_running_job_map_.find(job_id);
+          if (job_it != m_running_job_map_.end()) {
+            JobInCtld* job = job_it->second.get();
             absl::Time timeout_time = job->StartTime() + job->time_limit;
 
-            // If task exceeded time limit, use timeout time as end_time
+            // If job exceeded time limit, use timeout time as end_time
             if (current_time > timeout_time) {
               end_timestamp.set_seconds(ToUnixSeconds(timeout_time));
               end_timestamp.set_nanos(0);
               CRANE_DEBUG(
-                  "[Job #{}] Task exceeded time limit during craned {} "
+                  "[Job #{}] Job exceeded time limit during craned {} "
                   "offline. "
                   "Using timeout time {} as end_time instead of cancel time "
                   "{}.",
@@ -2965,7 +2965,7 @@ void TaskScheduler::CleanCancelQueueCb_() {
 
         for (auto step_id : step_ids)
           StepStatusChangeAsync(job_id, step_id, craned_id,
-                                crane::grpc::TaskStatus::Cancelled,
+                                crane::grpc::JobStatus::Cancelled,
                                 ExitCode::EC_TERMINATED, "", end_timestamp);
       }
       continue;
@@ -2981,47 +2981,47 @@ void TaskScheduler::CleanCancelQueueCb_() {
 
   absl::Time cancel_time = absl::Now();
 
-  if (!pending_task_ptr_vec.empty()) {
-    for (auto& task : pending_task_ptr_vec) {
-      task->SetStatus(crane::grpc::Cancelled);
-      task->SetStartTime(cancel_time);
-      task->SetEndTime(cancel_time);
-      g_account_meta_container->FreeQosSubmitResource(*task);
+  if (!pending_job_ptr_vec.empty()) {
+    for (auto& job : pending_job_ptr_vec) {
+      job->SetStatus(crane::grpc::Cancelled);
+      job->SetStartTime(cancel_time);
+      job->SetEndTime(cancel_time);
+      g_account_meta_container->FreeQosSubmitResource(*job);
 
-      task->TriggerDependencyEvents(crane::grpc::DependencyType::AFTER,
+      job->TriggerDependencyEvents(crane::grpc::DependencyType::AFTER,
                                     cancel_time);
-      task->TriggerDependencyEvents(crane::grpc::DependencyType::AFTER_ANY,
+      job->TriggerDependencyEvents(crane::grpc::DependencyType::AFTER_ANY,
                                     cancel_time);
-      task->TriggerDependencyEvents(crane::grpc::AFTER_OK,
+      job->TriggerDependencyEvents(crane::grpc::AFTER_OK,
                                     absl::InfiniteFuture());
-      task->TriggerDependencyEvents(crane::grpc::AFTER_NOT_OK,
+      job->TriggerDependencyEvents(crane::grpc::AFTER_NOT_OK,
                                     absl::InfiniteFuture());
 
-      if (task->type == crane::grpc::Interactive) {
-        auto& meta = std::get<InteractiveMeta>(task->meta);
+      if (job->type == crane::grpc::Interactive) {
+        auto& meta = std::get<InteractiveMeta>(job->meta);
         // Cancel request may not come from crun/calloc but from ccancel,
         // ask them to exit
         if (!meta.has_been_cancelled_on_front_end) {
           meta.has_been_cancelled_on_front_end = true;
           g_thread_pool->detach_task(
-              [cb = meta.cb_step_cancel, job_id = task->TaskId(),
+              [cb = meta.cb_step_cancel, job_id = job->JobId(),
                step_id = kPrimaryStepId] { cb({job_id, step_id}); });
         } else {
           // Cancel request from crun/calloc, reply CompletionAck
           g_thread_pool->detach_task(
               [cb = meta.cb_step_completed, cfored = meta.cfored_name,
-               job_id = task->TaskId(), step_id = kPrimaryStepId] {
+               job_id = job->JobId(), step_id = kPrimaryStepId] {
                 cb({job_id, step_id, true, cfored});
               });
         }
       }
     }
 
-    std::unordered_set<TaskInCtld*> pd_task_raw_ptrs;
+    std::unordered_set<JobInCtld*> pd_job_raw_ptrs;
 
-    for (auto& task : pending_task_ptr_vec)
-      pd_task_raw_ptrs.emplace(task.get());
-    ProcessFinalTasks_(pd_task_raw_ptrs);
+    for (auto& job : pending_job_ptr_vec)
+      pd_job_raw_ptrs.emplace(job.get());
+    ProcessFinalJobs_(pd_job_raw_ptrs);
   }
 
   if (pending_step_ptr_vec.empty()) return;
@@ -3061,31 +3061,31 @@ void TaskScheduler::CleanCancelQueueCb_() {
   ProcessFinalSteps_(pd_step_raw_ptrs);
 }
 
-void TaskScheduler::SubmitTaskTimerCb_() {
-  m_clean_submit_queue_handle_->send();
+void JobScheduler::SubmitJobTimerCb_() {
+  m_clean_submit_job_queue_handle_->send();
 }
 
-void TaskScheduler::SubmitTaskAsyncCb_() {
-  if (m_submit_task_queue_.size_approx() >= kSubmitTaskBatchNum)
-    m_clean_submit_queue_handle_->send();
+void JobScheduler::SubmitJobAsyncCb_() {
+  if (m_submit_job_queue_.size_approx() >= kSubmitJobBatchNum)
+    m_clean_submit_job_queue_handle_->send();
 }
 
-void TaskScheduler::CleanSubmitQueueCb_() {
-  using SubmitQueueElem = std::pair<std::unique_ptr<TaskInCtld>,
-                                    std::promise<CraneExpected<task_id_t>>>;
+void JobScheduler::CleanSubmitJobQueueCb_() {
+  using SubmitQueueElem = std::pair<std::unique_ptr<JobInCtld>,
+                                    std::promise<CraneExpected<job_id_t>>>;
 
   // It's ok to use an approximate size.
-  size_t approximate_size = m_submit_task_queue_.size_approx();
+  size_t approximate_size = m_submit_job_queue_.size_approx();
 
-  std::vector<SubmitQueueElem> accepted_tasks;
-  std::vector<TaskInCtld*> accepted_task_ptrs;
-  std::vector<SubmitQueueElem> rejected_tasks;
+  std::vector<SubmitQueueElem> accepted_jobs;
+  std::vector<JobInCtld*> accepted_job_ptrs;
+  std::vector<SubmitQueueElem> rejected_jobs;
 
   size_t map_size = m_pending_map_cached_size_.load(std::memory_order_acquire);
   size_t accepted_size;
   size_t rejected_size;
 
-  if (g_config.RejectTasksBeyondCapacity) {
+  if (g_config.RejectJobsBeyondCapacity) {
     accepted_size =
         std::min(approximate_size, g_config.PendingQueueMaxSize - map_size);
     rejected_size = approximate_size - accepted_size;
@@ -3097,30 +3097,30 @@ void TaskScheduler::CleanSubmitQueueCb_() {
   size_t accepted_actual_size;
   size_t rejected_actual_size;
 
-  // Accept tasks within queue capacity.
+  // Accept jobs within queue capacity.
   do {
     if (accepted_size == 0) break;
-    accepted_tasks.resize(accepted_size);
+    accepted_jobs.resize(accepted_size);
 
-    accepted_actual_size = m_submit_task_queue_.try_dequeue_bulk(
-        accepted_tasks.begin(), accepted_size);
+    accepted_actual_size = m_submit_job_queue_.try_dequeue_bulk(
+        accepted_jobs.begin(), accepted_size);
     if (accepted_actual_size == 0) break;
 
-    accepted_task_ptrs.reserve(accepted_actual_size);
+    accepted_job_ptrs.reserve(accepted_actual_size);
 
     // The order of element inside the bulk is reverse.
-    for (uint32_t i = 0; i < accepted_tasks.size(); i++) {
-      uint32_t pos = accepted_tasks.size() - 1 - i;
-      auto* task = accepted_tasks[pos].first.get();
-      // Add the task to the pending task queue.
-      task->SetStatus(crane::grpc::Pending);
-      accepted_task_ptrs.emplace_back(task);
+    for (uint32_t i = 0; i < accepted_jobs.size(); i++) {
+      uint32_t pos = accepted_jobs.size() - 1 - i;
+      auto* job = accepted_jobs[pos].first.get();
+      // Add the job to the pending job queue.
+      job->SetStatus(crane::grpc::Pending);
+      accepted_job_ptrs.emplace_back(job);
     }
 
-    if (!g_embedded_db_client->AppendTasksToPendingAndAdvanceTaskIds(
-            accepted_task_ptrs)) {
-      CRANE_ERROR("Failed to append a batch of tasks to embedded db queue.");
-      for (auto& pair : accepted_tasks) {
+    if (!g_embedded_db_client->AppendJobsToPendingAndAdvanceJobIds(
+            accepted_job_ptrs)) {
+      CRANE_ERROR("Failed to append a batch of jobs to embedded db queue.");
+      for (auto& pair : accepted_jobs) {
         g_account_meta_container->FreeQosSubmitResource(*pair.first);
         pair.second /*promise*/.set_value(
             std::unexpected(CraneErrCode::ERR_DB_INSERT_FAILED));
@@ -3128,21 +3128,21 @@ void TaskScheduler::CleanSubmitQueueCb_() {
       break;
     }
 
-    m_pending_task_map_mtx_.Lock();
+    m_pending_job_map_mtx_.Lock();
 
-    std::unordered_map<job_id_t, task_db_id_t> tasks_to_purge;
+    std::unordered_map<job_id_t, job_db_id_t> jobs_to_purge;
 
-    for (uint32_t i = 0; i < accepted_tasks.size(); i++) {
-      uint32_t pos = accepted_tasks.size() - 1 - i;
-      task_id_t id = accepted_tasks[pos].first->TaskId();
-      auto& task_id_promise = accepted_tasks[pos].second;
-      auto* job = accepted_tasks[pos].first.get();
-      std::vector<std::pair<crane::grpc::DependencyType, task_id_t>>
+    for (uint32_t i = 0; i < accepted_jobs.size(); i++) {
+      uint32_t pos = accepted_jobs.size() - 1 - i;
+      job_id_t id = accepted_jobs[pos].first->JobId();
+      auto& job_id_promise = accepted_jobs[pos].second;
+      auto* job = accepted_jobs[pos].first.get();
+      std::vector<std::pair<crane::grpc::DependencyType, job_id_t>>
           running_deps;
       for (const auto& [dep_job_id, dep_info] : job->Dependencies().deps) {
         const auto& [dep_type, delay_seconds] = dep_info;
-        auto dep_job_it = m_pending_task_map_.find(dep_job_id);
-        if (dep_job_it != m_pending_task_map_.end()) {
+        auto dep_job_it = m_pending_job_map_.find(dep_job_id);
+        if (dep_job_it != m_pending_job_map_.end()) {
           dep_job_it->second->AddDependent(dep_type, id);
           continue;
         }
@@ -3151,10 +3151,10 @@ void TaskScheduler::CleanSubmitQueueCb_() {
       if (!running_deps.empty()) {
         bool missing_deps = false;
         {
-          LockGuard running_guard(&m_running_task_map_mtx_);
+          LockGuard running_guard(&m_running_job_map_mtx_);
           for (const auto& [dep_type, dep_job_id] : running_deps) {
-            auto dep_job_it = m_running_task_map_.find(dep_job_id);
-            if (dep_job_it != m_running_task_map_.end()) {
+            auto dep_job_it = m_running_job_map_.find(dep_job_id);
+            if (dep_job_it != m_running_job_map_.end()) {
               dep_job_it->second->AddDependent(dep_type, id);
             } else {
               missing_deps = true;
@@ -3165,59 +3165,59 @@ void TaskScheduler::CleanSubmitQueueCb_() {
         if (missing_deps) {
           CRANE_WARN("Job #{} rejected: missing dependencies.", id);
           g_account_meta_container->FreeQosSubmitResource(*job);
-          task_id_promise.set_value(
+          job_id_promise.set_value(
               std::unexpected(CraneErrCode::ERR_MISSING_DEPENDENCY));
-          tasks_to_purge[id] = job->TaskDbId();
+          jobs_to_purge[id] = job->JobDbId();
           continue;
         }
       }
 
-      m_pending_task_map_.emplace(id, std::move(accepted_tasks[pos].first));
-      task_id_promise.set_value(id);
+      m_pending_job_map_.emplace(id, std::move(accepted_jobs[pos].first));
+      job_id_promise.set_value(id);
     }
 
-    m_pending_map_cached_size_.store(m_pending_task_map_.size(),
+    m_pending_map_cached_size_.store(m_pending_job_map_.size(),
                                      std::memory_order_release);
-    m_pending_task_map_mtx_.Unlock();
+    m_pending_job_map_mtx_.Unlock();
 
-    if (!tasks_to_purge.empty()) {
-      if (!g_embedded_db_client->PurgeEndedTasks(tasks_to_purge)) {
+    if (!jobs_to_purge.empty()) {
+      if (!g_embedded_db_client->PurgeEndedJobs(jobs_to_purge)) {
         CRANE_ERROR(
-            "Failed to purge {} task(s) with missing dependencies from "
+            "Failed to purge {} job(s) with missing dependencies from "
             "embedded db.",
-            tasks_to_purge.size());
+            jobs_to_purge.size());
       }
     }
   } while (false);
 
-  // Reject tasks beyond queue capacity
+  // Reject jobs beyond queue capacity
   do {
     if (rejected_size == 0) break;
-    rejected_tasks.resize(rejected_size);
+    rejected_jobs.resize(rejected_size);
 
-    rejected_actual_size = m_submit_task_queue_.try_dequeue_bulk(
-        rejected_tasks.begin(), rejected_size);
+    rejected_actual_size = m_submit_job_queue_.try_dequeue_bulk(
+        rejected_jobs.begin(), rejected_size);
     if (rejected_actual_size == 0) break;
 
-    CRANE_TRACE("Rejecting {} tasks...", rejected_actual_size);
+    CRANE_TRACE("Rejecting {} jobs...", rejected_actual_size);
     for (size_t i = 0; i < rejected_actual_size; i++) {
-      g_account_meta_container->FreeQosSubmitResource(*rejected_tasks[i].first);
-      rejected_tasks[i].second.set_value(
-          std::unexpected(CraneErrCode::ERR_BEYOND_TASK_ID));
+      g_account_meta_container->FreeQosSubmitResource(*rejected_jobs[i].first);
+      rejected_jobs[i].second.set_value(
+          std::unexpected(CraneErrCode::ERR_BEYOND_JOB_ID));
     }
   } while (false);
 }
 
-void TaskScheduler::SubmitStepTimerCb_() {
+void JobScheduler::SubmitStepTimerCb_() {
   m_clean_step_submit_queue_handle_->send();
 }
 
-void TaskScheduler::SubmitStepAsyncCb_() {
-  if (m_submit_step_queue_.size_approx() >= kSubmitTaskBatchNum)
+void JobScheduler::SubmitStepAsyncCb_() {
+  if (m_submit_step_queue_.size_approx() >= kSubmitJobBatchNum)
     m_clean_step_submit_queue_handle_->send();
 }
 
-void TaskScheduler::CleanStepSubmitQueueCb_() {
+void JobScheduler::CleanStepSubmitQueueCb_() {
   using SubmitQueueElem = std::pair<std::unique_ptr<CommonStepInCtld>,
                                     std::promise<CraneExpected<step_id_t>>>;
 
@@ -3243,13 +3243,13 @@ void TaskScheduler::CleanStepSubmitQueueCb_() {
   std::vector<std::pair<std::unique_ptr<StepInCtld>,
                         std::promise<CraneExpected<step_id_t>>>>
       valid_steps;
-  absl::MutexLock lk(&m_running_task_map_mtx_);
+  absl::MutexLock lk(&m_running_job_map_mtx_);
   auto now = absl::Now();
   for (uint32_t i = 0; i < elems.size(); i++) {
     uint32_t pos = elems.size() - 1 - i;
     auto& step = elems[pos].first;
-    auto it = m_running_task_map_.find(step->job_id);
-    if (it != m_running_task_map_.end()) {
+    auto it = m_running_job_map_.find(step->job_id);
+    if (it != m_running_job_map_.end()) {
       step->job = it->second.get();
       step->SetSubmitTime(now);
       auto err = AcquireStepAttributes(step.get());
@@ -3293,7 +3293,7 @@ void TaskScheduler::CleanStepSubmitQueueCb_() {
   }
 }
 
-void TaskScheduler::StartCraneCtldPrologThread(TaskInCtld* job) {
+void JobScheduler::StartCraneCtldPrologThread(JobInCtld* job) {
   // CraneCtldProlog runs during the DaemonStep Configuring phase, in parallel
   // with craned node configuration. The DaemonStep's Configuring->Running
   // transition is gated on both AllNodesConfigured() and PrologComplete().
@@ -3303,7 +3303,7 @@ void TaskScheduler::StartCraneCtldPrologThread(TaskInCtld* job) {
     // TODO: cbatch job must be requeue
     job->DaemonStep()->SetCtldPrologPending(true);
     g_thread_pool->detach_task(
-        [this, job_id = job->TaskId(), env = job->env]() {
+        [this, job_id = job->JobId(), env = job->env]() {
           // run prolog ctld script
           RunPrologEpilogArgs run_prolog_args{
               .scripts = g_config.JobLifecycleHook.CranectldPrologs,
@@ -3329,48 +3329,48 @@ void TaskScheduler::StartCraneCtldPrologThread(TaskInCtld* job) {
                         job_id, status.exit_code, status.signal_num);
             this->StepStatusChangeAsync(
                 job_id, kDaemonStepId, kCtldPrologInternalNodeIndex,
-                crane::grpc::TaskStatus::Cancelled, ExitCode::EC_PROLOG_ERR,
+                crane::grpc::JobStatus::Cancelled, ExitCode::EC_PROLOG_ERR,
                 "CraneCtldPrologError", now);
           } else {
             CRANE_DEBUG("[Job #{}]: CraneCtldProlog success", job_id);
             this->StepStatusChangeAsync(
                 job_id, kDaemonStepId, kCtldPrologInternalNodeIndex,
-                crane::grpc::TaskStatus::Running, 0, "", now);
+                crane::grpc::JobStatus::Running, 0, "", now);
           }
         });
   }
 }
 
-void TaskScheduler::StepStatusChangeAsync(
+void JobScheduler::StepStatusChangeAsync(
     job_id_t job_id, step_id_t step_id, const CranedId& craned_index,
-    crane::grpc::TaskStatus new_status, uint32_t exit_code, std::string reason,
+    crane::grpc::JobStatus new_status, uint32_t exit_code, std::string reason,
     google::protobuf::Timestamp timestamp) {
-  m_task_status_change_queue_.enqueue({.job_id = job_id,
+  m_job_status_change_queue_.enqueue({.job_id = job_id,
                                        .step_id = step_id,
                                        .exit_code = exit_code,
                                        .new_status = new_status,
                                        .craned_index = craned_index,
                                        .reason = std::move(reason),
                                        .timestamp = std::move(timestamp)});
-  m_task_status_change_async_handle_->send();
+  m_job_status_change_async_handle_->send();
 }
 
-void TaskScheduler::TaskStatusChangeTimerCb_() {
-  m_clean_task_status_change_handle_->send();
+void JobScheduler::JobStatusChangeTimerCb_() {
+  m_clean_job_status_change_handle_->send();
 }
 
-void TaskScheduler::TaskStatusChangeAsyncCb_() {
-  if (m_task_status_change_queue_.size_approx() >= kTaskStatusChangeBatchNum)
-    m_clean_task_status_change_handle_->send();
+void JobScheduler::JobStatusChangeAsyncCb_() {
+  if (m_job_status_change_queue_.size_approx() >= kJobStatusChangeBatchNum)
+    m_clean_job_status_change_handle_->send();
 }
 
-void TaskScheduler::CleanTaskStatusChangeQueueCb_() {
-  size_t approximate_size = m_task_status_change_queue_.size_approx();
+void JobScheduler::CleanJobStatusChangeQueueCb_() {
+  size_t approximate_size = m_job_status_change_queue_.size_approx();
 
-  std::vector<TaskStatusChangeArg> args;
+  std::vector<JobStatusChangeArg> args;
   args.resize(approximate_size);
 
-  size_t actual_size = m_task_status_change_queue_.try_dequeue_bulk(
+  size_t actual_size = m_job_status_change_queue_.try_dequeue_bulk(
       args.begin(), approximate_size);
   if (actual_size == 0) return;
   args.resize(actual_size);
@@ -3385,104 +3385,104 @@ void TaskScheduler::CleanTaskStatusChangeQueueCb_() {
   context.job_raw_ptrs.reserve(actual_size);
   context.rn_job_raw_ptrs.reserve(actual_size);
 
-  LockGuard running_guard(&m_running_task_map_mtx_);
-  LockGuard indexes_guard(&m_task_indexes_mtx_);
+  LockGuard running_guard(&m_running_job_map_mtx_);
+  LockGuard indexes_guard(&m_job_indexes_mtx_);
 
-  for (const auto& [task_id, step_id, exit_code, new_status, craned_index,
+  for (const auto& [job_id, step_id, exit_code, new_status, craned_index,
                     reason, timestamp] : args) {
-    auto iter = m_running_task_map_.find(task_id);
-    if (iter == m_running_task_map_.end()) {
+    auto iter = m_running_job_map_.find(job_id);
+    if (iter == m_running_job_map_.end()) {
       CRANE_WARN(
-          "[Job #{}] Ignoring unknown job in CleanTaskStatusChangeQueueCb_ "
+          "[Job #{}] Ignoring unknown job in CleanJobStatusChangeQueueCb_ "
           "(status: {}).",
-          task_id, util::StepStatusToString(new_status));
+          job_id, util::StepStatusToString(new_status));
       continue;
     }
 
     // Free job allocation
-    std::optional<std::pair<crane::grpc::TaskStatus, uint32_t /*exit code*/>>
+    std::optional<std::pair<crane::grpc::JobStatus, uint32_t /*exit code*/>>
         job_finished_status{std::nullopt};
 
-    std::unique_ptr<TaskInCtld>& task = iter->second;
-    if (task->DaemonStep() != nullptr &&
-        step_id == task->DaemonStep()->StepId()) {
+    std::unique_ptr<JobInCtld>& job = iter->second;
+    if (job->DaemonStep() != nullptr &&
+        step_id == job->DaemonStep()->StepId()) {
       CRANE_TRACE(
           "[Step #{}.{}] Daemon step status change received, status: {}.",
-          task->TaskId(), step_id, new_status);
-      auto* step = task->DaemonStep();
+          job->JobId(), step_id, new_status);
+      auto* step = job->DaemonStep();
       job_finished_status = step->StepStatusChange(
           new_status, exit_code, reason, craned_index, timestamp, &context);
     } else {
-      CommonStepInCtld* step = task->GetStep(step_id);
+      CommonStepInCtld* step = job->GetStep(step_id);
       if (step == nullptr) {
-        CRANE_WARN("[Step #{}.{}] Ignoring unknown step in TaskStatusChange.",
-                   task_id, step_id);
+        CRANE_WARN("[Step #{}.{}] Ignoring unknown step in StepStatusChange.",
+                   job_id, step_id);
         continue;
       }
       CRANE_TRACE("[Step #{}.{}] Step status change received, status: {}.",
-                  task_id, step_id, new_status);
+                  job_id, step_id, new_status);
       job_finished_status = step->StepStatusChange(
           new_status, exit_code, reason, craned_index, timestamp, &context);
     }
 
     if (job_finished_status.has_value()) {
-      CRANE_TRACE("[Job #{}] Completed with status {}.", task_id,
+      CRANE_TRACE("[Job #{}] Completed with status {}.", job_id,
                   job_finished_status.value());
-      task->SetStatus(job_finished_status.value().first);
-      task->SetExitCode(job_finished_status.value().second);
+      job->SetStatus(job_finished_status.value().first);
+      job->SetExitCode(job_finished_status.value().second);
 
       // Validate and adjust end_time to prevent it from exceeding time_limit
       // by too much. Allow 5 seconds of floating tolerance.
       absl::Time end_time = absl::FromUnixSeconds(timestamp.seconds()) +
                             absl::Nanoseconds(timestamp.nanos());
-      absl::Time expected_end_time = task->StartTime() + task->time_limit;
+      absl::Time expected_end_time = job->StartTime() + job->time_limit;
 
       if (end_time > expected_end_time + absl::Seconds(kEndTimeToleranceSec)) {
         CRANE_WARN(
             "[Job #{}] Reported end_time {} exceeds expected end_time {} by "
             "more than {}s. Adjusting to expected end_time.",
-            task->TaskId(), absl::FormatTime(end_time),
+            job->JobId(), absl::FormatTime(end_time),
             absl::FormatTime(expected_end_time), kEndTimeToleranceSec);
         end_time = expected_end_time;
       }
-      task->SetEndTime(end_time);
+      job->SetEndTime(end_time);
 
-      uint32_t task_exit_code = job_finished_status.value().second;
-      task->TriggerDependencyEvents(crane::grpc::DependencyType::AFTER_ANY,
+      uint32_t job_exit_code = job_finished_status.value().second;
+      job->TriggerDependencyEvents(crane::grpc::DependencyType::AFTER_ANY,
                                     end_time);
-      task->TriggerDependencyEvents(
+      job->TriggerDependencyEvents(
           crane::grpc::DependencyType::AFTER_OK,
-          task_exit_code == 0 ? end_time : absl::InfiniteFuture());
-      task->TriggerDependencyEvents(
+          job_exit_code == 0 ? end_time : absl::InfiniteFuture());
+      job->TriggerDependencyEvents(
           crane::grpc::DependencyType::AFTER_NOT_OK,
-          task_exit_code != 0 ? end_time : absl::InfiniteFuture());
+          job_exit_code != 0 ? end_time : absl::InfiniteFuture());
 
-      for (CranedId const& craned_id : task->CranedIds()) {
-        auto node_to_task_map_it = m_node_to_tasks_map_.find(craned_id);
-        if (node_to_task_map_it == m_node_to_tasks_map_.end()) [[unlikely]] {
-          CRANE_ERROR("Failed to find craned_id {} in m_node_to_tasks_map_",
+      for (CranedId const& craned_id : job->CranedIds()) {
+        auto node_to_job_map_it = m_node_to_jobs_map_.find(craned_id);
+        if (node_to_job_map_it == m_node_to_jobs_map_.end()) [[unlikely]] {
+          CRANE_ERROR("Failed to find craned_id {} in m_node_to_jobs_map_",
                       craned_id);
         } else {
-          node_to_task_map_it->second.erase(task_id);
-          if (node_to_task_map_it->second.empty()) {
-            m_node_to_tasks_map_.erase(node_to_task_map_it);
+          node_to_job_map_it->second.erase(job_id);
+          if (node_to_job_map_it->second.empty()) {
+            m_node_to_jobs_map_.erase(node_to_job_map_it);
           }
         }
       }
 
-      for (CranedId const& craned_id : task->CranedIds()) {
-        g_meta_container->FreeResourceFromNode(craned_id, task_id);
+      for (CranedId const& craned_id : job->CranedIds()) {
+        g_meta_container->FreeResourceFromNode(craned_id, job_id);
       }
-      if (task->reservation != "")
-        g_meta_container->FreeResourceFromResv(task->reservation,
-                                               task->TaskId());
-      g_account_meta_container->FreeQosResource(*task);
-      if (!task->licenses_count.empty())
-        g_licenses_manager->FreeLicense(task->licenses_count);
+      if (job->reservation != "")
+        g_meta_container->FreeResourceFromResv(job->reservation,
+                                               job->JobId());
+      g_account_meta_container->FreeQosResource(*job);
+      if (!job->licenses_count.empty())
+        g_licenses_manager->FreeLicense(job->licenses_count);
 
       if (!g_config.JobLifecycleHook.CranectldEpilogs.empty()) {
         g_thread_pool->detach_task(
-            [job_id = task->TaskId(), env_copy = task->env]() {
+            [job_id = job->JobId(), env_copy = job->env]() {
               RunPrologEpilogArgs run_epilog_ctld_args{
                   .scripts = g_config.JobLifecycleHook.CranectldEpilogs,
                   .envs = env_copy,
@@ -3508,14 +3508,14 @@ void TaskScheduler::CleanTaskStatusChangeQueueCb_() {
             });
       }
 
-      context.job_raw_ptrs.insert(task.get());
-      context.job_ptrs.emplace(std::move(task));
+      context.job_raw_ptrs.insert(job.get());
+      context.job_ptrs.emplace(std::move(job));
 
-      // As for now, task status change includes only
+      // As for now, job status change includes only
       // Pending / Running -> Completed / Failed / Cancelled.
-      // It means all task status changes will put the task into mongodb,
+      // It means all job status changes will put the job into mongodb,
       // so we don't have any branch code here and just put it into mongodb.
-      m_running_task_map_.erase(iter);
+      m_running_job_map_.erase(iter);
     }
   }
 
@@ -3532,7 +3532,7 @@ void TaskScheduler::CleanTaskStatusChangeQueueCb_() {
             stub->AllocSteps(context.craned_step_alloc_map.at(craned_id));
         if (err != CraneErrCode::SUCCESS) {
           CRANE_ERROR(
-              "Failed to AllocSteps for [{}] tasks on Node {}: Rpc failure",
+              "Failed to AllocSteps for [{}] jobs on Node {}: Rpc failure",
               absl::StrJoin(context.craned_step_alloc_map.at(craned_id) |
                                 std::views::transform(
                                     [](const crane::grpc::StepToD& step) {
@@ -3544,7 +3544,7 @@ void TaskScheduler::CleanTaskStatusChangeQueueCb_() {
         }
       } else {
         CRANE_ERROR(
-            "Failed to AllocSteps for [{}] tasks on Node {}: Craned down",
+            "Failed to AllocSteps for [{}] jobs on Node {}: Craned down",
             absl::StrJoin(
                 context.craned_step_alloc_map.at(craned_id) |
                     std::views::transform([](const crane::grpc::StepToD& step) {
@@ -3557,7 +3557,7 @@ void TaskScheduler::CleanTaskStatusChangeQueueCb_() {
         for (const auto& steps : context.craned_step_alloc_map.at(craned_id)) {
           StepStatusChangeWithReasonAsync(
               steps.job_id(), steps.step_id(), craned_id,
-              crane::grpc::TaskStatus::Failed, ExitCode::EC_CRANED_DOWN,
+              crane::grpc::JobStatus::Failed, ExitCode::EC_CRANED_DOWN,
               "CranedDown", now);
         }
       }
@@ -3607,7 +3607,7 @@ void TaskScheduler::CleanTaskStatusChangeQueueCb_() {
           for (const auto& [job_id, step_ids] : failed_steps.value()) {
             for (const auto& step_id : step_ids)
               StepStatusChangeWithReasonAsync(
-                  job_id, step_id, craned_id, crane::grpc::TaskStatus::Failed,
+                  job_id, step_id, craned_id, crane::grpc::JobStatus::Failed,
                   ExitCode::EC_RPC_ERR, "ExecRpcError", now);
           }
         }
@@ -3620,7 +3620,7 @@ void TaskScheduler::CleanTaskStatusChangeQueueCb_() {
              context.craned_step_exec_map.at(craned_id)) {
           for (const auto& step_id : step_ids)
             StepStatusChangeWithReasonAsync(
-                job_id, step_id, craned_id, crane::grpc::TaskStatus::Failed,
+                job_id, step_id, craned_id, crane::grpc::JobStatus::Failed,
                 ExitCode::EC_CRANED_DOWN, "CranedDown", now);
         }
       }
@@ -3642,7 +3642,7 @@ void TaskScheduler::CleanTaskStatusChangeQueueCb_() {
             auto err = stub->TerminateOrphanedSteps(steps);
             if (err != CraneErrCode::SUCCESS) {
               CRANE_ERROR(
-                  "Failed to TerminateOrphanedSteps for [{}] tasks on Node {}",
+                  "Failed to TerminateOrphanedSteps for [{}] jobs on Node {}",
                   util::JobStepsToString(steps), craned_id);
             }
           }
@@ -3662,7 +3662,7 @@ void TaskScheduler::CleanTaskStatusChangeQueueCb_() {
             const auto& steps = context.craned_cancel_steps.at(craned_id);
             auto err = stub->TerminateSteps(steps);
             if (err != CraneErrCode::SUCCESS) {
-              CRANE_ERROR("Failed to TerminateSteps for [{}] tasks on Node {}",
+              CRANE_ERROR("Failed to TerminateSteps for [{}] jobs on Node {}",
                           util::JobStepsToString(steps), craned_id);
             }
           }
@@ -3692,7 +3692,7 @@ void TaskScheduler::CleanTaskStatusChangeQueueCb_() {
         auto now = google::protobuf::util::TimeUtil::GetCurrentTime();
         for (const auto& job_id : context.craned_jobs_to_free.at(craned_id)) {
           StepStatusChangeWithReasonAsync(
-              job_id, kDaemonStepId, craned_id, crane::grpc::TaskStatus::Failed,
+              job_id, kDaemonStepId, craned_id, crane::grpc::JobStatus::Failed,
               ExitCode::EC_RPC_ERR, "Rpc failure when free job", now);
         }
       }
@@ -3714,7 +3714,7 @@ void TaskScheduler::CleanTaskStatusChangeQueueCb_() {
   auto ok = g_embedded_db_client->BeginStepVarDbTransaction(&txn_id);
   if (!ok) {
     CRANE_ERROR(
-        "TaskScheduler failed to start step transaction when clean step status "
+        "JobScheduler failed to start step transaction when clean step status "
         "change");
   }
   // Steps will update in embedded db
@@ -3727,7 +3727,7 @@ void TaskScheduler::CleanTaskStatusChangeQueueCb_() {
   ok = g_embedded_db_client->CommitStepVarDbTransaction(txn_id);
   if (!ok) {
     CRANE_ERROR(
-        "TaskScheduler failed to commit step transaction when clean step "
+        "JobScheduler failed to commit step transaction when clean step "
         "status change.");
   }
   auto duration = std::chrono::steady_clock::now() - now;
@@ -3746,21 +3746,21 @@ void TaskScheduler::CleanTaskStatusChangeQueueCb_() {
   ok = g_embedded_db_client->BeginVariableDbTransaction(&txn_id);
   if (!ok) {
     CRANE_ERROR(
-        "TaskScheduler failed to start job transaction when clean step status "
+        "JobScheduler failed to start job transaction when clean step status "
         "change.");
   }
   // Jobs will update in embedded db
   for (auto* job : context.rn_job_raw_ptrs) {
-    if (!g_embedded_db_client->UpdateRuntimeAttrOfTask(txn_id, job->TaskDbId(),
+    if (!g_embedded_db_client->UpdateRuntimeAttrOfJob(txn_id, job->JobDbId(),
                                                        job->RuntimeAttr()))
-      CRANE_ERROR("[Job #{}] Failed to call UpdateRuntimeAttrOfTask()",
-                  job->TaskId());
+      CRANE_ERROR("[Job #{}] Failed to call UpdateRuntimeAttrOfJob()",
+                  job->JobId());
   }
 
   ok = g_embedded_db_client->CommitVariableDbTransaction(txn_id);
   if (!ok) {
     CRANE_ERROR(
-        "TaskScheduler failed to commit job transaction when clean  step "
+        "JobScheduler failed to commit job transaction when clean  step "
         "status change.");
   }
   duration = std::chrono::steady_clock::now() - now;
@@ -3768,10 +3768,10 @@ void TaskScheduler::CleanTaskStatusChangeQueueCb_() {
       "Persist job status changes to embedded db cost {} ms",
       std::chrono::duration_cast<std::chrono::milliseconds>(duration).count());
   now = std::chrono::steady_clock::now();
-  ProcessFinalTasks_(context.job_raw_ptrs);
+  ProcessFinalJobs_(context.job_raw_ptrs);
   duration = std::chrono::steady_clock::now() - now;
   CRANE_TRACE(
-      "ProcessFinalTasks_ took {} ms",
+      "ProcessFinalJobs_ took {} ms",
       std::chrono::duration_cast<std::chrono::milliseconds>(duration).count());
 
   auto end_time = std::chrono::steady_clock::now();
@@ -3781,13 +3781,13 @@ void TaskScheduler::CleanTaskStatusChangeQueueCb_() {
                   .count());
 }
 
-void TaskScheduler::QueryTasksInRam(
-    const crane::grpc::QueryTasksInfoRequest* request,
-    std::unordered_map<job_id_t, crane::grpc::TaskInfo>* job_info_map) {
+void JobScheduler::QueryJobsInRam(
+    const crane::grpc::QueryJobsInfoRequest* request,
+    std::unordered_map<job_id_t, crane::grpc::JobInfo>* job_info_map) {
   auto now = absl::Now();
 
-  auto task_rng_filter_time = [&](auto* job_ptr) {
-    TaskInCtld& job = *job_ptr;
+  auto job_rng_filter_time = [&](auto* job_ptr) {
+    JobInCtld& job = *job_ptr;
     bool has_submit_time_interval = request->has_filter_submit_time_interval();
     bool has_start_time_interval = request->has_filter_start_time_interval();
     bool has_end_time_interval = request->has_filter_end_time_interval();
@@ -3823,41 +3823,41 @@ void TaskScheduler::QueryTasksInRam(
   bool no_accounts_constraint = request->filter_accounts().empty();
   std::unordered_set<std::string> req_accounts(
       request->filter_accounts().begin(), request->filter_accounts().end());
-  auto task_rng_filter_account = [&](auto* job_ptr) {
-    TaskInCtld& job = *job_ptr;
+  auto job_rng_filter_account = [&](auto* job_ptr) {
+    JobInCtld& job = *job_ptr;
     return no_accounts_constraint || req_accounts.contains(job.account);
   };
 
   bool no_username_constraint = request->filter_users().empty();
   std::unordered_set<std::string> req_users(request->filter_users().begin(),
                                             request->filter_users().end());
-  auto task_rng_filter_username = [&](auto* job_ptr) {
-    TaskInCtld& job = *job_ptr;
+  auto job_rng_filter_username = [&](auto* job_ptr) {
+    JobInCtld& job = *job_ptr;
     return no_username_constraint || req_users.contains(job.Username());
   };
 
   bool no_qos_constraint = request->filter_qos().empty();
   std::unordered_set<std::string> req_qos(request->filter_qos().begin(),
                                           request->filter_qos().end());
-  auto task_rng_filter_qos = [&](auto* job_ptr) {
-    TaskInCtld& job = *job_ptr;
+  auto job_rng_filter_qos = [&](auto* job_ptr) {
+    JobInCtld& job = *job_ptr;
     return no_qos_constraint || req_qos.contains(job.qos);
   };
 
-  bool no_task_names_constraint = request->filter_task_names().empty();
-  std::unordered_set<std::string> req_task_names(
-      request->filter_task_names().begin(), request->filter_task_names().end());
-  auto task_rng_filter_name = [&](auto* job_ptr) {
-    TaskInCtld& job = *job_ptr;
-    return no_task_names_constraint ||
-           req_task_names.contains(job.TaskToCtld().name());
+  bool no_job_names_constraint = request->filter_job_names().empty();
+  std::unordered_set<std::string> req_job_names(
+      request->filter_job_names().begin(), request->filter_job_names().end());
+  auto job_rng_filter_name = [&](auto* job_ptr) {
+    JobInCtld& job = *job_ptr;
+    return no_job_names_constraint ||
+           req_job_names.contains(job.JobToCtld().name());
   };
 
   bool no_partitions_constraint = request->filter_partitions().empty();
   std::unordered_set<std::string> req_partitions(
       request->filter_partitions().begin(), request->filter_partitions().end());
-  auto task_rng_filter_partition = [&](auto* job_ptr) {
-    TaskInCtld& job = *job_ptr;
+  auto job_rng_filter_partition = [&](auto* job_ptr) {
+    JobInCtld& job = *job_ptr;
     return no_partitions_constraint ||
            req_partitions.contains(job.partition_id);
   };
@@ -3866,7 +3866,7 @@ void TaskScheduler::QueryTasksInRam(
   bool no_licenses_constraint = request->filter_licenses().empty();
   std::unordered_set<std::string> req_licenses(
       request->filter_licenses().begin(), request->filter_licenses().end());
-  auto task_rng_filter_licenses = [&](auto* job_ptr) {
+  auto job_rng_filter_licenses = [&](auto* job_ptr) {
     if (no_licenses_constraint) {
       return true;
     }
@@ -3885,27 +3885,27 @@ void TaskScheduler::QueryTasksInRam(
                                                       step_ids.steps().end());
   }
 
-  bool no_task_states_constraint = request->filter_states().empty();
-  std::unordered_set<int> req_task_states(request->filter_states().begin(),
+  bool no_job_states_constraint = request->filter_states().empty();
+  std::unordered_set<int> req_job_states(request->filter_states().begin(),
                                           request->filter_states().end());
-  auto task_rng_filter_state = [&](auto* job_ptr) {
-    TaskInCtld& job = *job_ptr;
-    return no_task_states_constraint ||
-           req_task_states.contains(job.RuntimeAttr().status());
+  auto job_rng_filter_state = [&](auto* job_ptr) {
+    JobInCtld& job = *job_ptr;
+    return no_job_states_constraint ||
+           req_job_states.contains(job.RuntimeAttr().status());
   };
 
-  bool no_task_types_constraint = request->filter_task_types().empty();
-  std::unordered_set<int> req_task_types(request->filter_task_types().begin(),
-                                         request->filter_task_types().end());
-  auto task_rng_filter_task_type = [&](auto* job_ptr) {
-    return no_task_types_constraint || req_task_types.contains(job_ptr->type);
+  bool no_job_types_constraint = request->filter_job_types().empty();
+  std::unordered_set<int> req_job_types(request->filter_job_types().begin(),
+                                         request->filter_job_types().end());
+  auto job_rng_filter_job_type = [&](auto* job_ptr) {
+    return no_job_types_constraint || req_job_types.contains(job_ptr->type);
   };
 
   bool no_nodename_list_constraint = request->filter_nodename_list().empty();
   std::unordered_set<std::string> req_nodename_list(
       request->filter_nodename_list().begin(),
       request->filter_nodename_list().end());
-  auto task_rng_filter_nodename_list = [&](auto* job_ptr) {
+  auto job_rng_filter_nodename_list = [&](auto* job_ptr) {
     if (no_nodename_list_constraint) return true;
     for (const auto& nodename : job_ptr->RuntimeAttr().craned_ids()) {
       if (req_nodename_list.contains(nodename)) return true;
@@ -3913,7 +3913,7 @@ void TaskScheduler::QueryTasksInRam(
     return false;
   };
 
-  size_t num_limit = request->num_limit() == 0 ? kDefaultQueryTaskNumLimit
+  size_t num_limit = request->num_limit() == 0 ? kDefaultQueryJobNumLimit
                                                : request->num_limit();
 
   auto append_step_fn = [&](auto* step_info_list, StepInCtld* step) {
@@ -3928,19 +3928,19 @@ void TaskScheduler::QueryTasksInRam(
   };
 
   auto append_fn = [&](auto* job_ptr) {
-    TaskInCtld& job = *job_ptr;
-    crane::grpc::TaskInfo job_info;
-    job.SetFieldsOfTaskInfo(&job_info);
+    JobInCtld& job = *job_ptr;
+    crane::grpc::JobInfo job_info;
+    job.SetFieldsOfJobInfo(&job_info);
 
     job_info.set_status(job.Status());
     job_info.mutable_elapsed_time()->set_seconds(
         ToInt64Seconds(now - job.StartTime()));
 
-    // Check if task has exceeded time limit
-    if (job.Status() == crane::grpc::TaskStatus::Running ||
-        job.Status() == crane::grpc::TaskStatus::Configuring) {
+    // Check if job has exceeded time limit
+    if (job.Status() == crane::grpc::JobStatus::Running ||
+        job.Status() == crane::grpc::JobStatus::Configuring) {
       if (job.StartTime() + job.time_limit < now) {
-        job_info.set_status(crane::grpc::TaskStatus::Completing);
+        job_info.set_status(crane::grpc::JobStatus::Completing);
         job_info.mutable_end_time()->set_seconds(
             ToUnixSeconds(job.StartTime() + job.time_limit));
         job_info.mutable_elapsed_time()->set_seconds(
@@ -3955,83 +3955,83 @@ void TaskScheduler::QueryTasksInRam(
     for (const auto& step : job.Steps() | std::views::values) {
       append_step_fn(proto_steps, step.get());
     }
-    job_info_map->emplace(job.TaskId(), std::move(job_info));
+    job_info_map->emplace(job.JobId(), std::move(job_info));
   };
 
-  auto joined_filters = ranges::views::filter(task_rng_filter_account) |
-                        ranges::views::filter(task_rng_filter_name) |
-                        ranges::views::filter(task_rng_filter_partition) |
-                        ranges::views::filter(task_rng_filter_state) |
-                        ranges::views::filter(task_rng_filter_username) |
-                        ranges::views::filter(task_rng_filter_time) |
-                        ranges::views::filter(task_rng_filter_qos) |
-                        ranges::views::filter(task_rng_filter_task_type) |
-                        ranges::views::filter(task_rng_filter_licenses) |
-                        ranges::views::filter(task_rng_filter_nodename_list) |
+  auto joined_filters = ranges::views::filter(job_rng_filter_account) |
+                        ranges::views::filter(job_rng_filter_name) |
+                        ranges::views::filter(job_rng_filter_partition) |
+                        ranges::views::filter(job_rng_filter_state) |
+                        ranges::views::filter(job_rng_filter_username) |
+                        ranges::views::filter(job_rng_filter_time) |
+                        ranges::views::filter(job_rng_filter_qos) |
+                        ranges::views::filter(job_rng_filter_job_type) |
+                        ranges::views::filter(job_rng_filter_licenses) |
+                        ranges::views::filter(job_rng_filter_nodename_list) |
                         ranges::views::take(num_limit);
 
-  auto get_job_ptr_by_id = [&](auto& job_id) -> TaskInCtld* {
+  auto get_job_ptr_by_id = [&](auto& job_id) -> JobInCtld* {
     {
-      auto job_it = m_pending_task_map_.find(job_id);
-      if (job_it != m_pending_task_map_.end()) {
+      auto job_it = m_pending_job_map_.find(job_id);
+      if (job_it != m_pending_job_map_.end()) {
         return job_it->second.get();
       }
     }
 
     {
-      auto job_it = m_running_task_map_.find(job_id);
-      if (job_it != m_running_task_map_.end()) {
+      auto job_it = m_running_job_map_.find(job_id);
+      if (job_it != m_running_job_map_.end()) {
         return job_it->second.get();
       }
     }
     return nullptr;
   };
 
-  auto pending_rng = m_pending_task_map_ | ranges::views::all;
-  auto running_rng = m_running_task_map_ | ranges::views::all;
+  auto pending_rng = m_pending_job_map_ | ranges::views::all;
+  auto running_rng = m_running_job_map_ | ranges::views::all;
   auto pd_r_rng = ranges::views::concat(pending_rng, running_rng);
 
-  ranges::any_view<TaskInCtld*, ranges::category::forward> filtered_job_rng =
+  ranges::any_view<JobInCtld*, ranges::category::forward> filtered_job_rng =
       req_steps | ranges::views::keys | ranges::views::common |
       ranges::views::transform(get_job_ptr_by_id) |
       ranges::views::filter([](auto* job_ptr) { return job_ptr != nullptr; });
 
-  ranges::any_view<TaskInCtld*, ranges::category::forward> all_job_rng =
+  ranges::any_view<JobInCtld*, ranges::category::forward> all_job_rng =
       pd_r_rng |
       ranges::views::transform([](auto& it) { return it.second.get(); }) |
       joined_filters;
 
-  ranges::any_view<TaskInCtld*, ranges::category::forward> id_filtered_job_rng =
+  ranges::any_view<JobInCtld*, ranges::category::forward> id_filtered_job_rng =
       no_ids_constraint ? all_job_rng : filtered_job_rng;
-  LockGuard pending_guard(&m_pending_task_map_mtx_);
-  LockGuard running_guard(&m_running_task_map_mtx_);
+  LockGuard pending_guard(&m_pending_job_map_mtx_);
+  LockGuard running_guard(&m_running_job_map_mtx_);
 
   ranges::for_each(id_filtered_job_rng, append_fn);
 }
 
-void TaskScheduler::QueryRnJobOnCtldForNodeConfig(
+void JobScheduler::QueryRnJobOnCtldForNodeConfig(
     const CranedId& craned_id, crane::grpc::ConfigureCranedRequest* req) {
-  LockGuard running_job_guard(&m_running_task_map_mtx_);
-  LockGuard indexes_guard(&m_task_indexes_mtx_);
+  LockGuard running_job_guard(&m_running_job_map_mtx_);
+  LockGuard indexes_guard(&m_job_indexes_mtx_);
 
-  auto it = m_node_to_tasks_map_.find(craned_id);
-  if (it == m_node_to_tasks_map_.end()) return;
+  auto it = m_node_to_jobs_map_.find(craned_id);
+  if (it == m_node_to_jobs_map_.end()) return;
 
   auto& job_steps = *req->mutable_job_steps();
   absl::Time now = absl::Now();
 
   for (const auto& job_id : it->second) {
-    auto job_it = m_running_task_map_.find(job_id);
-    if (job_it == m_running_task_map_.end()) continue;
+    auto job_it = m_running_job_map_.find(job_id);
+    if (job_it == m_running_job_map_.end()) continue;
 
-    TaskInCtld* job = job_it->second.get();
+    JobInCtld* job = job_it->second.get();
     auto* daemon_step = job->DaemonStep();
 
-    // Check if task has exceeded time limit during craned offline
-    if (job->Status() == crane::grpc::TaskStatus::Running &&
+    // Check if job has exceeded time limit during craned offline
+    if (job->Status() == crane::grpc::JobStatus::Running &&
         job->StartTime() + job->time_limit < now) {
       CRANE_INFO(
-          "[Job #{}] Task exceeded time limit during craned {} offline. "
+          "[Job #{}] Job exceeded time limit during craned {} offline. "
           "StartTime: {}, TimeLimit: {}s, Current: {}. "
           "State will be updated when craned reconnects.",
           job_id, craned_id, absl::FormatTime(job->StartTime()),
@@ -4061,23 +4061,23 @@ void TaskScheduler::QueryRnJobOnCtldForNodeConfig(
   }
 }
 
-void TaskScheduler::TerminateOrphanedSteps(
+void JobScheduler::TerminateOrphanedSteps(
     const std::unordered_map<job_id_t, std::set<step_id_t>>& steps,
     const CranedId& excluded_node) {
   CRANE_INFO("Terminate orphaned steps: [{}] synced by {}.",
              util::JobStepsToString(steps), excluded_node);
 
-  // Now we just terminate all job and task.
+  // Now we just terminate all jobs.
   std::unordered_map<CranedId,
                      std::unordered_map<job_id_t, std::set<step_id_t>>>
       craned_steps_map;
   {
-    LockGuard running_job_guard(&m_running_task_map_mtx_);
-    LockGuard indexes_guard(&m_task_indexes_mtx_);
+    LockGuard running_job_guard(&m_running_job_map_mtx_);
+    LockGuard indexes_guard(&m_job_indexes_mtx_);
     for (const auto& [job_id, step_ids] : steps) {
-      auto job_it = m_running_task_map_.find(job_id);
-      if (job_it == m_running_task_map_.end()) {
-        CRANE_WARN("Job {} not found in running task map.", job_id);
+      auto job_it = m_running_job_map_.find(job_id);
+      if (job_it == m_running_job_map_.end()) {
+        CRANE_WARN("Job {} not found in running job map.", job_id);
         continue;
       }
 
@@ -4168,9 +4168,9 @@ bool SchedulerAlgo::LocalScheduler::CalculateRunningNodesAndStartTime_(
        m_node_selector_->GetOrderedNodesSet() | std::views::values) {
     const auto& craned_id = node_state->craned_id;
     auto& time_avail_res_map = node_state->time_avail_res_map;
-    // Number of tasks is not less than map size.
-    // When condition is true, the craned has too many tasks.
-    if (time_avail_res_map.size() >= kAlgoMaxTaskNumPerNode) {
+    // Number of jobs is not less than map size.
+    // When condition is true, the craned has too many jobs.
+    if (time_avail_res_map.size() >= kAlgoMaxJobNumPerNode) {
       if constexpr (kAlgoTraceOutput) {
         CRANE_TRACE("Craned {} has too many jobs. Skipping this craned.",
                     craned_id);
@@ -4221,10 +4221,10 @@ bool SchedulerAlgo::LocalScheduler::CalculateRunningNodesAndStartTime_(
     }
 
     // Given N as the required number of nodes,
-    // all the nodes that is able to run the task at some time-point will be
+    // all the nodes that is able to run the job at some time-point will be
     // iterated and the first N nodes will be in the craned_ids_.
 
-    // Find all possible nodes that can run the task now.
+    // Find all possible nodes that can run the job now.
     if (job->exclusive) {
       bool satisfied = true;
       for (const auto& [time, res] : time_avail_res_map) {
@@ -4314,8 +4314,8 @@ bool SchedulerAlgo::LocalScheduler::CalculateRunningNodesAndStartTime_(
   if (topk_nodes_total.size() < job->node_num ||
       topk_ntasks_sum_total < job->ntasks) {
     CRANE_TRACE(
-        "Only {} nodes with {} tasks are available for job #{} but {} nodes "
-        "with {} tasks are required.",
+        "Only {} nodes with {} jobs are available for job #{} but {} nodes "
+        "with {} jobs are required.",
         topk_nodes_total.size(), topk_ntasks_sum_total, job->job_id,
         job->node_num, job->ntasks);
     return false;
@@ -4490,7 +4490,7 @@ void SchedulerAlgo::NodeSelect(
     for (const auto& job : running_jobs) {
       absl::Time end_time = std::max(
           job->end_time,
-          now + absl::Seconds(1));  // In case TaskStatusChange is delayed
+          now + absl::Seconds(1));  // In case StepStatusChange is delayed
       if (job->reservation.empty()) {
         for (auto& [craned_id, res] : job->allocated_res.EachNodeResMap()) {
           auto it = node_state_map.find(craned_id);
@@ -4547,7 +4547,7 @@ void SchedulerAlgo::NodeSelect(
 
   g_licenses_manager->CheckLicenseCountSufficient(&job_ptr_vec);
 
-  // Schedule pending tasks
+  // Schedule pending jobs
   // TODO: do it in parallel
   for (const auto& job : job_ptr_vec) {
     if (!job->reason.empty()) continue;
@@ -4624,13 +4624,13 @@ void SchedulerAlgo::NodeSelect(
   }
 }
 
-void TaskScheduler::ProcessFinalSteps_(
+void JobScheduler::ProcessFinalSteps_(
     std::unordered_set<StepInCtld*> const& steps) {
   PersistAndTransferStepsToMongodb_(steps);
-  // CallPluginHookForFinalTasks_(tasks);
+  // CallPluginHookForFinalJobs_(jobs);
 }
 
-void TaskScheduler::PersistAndTransferStepsToMongodb_(
+void JobScheduler::PersistAndTransferStepsToMongodb_(
     std::unordered_set<StepInCtld*> const& steps) {
   if (steps.empty()) return;
 
@@ -4645,78 +4645,78 @@ void TaskScheduler::PersistAndTransferStepsToMongodb_(
 
   g_embedded_db_client->CommitStepVarDbTransaction(txn_id);
 
-  // Now tasks are in MongoDB.
+  // Now jobs are in MongoDB.
   if (!g_db_client->InsertSteps(steps)) {
     CRANE_ERROR("Failed to call g_db_client->InsertSteps() ");
     return;
   }
 
-  // Remove tasks in final queue.
+  // Remove jobs in final queue.
   std::vector<step_db_id_t> db_ids;
   for (StepInCtld* step : steps) db_ids.emplace_back(step->StepDbId());
 
   if (!g_embedded_db_client->PurgeEndedSteps(db_ids)) {
     CRANE_ERROR(
         "Failed to call g_embedded_db_client->PurgeEndedSteps() "
-        "for final tasks");
+        "for final jobs");
   }
 }
 
-void TaskScheduler::ProcessFinalTasks_(
-    const std::unordered_set<TaskInCtld*>& tasks) {
-  PersistAndTransferTasksToMongodb_(tasks);
-  CallPluginHookForFinalTasks_(tasks);
+void JobScheduler::ProcessFinalJobs_(
+    const std::unordered_set<JobInCtld*>& jobs) {
+  PersistAndTransferJobsToMongodb_(jobs);
+  CallPluginHookForFinalJobs_(jobs);
 }
 
-void TaskScheduler::CallPluginHookForFinalTasks_(
-    std::unordered_set<TaskInCtld*> const& tasks) {
-  if (g_config.Plugin.Enabled && !tasks.empty()) {
-    std::vector<crane::grpc::TaskInfo> tasks_post_comp;
-    for (TaskInCtld* task : tasks) {
-      crane::grpc::TaskInfo t;
-      task->SetFieldsOfTaskInfo(&t);
-      tasks_post_comp.emplace_back(std::move(t));
+void JobScheduler::CallPluginHookForFinalJobs_(
+    std::unordered_set<JobInCtld*> const& jobs) {
+  if (g_config.Plugin.Enabled && !jobs.empty()) {
+    std::vector<crane::grpc::JobInfo> jobs_post_comp;
+    for (JobInCtld* job : jobs) {
+      crane::grpc::JobInfo t;
+      job->SetFieldsOfJobInfo(&t);
+      jobs_post_comp.emplace_back(std::move(t));
     }
-    g_plugin_client->EndHookAsync(std::move(tasks_post_comp));
+    g_plugin_client->EndHookAsync(std::move(jobs_post_comp));
   }
 }
 
-void TaskScheduler::PersistAndTransferTasksToMongodb_(
-    std::unordered_set<TaskInCtld*> const& tasks) {
-  if (tasks.empty()) return;
+void JobScheduler::PersistAndTransferJobsToMongodb_(
+    std::unordered_set<JobInCtld*> const& jobs) {
+  if (jobs.empty()) return;
 
   txn_id_t txn_id;
   g_embedded_db_client->BeginVariableDbTransaction(&txn_id);
-  for (TaskInCtld* task : tasks) {
-    if (!g_embedded_db_client->UpdateRuntimeAttrOfTask(txn_id, task->TaskDbId(),
-                                                       task->RuntimeAttr()))
-      CRANE_ERROR("Failed to call UpdateRuntimeAttrOfTask() for task #{}",
-                  task->TaskId());
+  for (JobInCtld* job : jobs) {
+    if (!g_embedded_db_client->UpdateRuntimeAttrOfJob(txn_id, job->JobDbId(),
+                                                       job->RuntimeAttr()))
+      CRANE_ERROR("Failed to call UpdateRuntimeAttrOfJob() for job #{}",
+                  job->JobId());
   }
 
   g_embedded_db_client->CommitVariableDbTransaction(txn_id);
 
-  // Now tasks are in MongoDB.
-  if (!g_db_client->InsertJobs(tasks)) {
+  // Now jobs are in MongoDB.
+  if (!g_db_client->InsertJobs(jobs)) {
     CRANE_ERROR("Failed to call g_db_client->InsertJobs() ");
     return;
   }
 
-  // Remove tasks in final queue.
-  std::unordered_map<job_id_t, task_db_id_t> db_ids;
-  for (TaskInCtld* task : tasks) db_ids[task->TaskId()] = task->TaskDbId();
+  // Remove jobs in final queue.
+  std::unordered_map<job_id_t, job_db_id_t> db_ids;
+  for (JobInCtld* job : jobs) db_ids[job->JobId()] = job->JobDbId();
 
-  if (!g_embedded_db_client->PurgeEndedTasks(db_ids)) {
+  if (!g_embedded_db_client->PurgeEndedJobs(db_ids)) {
     CRANE_ERROR(
-        "Failed to call g_embedded_db_client->PurgeEndedTasks() "
-        "for final tasks");
+        "Failed to call g_embedded_db_client->PurgeEndedJobs() "
+        "for final jobs");
   }
 }
 
-CraneExpected<void> TaskScheduler::HandleUnsetOptionalInTaskToCtld(
-    TaskInCtld* task) {
-  if (task->IsBatch()) {
-    auto* batch_meta = task->MutableTaskToCtld()->mutable_batch_meta();
+CraneExpected<void> JobScheduler::HandleUnsetOptionalInJobToCtld(
+    JobInCtld* job) {
+  if (job->IsBatch()) {
+    auto* batch_meta = job->MutableJobToCtld()->mutable_batch_meta();
     if (!batch_meta->has_open_mode_append())
       batch_meta->set_open_mode_append(g_config.JobFileOpenModeAppend);
   }
@@ -4724,182 +4724,182 @@ CraneExpected<void> TaskScheduler::HandleUnsetOptionalInTaskToCtld(
   return {};
 }
 
-CraneExpected<void> TaskScheduler::AcquireTaskAttributes(TaskInCtld* task) {
-  auto part_it = g_config.Partitions.find(task->partition_id);
+CraneExpected<void> JobScheduler::AcquireJobAttributes(JobInCtld* job) {
+  auto part_it = g_config.Partitions.find(job->partition_id);
   if (part_it == g_config.Partitions.end()) {
-    CRANE_ERROR("Failed to call AcquireTaskAttributes: no such partition {}",
-                task->partition_id);
+    CRANE_ERROR("Failed to call AcquireJobAttributes: no such partition {}",
+                job->partition_id);
     return std::unexpected(CraneErrCode::ERR_INVALID_PARTITION);
   }
 
-  task->partition_priority = part_it->second.priority;
+  job->partition_priority = part_it->second.priority;
 
   Config::Partition const& part_meta = part_it->second;
   CRANE_TRACE(
-      "Task {} node res:{}, task res:{}, part default_mem_per_cpu:{}, "
+      "Job {} node res:{}, job res:{}, part default_mem_per_cpu:{}, "
       "default_mem_per_node:{}, max_mem_per_cpu:{}, max_mem_per_node:{}",
-      task->TaskId(), util::ReadableResourceView(task->req_node_res_view),
-      util::ReadableResourceView(task->req_task_res_view),
+      job->JobId(), util::ReadableResourceView(job->req_node_res_view),
+      util::ReadableResourceView(job->req_task_res_view),
       part_meta.default_mem_per_cpu, part_meta.default_mem_per_node,
       part_meta.max_mem_per_cpu, part_meta.max_mem_per_node);
 
-  bool user_set_mem_per_cpu = task->TaskToCtld().has_mem_per_cpu();
-  bool user_set_mem_per_node = task->TaskToCtld().has_mem_per_node();
+  bool user_set_mem_per_cpu = job->JobToCtld().has_mem_per_cpu();
+  bool user_set_mem_per_node = job->JobToCtld().has_mem_per_node();
 
   if (user_set_mem_per_cpu && user_set_mem_per_node) {
     CRANE_ERROR(
-        "Task {} has both mem_per_cpu and mem_per_node set by user, which is "
+        "Job {} has both mem_per_cpu and mem_per_node set by user, which is "
         "not allowed.",
-        task->TaskId());
+        job->JobId());
     return std::unexpected(CraneErrCode::ERR_INVALID_RESOURCE);
   }
 
-  CRANE_ASSERT(task->req_node_res_view.CpuCount() == 0);
+  CRANE_ASSERT(job->req_node_res_view.CpuCount() == 0);
 
   if (!user_set_mem_per_cpu && !user_set_mem_per_node) {
     if (part_meta.default_mem_per_node != 0) {
-      task->req_node_res_view.GetAllocatableRes().memory_bytes =
+      job->req_node_res_view.GetAllocatableRes().memory_bytes =
           part_meta.default_mem_per_node;
-      task->req_node_res_view.GetAllocatableRes().memory_sw_bytes =
+      job->req_node_res_view.GetAllocatableRes().memory_sw_bytes =
           part_meta.default_mem_per_node;
       user_set_mem_per_node = true;
       CRANE_TRACE("default_mem_per_node for job #{} is set to {}",
-                  task->TaskId(), part_meta.default_mem_per_node);
+                  job->JobId(), part_meta.default_mem_per_node);
     } else if (part_meta.default_mem_per_cpu != 0) {
-      auto task_mem_per_cpu = part_meta.default_mem_per_cpu;
-      task->req_task_res_view.GetAllocatableRes().memory_bytes =
-          static_cast<double>(task->req_task_res_view.CpuCount()) *
-          task_mem_per_cpu;
-      task->req_task_res_view.GetAllocatableRes().memory_sw_bytes =
-          static_cast<double>(task->req_task_res_view.CpuCount()) *
-          task_mem_per_cpu;
+      auto job_mem_per_cpu = part_meta.default_mem_per_cpu;
+      job->req_task_res_view.GetAllocatableRes().memory_bytes =
+          static_cast<double>(job->req_task_res_view.CpuCount()) *
+          job_mem_per_cpu;
+      job->req_task_res_view.GetAllocatableRes().memory_sw_bytes =
+          static_cast<double>(job->req_task_res_view.CpuCount()) *
+          job_mem_per_cpu;
       user_set_mem_per_cpu = true;
       CRANE_TRACE("default_mem_per_cpu for job #{} is set to {}",
-                  task->TaskId(), task_mem_per_cpu);
+                  job->JobId(), job_mem_per_cpu);
     } else {
       CRANE_ERROR(
-          "Neither mem_per_cpu nor mem_per_node is set for task #{} and "
+          "Neither mem_per_cpu nor mem_per_node is set for job #{} and "
           "partition {}, and no default is provided by partition meta.",
-          task->TaskId(), task->partition_id);
+          job->JobId(), job->partition_id);
       return std::unexpected(CraneErrCode::ERR_INVALID_RESOURCE);
     }
   }
 
   if (part_meta.max_mem_per_cpu != 0) {
     if (user_set_mem_per_cpu) {
-      auto max_task_mem =
-          static_cast<double>(task->req_task_res_view.CpuCount()) *
+      auto max_job_mem =
+          static_cast<double>(job->req_task_res_view.CpuCount()) *
           part_meta.max_mem_per_cpu;
-      if (task->req_task_res_view.MemoryBytes() > max_task_mem) {
-        task->req_task_res_view.GetAllocatableRes().memory_bytes = max_task_mem;
-        task->req_task_res_view.GetAllocatableRes().memory_sw_bytes =
-            max_task_mem;
+      if (job->req_task_res_view.MemoryBytes() > max_job_mem) {
+        job->req_task_res_view.GetAllocatableRes().memory_bytes = max_job_mem;
+        job->req_task_res_view.GetAllocatableRes().memory_sw_bytes =
+            max_job_mem;
       }
     } else {
       // mem_per_node / (ntasks_per_node * cpus_per_task) <= max_mem_per_cpu
       // ntasks_per_node >= ceil(mem_per_node / (max_mem_per_cpu *
       // cpus_per_task))
-      double cpus_per_task = task->req_task_res_view.CpuCount();
+      double cpus_per_task = job->req_task_res_view.CpuCount();
       if (cpus_per_task > 0) {
         auto required_min = static_cast<uint32_t>(std::ceil(
-            static_cast<double>(task->req_node_res_view.MemoryBytes()) /
+            static_cast<double>(job->req_node_res_view.MemoryBytes()) /
             (part_meta.max_mem_per_cpu * cpus_per_task)));
-        task->ntasks_per_node_min =
-            std::max(task->ntasks_per_node_min, required_min);
+        job->ntasks_per_node_min =
+            std::max(job->ntasks_per_node_min, required_min);
       }
     }
   }
 
   if (part_meta.max_mem_per_node != 0) {
     if (user_set_mem_per_node) {
-      if (task->req_node_res_view.MemoryBytes() > part_meta.max_mem_per_node) {
-        task->req_node_res_view.GetAllocatableRes().memory_bytes =
+      if (job->req_node_res_view.MemoryBytes() > part_meta.max_mem_per_node) {
+        job->req_node_res_view.GetAllocatableRes().memory_bytes =
             part_meta.max_mem_per_node;
-        task->req_node_res_view.GetAllocatableRes().memory_sw_bytes =
+        job->req_node_res_view.GetAllocatableRes().memory_sw_bytes =
             part_meta.max_mem_per_node;
       }
     } else {
       // ntasks_per_node * task_memory <= max_mem_per_node
       // ntasks_per_node_max <= floor(max_mem_per_node / task_memory)
-      auto task_mem = task->req_task_res_view.MemoryBytes();
-      if (task_mem > 0) {
+      auto job_mem = job->req_task_res_view.MemoryBytes();
+      if (job_mem > 0) {
         auto required_max = static_cast<uint32_t>(
-            static_cast<double>(part_meta.max_mem_per_node) / task_mem);
-        if (task->ntasks_per_node_max == 0 ||
-            task->ntasks_per_node_max > required_max) {
-          task->ntasks_per_node_max = required_max;
+            static_cast<double>(part_meta.max_mem_per_node) / job_mem);
+        if (job->ntasks_per_node_max == 0 ||
+            job->ntasks_per_node_max > required_max) {
+          job->ntasks_per_node_max = required_max;
         }
       }
     }
   }
 
-  // Finalize ntasks_per_node bounds from task distribution constraint.
+  // Finalize ntasks_per_node bounds from job distribution constraint.
   // One pass suffices: the second iteration is provably idempotent
   // because N >= K*m holds for any valid job (ntasks >= node_num).
   {
-    uint32_t dist_max = task->ntasks - task->node_num + 1;
-    if (task->ntasks_per_node_max == 0)
-      task->ntasks_per_node_max = dist_max;
+    uint32_t dist_max = job->ntasks - job->node_num + 1;
+    if (job->ntasks_per_node_max == 0)
+      job->ntasks_per_node_max = dist_max;
     else
-      task->ntasks_per_node_max = std::min(task->ntasks_per_node_max, dist_max);
+      job->ntasks_per_node_max = std::min(job->ntasks_per_node_max, dist_max);
 
-    task->ntasks_per_node_min = std::max(
-        task->ntasks_per_node_min,
-        task->ntasks - (task->node_num - 1) * task->ntasks_per_node_max);
+    job->ntasks_per_node_min = std::max(
+        job->ntasks_per_node_min,
+        job->ntasks - (job->node_num - 1) * job->ntasks_per_node_max);
 
-    task->ntasks_per_node_max = std::min(
-        task->ntasks_per_node_max,
-        task->ntasks - (task->node_num - 1) * task->ntasks_per_node_min);
+    job->ntasks_per_node_max = std::min(
+        job->ntasks_per_node_max,
+        job->ntasks - (job->node_num - 1) * job->ntasks_per_node_min);
   }
 
-  if (task->ntasks_per_node_min > task->ntasks_per_node_max) {
+  if (job->ntasks_per_node_min > job->ntasks_per_node_max) {
     CRANE_ERROR(
         "Job #{}: ntasks_per_node_min ({}) > ntasks_per_node_max ({}), "
         "infeasible constraints.",
-        task->TaskId(), task->ntasks_per_node_min, task->ntasks_per_node_max);
+        job->JobId(), job->ntasks_per_node_min, job->ntasks_per_node_max);
     return std::unexpected(CraneErrCode::ERR_INVALID_PARAM);
   }
 
   CRANE_TRACE(
-      "Job #{} after mem adjust: node res:{}, task res:{}, "
+      "Job #{} after mem adjust: node res:{}, job res:{}, "
       "ntasks_per_node_min:{}, ntasks_per_node_max:{}",
-      task->TaskId(), util::ReadableResourceView(task->req_node_res_view),
-      util::ReadableResourceView(task->req_task_res_view),
-      task->ntasks_per_node_min, task->ntasks_per_node_max);
+      job->JobId(), util::ReadableResourceView(job->req_node_res_view),
+      util::ReadableResourceView(job->req_task_res_view),
+      job->ntasks_per_node_min, job->ntasks_per_node_max);
 
-  task->req_total_res_view = task->req_node_res_view * task->node_num +
-                             task->req_task_res_view * task->ntasks;
-  CRANE_TRACE("Job #{} total res:{}", task->TaskId(),
-              util::ReadableResourceView(task->req_total_res_view));
+  job->req_total_res_view = job->req_node_res_view * job->node_num +
+                             job->req_task_res_view * job->ntasks;
+  CRANE_TRACE("Job #{} total res:{}", job->JobId(),
+              util::ReadableResourceView(job->req_total_res_view));
 
-  auto check_qos_result = g_account_manager->CheckQosLimitOnTask(
-      task->Username(), task->account, task);
+  auto check_qos_result = g_account_manager->CheckQosLimitOnJob(
+      job->Username(), job->account, job);
   if (!check_qos_result) {
-    CRANE_ERROR("Failed to call CheckQosLimitOnTask: {}",
+    CRANE_ERROR("Failed to call CheckQosLimitOnJob: {}",
                 CraneErrStr(check_qos_result.error()));
     return check_qos_result;
   }
 
-  if (!task->TaskToCtld().nodelist().empty() && task->included_nodes.empty()) {
+  if (!job->JobToCtld().nodelist().empty() && job->included_nodes.empty()) {
     std::list<std::string> nodes;
-    bool ok = util::ParseHostList(task->TaskToCtld().nodelist(), &nodes);
+    bool ok = util::ParseHostList(job->JobToCtld().nodelist(), &nodes);
     if (!ok) return std::unexpected(CraneErrCode::ERR_INVALID_NODE_LIST);
 
-    for (auto&& node : nodes) task->included_nodes.emplace(std::move(node));
+    for (auto&& node : nodes) job->included_nodes.emplace(std::move(node));
   }
 
-  if (!task->TaskToCtld().excludes().empty() && task->excluded_nodes.empty()) {
+  if (!job->JobToCtld().excludes().empty() && job->excluded_nodes.empty()) {
     std::list<std::string> nodes;
-    bool ok = util::ParseHostList(task->TaskToCtld().excludes(), &nodes);
+    bool ok = util::ParseHostList(job->JobToCtld().excludes(), &nodes);
     if (!ok) return std::unexpected(CraneErrCode::ERR_INVALID_EX_NODE_LIST);
 
-    for (auto&& node : nodes) task->excluded_nodes.emplace(std::move(node));
+    for (auto&& node : nodes) job->excluded_nodes.emplace(std::move(node));
   }
 
-  if (!task->TaskToCtld().licenses_count().empty()) {
+  if (!job->JobToCtld().licenses_count().empty()) {
     auto check_licenses_result = g_licenses_manager->CheckLicensesLegal(
-        task->TaskToCtld().licenses_count(),
-        task->TaskToCtld().is_licenses_or());
+        job->JobToCtld().licenses_count(),
+        job->JobToCtld().is_licenses_or());
     if (!check_licenses_result) {
       CRANE_ERROR("Failed to call CheckLicensesLegal: {}",
                   check_licenses_result.error());
@@ -4908,63 +4908,63 @@ CraneExpected<void> TaskScheduler::AcquireTaskAttributes(TaskInCtld* task) {
   }
 
   if (g_config.WckeyValid) {
-    if (task->MutableTaskToCtld()->has_wckey() &&
-        !task->MutableTaskToCtld()->wckey().empty()) {
-      std::string wckey = task->MutableTaskToCtld()->wckey();
+    if (job->MutableJobToCtld()->has_wckey() &&
+        !job->MutableJobToCtld()->wckey().empty()) {
+      std::string wckey = job->MutableJobToCtld()->wckey();
       auto wckey_scoped_ptr =
-          g_account_manager->GetExistedWckeyInfo(wckey, task->Username());
+          g_account_manager->GetExistedWckeyInfo(wckey, job->Username());
       if (!wckey_scoped_ptr) {
         CRANE_DEBUG("Job wckey '{}' not found in the wckey database, rejected.",
                     wckey);
         return std::unexpected(CraneErrCode::ERR_INVALID_WCKEY);
       }
 
-      task->wckey = wckey;
+      job->wckey = wckey;
       // Note: Ignore error from GetExistedDefaultWckeyName since the user's
       // wckey was already validated; the default check is only for marking
     } else {
       // No wckey provided; use the default
       auto result =
-          g_account_manager->GetExistedDefaultWckeyName(task->Username());
-      task->using_default_wckey = true;
-      if (result) task->wckey = result.value();
+          g_account_manager->GetExistedDefaultWckeyName(job->Username());
+      job->using_default_wckey = true;
+      if (result) job->wckey = result.value();
     }
   } else {
-    task->wckey.clear();
+    job->wckey.clear();
   }
 
   return {};
 }
 
-CraneExpected<void> TaskScheduler::CheckTaskValidity(TaskInCtld* task) {
-  if (!CheckIfTimeLimitIsValid(task->time_limit))
+CraneExpected<void> JobScheduler::CheckJobValidity(JobInCtld* job) {
+  if (!CheckIfTimeLimitIsValid(job->time_limit))
     return std::unexpected(CraneErrCode::ERR_TIME_TIMIT_BEYOND);
 
   // Check res req valid
-  if (task->req_total_res_view.MemoryBytes() == 0) {
-    CRANE_DEBUG("Job #{} has zero memory request.", task->TaskId());
+  if (job->req_total_res_view.MemoryBytes() == 0) {
+    CRANE_DEBUG("Job #{} has zero memory request.", job->JobId());
     return std::unexpected(CraneErrCode::ERR_INVALID_PARAM);
   }
-  if (task->req_task_res_view.CpuCount() == 0) {
-    CRANE_DEBUG("Job #{} has zero cpu request.", task->TaskId());
+  if (job->req_task_res_view.CpuCount() == 0) {
+    CRANE_DEBUG("Job #{} has zero cpu request.", job->JobId());
     return std::unexpected(CraneErrCode::ERR_INVALID_PARAM);
   }
 
-  // Check whether the selected partition is able to run this task.
+  // Check whether the selected partition is able to run this job.
   std::unordered_set<std::string> avail_nodes;
   {
     // Preserve lock ordering.
-    auto metas_ptr = g_meta_container->GetPartitionMetasPtr(task->partition_id);
+    auto metas_ptr = g_meta_container->GetPartitionMetasPtr(job->partition_id);
 
     // Since we do not access the elements in partition_metas_m
 
-    // Check whether the selected partition is able to run this task.
-    if (!(task->req_total_res_view <=
+    // Check whether the selected partition is able to run this job.
+    if (!(job->req_total_res_view <=
           metas_ptr->partition_global_meta.res_total_inc_dead)) {
       CRANE_TRACE(
-          "Resource not enough for task #{}. "
+          "Resource not enough for job #{}. "
           "Partition total: cpu {}, mem: {}, mem+sw: {}, gres: {}",
-          task->TaskId(),
+          job->JobId(),
           metas_ptr->partition_global_meta.res_total_inc_dead
               .GetAllocatableRes()
               .cpu_count,
@@ -4981,55 +4981,55 @@ CraneExpected<void> TaskScheduler::CheckTaskValidity(TaskInCtld* task) {
       return std::unexpected(CraneErrCode::ERR_NO_RESOURCE);
     }
 
-    if (task->node_num > metas_ptr->craned_ids.size()) {
+    if (job->node_num > metas_ptr->craned_ids.size()) {
       CRANE_TRACE(
-          "Nodes not enough for task #{}. "
+          "Nodes not enough for job #{}. "
           "Partition total Nodes: {}",
-          task->TaskId(), metas_ptr->craned_ids.size());
+          job->JobId(), metas_ptr->craned_ids.size());
       return std::unexpected(CraneErrCode::ERR_INVALID_NODE_NUM);
     }
 
-    if (task->reservation != "") {
+    if (job->reservation != "") {
       if (!g_meta_container->GetResvMetaMapConstPtr()->contains(
-              task->reservation)) {
-        CRANE_TRACE("Reservation {} not found for task #{}", task->reservation,
-                    task->TaskId());
+              job->reservation)) {
+        CRANE_TRACE("Reservation {} not found for job #{}", job->reservation,
+                    job->JobId());
         return std::unexpected(CraneErrCode::ERR_INVALID_PARAM);
       }
 
-      auto resv_meta = g_meta_container->GetResvMetaPtr(task->reservation);
+      auto resv_meta = g_meta_container->GetResvMetaPtr(job->reservation);
 
       if (resv_meta->part_id != "" &&
-          resv_meta->part_id != task->partition_id) {
-        CRANE_TRACE("Partition {} not allowed for reservation {} for task #{}",
-                    task->partition_id, task->reservation, task->TaskId());
+          resv_meta->part_id != job->partition_id) {
+        CRANE_TRACE("Partition {} not allowed for reservation {} for job #{}",
+                    job->partition_id, job->reservation, job->JobId());
         return std::unexpected(CraneErrCode::ERR_INVALID_PARAM);
       }
 
       // if passed, either not in the black list (true, true)
       // or in the white list (false, false)
       if (resv_meta->accounts_black_list ^
-          !resv_meta->accounts.contains(task->account)) {
-        CRANE_TRACE("Account {} not allowed for reservation {} for task #{}",
-                    task->account, task->reservation, task->TaskId());
+          !resv_meta->accounts.contains(job->account)) {
+        CRANE_TRACE("Account {} not allowed for reservation {} for job #{}",
+                    job->account, job->reservation, job->JobId());
         return std::unexpected(CraneErrCode::ERR_INVALID_PARAM);
       }
       if (resv_meta->users_black_list ^
-          !resv_meta->users.contains(task->Username())) {
-        CRANE_TRACE("User {} not allowed for reservation {} for task #{}",
-                    task->Username(), task->reservation, task->TaskId());
+          !resv_meta->users.contains(job->Username())) {
+        CRANE_TRACE("User {} not allowed for reservation {} for job #{}",
+                    job->Username(), job->reservation, job->JobId());
         return std::unexpected(CraneErrCode::ERR_INVALID_PARAM);
       }
 
-      if (!task->included_nodes.empty()) {
+      if (!job->included_nodes.empty()) {
         auto reserved_craned_id_list = resv_meta->craned_ids;
         std::unordered_set<std::string> reserved_craned_id_set;
         reserved_craned_id_set.insert(reserved_craned_id_list.begin(),
                                       reserved_craned_id_list.end());
-        for (const auto& craned_id : task->included_nodes) {
+        for (const auto& craned_id : job->included_nodes) {
           if (!reserved_craned_id_set.contains(craned_id)) {
-            CRANE_TRACE("Craned {} is not in the reservation {} for task #{}",
-                        craned_id, task->reservation, task->TaskId());
+            CRANE_TRACE("Craned {} is not in the reservation {} for job #{}",
+                        craned_id, job->reservation, job->JobId());
             return std::unexpected(CraneErrCode::ERR_INVALID_PARAM);
           }
         }
@@ -5039,30 +5039,30 @@ CraneExpected<void> TaskScheduler::CheckTaskValidity(TaskInCtld* task) {
     auto craned_meta_map = g_meta_container->GetCranedMetaMapConstPtr();
     for (const auto& craned_id : metas_ptr->craned_ids) {
       auto craned_meta = craned_meta_map->at(craned_id).GetExclusivePtr();
-      if (task->req_node_res_view + task->req_task_res_view <=
+      if (job->req_node_res_view + job->req_task_res_view <=
               craned_meta->res_total &&
-          (task->included_nodes.empty() ||
-           task->included_nodes.contains(craned_id)) &&
-          (task->excluded_nodes.empty() ||
-           !task->excluded_nodes.contains(craned_id)))
+          (job->included_nodes.empty() ||
+           job->included_nodes.contains(craned_id)) &&
+          (job->excluded_nodes.empty() ||
+           !job->excluded_nodes.contains(craned_id)))
         avail_nodes.emplace(craned_meta->static_meta.hostname);
 
-      if (avail_nodes.size() >= task->node_num) break;
+      if (avail_nodes.size() >= job->node_num) break;
     }
   }
 
-  if (task->node_num > avail_nodes.size()) {
+  if (job->node_num > avail_nodes.size()) {
     CRANE_TRACE(
-        "Resource not enough. Task #{} needs {} nodes, while only {} "
+        "Resource not enough. Job #{} needs {} nodes, while only {} "
         "nodes satisfy its requirement.",
-        task->TaskId(), task->node_num, avail_nodes.size());
+        job->JobId(), job->node_num, avail_nodes.size());
     return std::unexpected(CraneErrCode::ERR_NO_ENOUGH_NODE);
   }
 
   return {};
 }
 
-CraneExpected<void> TaskScheduler::AcquireStepAttributes(StepInCtld* step) {
+CraneExpected<void> JobScheduler::AcquireStepAttributes(StepInCtld* step) {
   if (!step->StepToCtld().nodelist().empty() && step->included_nodes.empty()) {
     std::list<std::string> nodes;
     bool ok = util::ParseHostList(step->StepToCtld().nodelist(), &nodes);
@@ -5124,14 +5124,14 @@ CraneExpected<void> TaskScheduler::AcquireStepAttributes(StepInCtld* step) {
 
     if (part_meta.max_mem_per_cpu != 0) {
       if (user_set_mem_per_cpu) {
-        auto max_task_mem =
+        auto max_job_mem =
             static_cast<double>(step->req_task_res_view.CpuCount()) *
             part_meta.max_mem_per_cpu;
-        if (step->req_task_res_view.MemoryBytes() > max_task_mem) {
+        if (step->req_task_res_view.MemoryBytes() > max_job_mem) {
           step->req_task_res_view.GetAllocatableRes().memory_bytes =
-              max_task_mem;
+              max_job_mem;
           step->req_task_res_view.GetAllocatableRes().memory_sw_bytes =
-              max_task_mem;
+              max_job_mem;
         }
       } else if (user_set_mem_per_node) {
         double cpus_per_task = step->req_task_res_view.CpuCount();
@@ -5155,10 +5155,10 @@ CraneExpected<void> TaskScheduler::AcquireStepAttributes(StepInCtld* step) {
               part_meta.max_mem_per_node;
         }
       } else if (user_set_mem_per_cpu) {
-        auto task_mem = step->req_task_res_view.MemoryBytes();
-        if (task_mem > 0) {
+        auto job_mem = step->req_task_res_view.MemoryBytes();
+        if (job_mem > 0) {
           auto required_max = static_cast<uint32_t>(
-              static_cast<double>(part_meta.max_mem_per_node) / task_mem);
+              static_cast<double>(part_meta.max_mem_per_node) / job_mem);
           if (step->ntasks_per_node_max == 0 ||
               step->ntasks_per_node_max > required_max) {
             step->ntasks_per_node_max = required_max;
@@ -5199,7 +5199,7 @@ CraneExpected<void> TaskScheduler::AcquireStepAttributes(StepInCtld* step) {
   return {};
 }
 
-CraneExpected<void> TaskScheduler::CheckStepValidity(StepInCtld* step) {
+CraneExpected<void> JobScheduler::CheckStepValidity(StepInCtld* step) {
   auto* job = step->job;
   if (!CheckIfTimeLimitIsValid(step->time_limit))
     return std::unexpected(CraneErrCode::ERR_TIME_TIMIT_BEYOND);
@@ -5219,9 +5219,9 @@ CraneExpected<void> TaskScheduler::CheckStepValidity(StepInCtld* step) {
     return std::unexpected{CraneErrCode::ERR_PERMISSION_DENIED};
   }
 
-  if (step->type == crane::grpc::TaskType::Container) {
+  if (step->type == crane::grpc::JobType::Container) {
     // Check if step is send to a job not supporting container
-    if (job->type != crane::grpc::TaskType::Container)
+    if (job->type != crane::grpc::JobType::Container)
       return std::unexpected{CraneErrCode::ERR_INVALID_PARAM};
     // Copy pod_meta for step
     step->pod_meta = job->pod_meta;
@@ -5256,27 +5256,27 @@ CraneExpected<void> TaskScheduler::CheckStepValidity(StepInCtld* step) {
   return {};
 }
 
-void TaskScheduler::TerminateTasksOnCraned(const CranedId& craned_id,
+void JobScheduler::TerminateJobsOnCraned(const CranedId& craned_id,
                                            uint32_t exit_code) {
-  CRANE_TRACE("Terminate tasks on craned {}", craned_id);
+  CRANE_TRACE("Terminate jobs on craned {}", craned_id);
 
   // The order of LockGuards matters.
-  LockGuard indexes_guard(&m_task_indexes_mtx_);
+  LockGuard indexes_guard(&m_job_indexes_mtx_);
 
-  auto it = m_node_to_tasks_map_.find(craned_id);
-  if (it != m_node_to_tasks_map_.end()) {
-    // m_node_to_tasks_map_[craned_id] will be cleaned in
-    // TaskStatusChangeNoLock_. Do not clean it here and make a copy of
+  auto it = m_node_to_jobs_map_.find(craned_id);
+  if (it != m_node_to_jobs_map_.end()) {
+    // m_node_to_jobs_map_[craned_id] will be cleaned in
+    // StepStatusChangeNoLock_. Do not clean it here and make a copy of
     // it->second.
-    std::vector<task_id_t> task_ids(it->second.begin(), it->second.end());
+    std::vector<job_id_t> job_ids(it->second.begin(), it->second.end());
 
-    for (task_id_t task_id : task_ids)
-      StepStatusChangeAsync(task_id, kDaemonStepId, craned_id,
-                            crane::grpc::TaskStatus::Failed, exit_code,
+    for (job_id_t job_id : job_ids)
+      StepStatusChangeAsync(job_id, kDaemonStepId, craned_id,
+                            crane::grpc::JobStatus::Failed, exit_code,
                             "Terminated",
                             google::protobuf::util::TimeUtil::GetCurrentTime());
   } else {
-    CRANE_TRACE("No task is executed by craned {}. Ignore cleaning step...",
+    CRANE_TRACE("No job is executed by craned {}. Ignore cleaning step...",
                 craned_id);
   }
 }

--- a/src/CraneCtld/JobScheduler.cpp
+++ b/src/CraneCtld/JobScheduler.cpp
@@ -93,13 +93,12 @@ bool JobScheduler::Init() {
       job->SetFieldsByRuntimeAttrOfJob(job_in_embedded_db.runtime_attr());
       job_id_t job_id = job->JobId();
 
-      CRANE_TRACE("Restore job #{} from embedded running queue.",
-                  job->JobId());
+      CRANE_TRACE("Restore job #{} from embedded running queue.", job->JobId());
       auto result = AcquireJobAttributes(job.get());
       if (!result || job->type == crane::grpc::Interactive) {
         job->SetStatus(crane::grpc::Failed);
         ok = g_embedded_db_client->UpdateRuntimeAttrOfJob(0, job_db_id,
-                                                           job->RuntimeAttr());
+                                                          job->RuntimeAttr());
         if (!ok) {
           CRANE_ERROR(
               "UpdateRuntimeAttrOfJob failed for job #{} when "
@@ -124,8 +123,8 @@ bool JobScheduler::Init() {
                 job->JobId());
           }
 
-          ok = g_embedded_db_client->PurgeEndedJobs(
-              {{job->JobId(), job_db_id}});
+          ok =
+              g_embedded_db_client->PurgeEndedJobs({{job->JobId(), job_db_id}});
           if (!ok) {
             CRANE_ERROR(
                 "PurgeEndedJobs failed for job #{} when recovering "
@@ -156,8 +155,7 @@ bool JobScheduler::Init() {
 
       job_id_t job_id = job->JobId();
 
-      CRANE_TRACE("Restore job #{} from embedded pending queue.",
-                  job->JobId());
+      CRANE_TRACE("Restore job #{} from embedded pending queue.", job->JobId());
 
       bool mark_job_as_failed = false;
 
@@ -203,7 +201,7 @@ bool JobScheduler::Init() {
         job->SetStartTime(recovery_time);
         job->SetEndTime(recovery_time);
         ok = g_embedded_db_client->UpdateRuntimeAttrOfJob(0, job_db_id,
-                                                           job->RuntimeAttr());
+                                                          job->RuntimeAttr());
         if (!ok) {
           CRANE_ERROR(
               "UpdateRuntimeAttrOfJob failed for job #{} when "
@@ -285,7 +283,7 @@ bool JobScheduler::Init() {
                 job_id);
     job->SetStatus(crane::grpc::Failed);
     auto ok = g_embedded_db_client->UpdateRuntimeAttrOfJob(0, job->JobDbId(),
-                                                            job->RuntimeAttr());
+                                                           job->RuntimeAttr());
     if (!ok) {
       CRANE_ERROR(
           "[Job #{}] UpdateRuntimeAttrOfJob failed when "
@@ -301,8 +299,7 @@ bool JobScheduler::Init() {
           job_id);
     }
 
-    ok = g_embedded_db_client->PurgeEndedJobs(
-        {{job->JobId(), job->JobDbId()}});
+    ok = g_embedded_db_client->PurgeEndedJobs({{job->JobId(), job->JobDbId()}});
     if (!ok) {
       CRANE_ERROR(
           "PurgeEndedJobs failed for job #{} when recovering "
@@ -414,8 +411,7 @@ bool JobScheduler::Init() {
 
   {
     std::unordered_map<
-        job_id_t,
-        std::vector<std::pair<job_id_t, crane::grpc::DependencyType>>>
+        job_id_t, std::vector<std::pair<job_id_t, crane::grpc::DependencyType>>>
         dependee_to_dependents;
 
     for (const auto& [job_id, job] : m_pending_job_map_) {
@@ -528,8 +524,7 @@ bool JobScheduler::Init() {
       std::chrono::milliseconds(kJobHoldTimerTimeoutMs * 3),
       std::chrono::milliseconds(kJobHoldTimerTimeoutMs));
 
-  m_job_timeout_async_handle_ =
-      uvw_release_loop->resource<uvw::async_handle>();
+  m_job_timeout_async_handle_ = uvw_release_loop->resource<uvw::async_handle>();
   m_job_timeout_async_handle_->on<uvw::async_event>(
       [this](const uvw::async_event&, uvw::async_handle&) {
         JobTimerAsyncCb_();
@@ -562,7 +557,8 @@ bool JobScheduler::Init() {
         CancelJobAsyncCb_();
       });
 
-  m_clean_cancel_job_queue_handle_ = uvw_cancel_loop->resource<uvw::async_handle>();
+  m_clean_cancel_job_queue_handle_ =
+      uvw_cancel_loop->resource<uvw::async_handle>();
   m_clean_cancel_job_queue_handle_->on<uvw::async_event>(
       [this](const uvw::async_event&, uvw::async_handle&) {
         CleanCancelJobQueueCb_();
@@ -587,7 +583,8 @@ bool JobScheduler::Init() {
         SubmitJobAsyncCb_();
       });
 
-  m_clean_submit_job_queue_handle_ = uvw_submit_loop->resource<uvw::async_handle>();
+  m_clean_submit_job_queue_handle_ =
+      uvw_submit_loop->resource<uvw::async_handle>();
   m_clean_submit_job_queue_handle_->on<uvw::async_event>(
       [this](const uvw::async_event&, uvw::async_handle&) {
         CleanSubmitJobQueueCb_();
@@ -967,7 +964,7 @@ void JobScheduler::ScheduleThread_() {
 
       schedule_begin = std::chrono::steady_clock::now();
       num_jobs_single_schedule = std::min((size_t)g_config.ScheduledBatchSize,
-                                           m_pending_job_map_.size());
+                                          m_pending_job_map_.size());
 
       g_meta_container->StartLogging();
 
@@ -1190,7 +1187,7 @@ void JobScheduler::ScheduleThread_() {
         // time-consuming operation, otherwise StepStatusChange RPC will come
         // earlier before job is put into running_job_map.
         g_embedded_db_client->UpdateRuntimeAttrOfJob(txn_id, job->JobDbId(),
-                                                      job->RuntimeAttr());
+                                                     job->RuntimeAttr());
       }
 
       ok = g_embedded_db_client->CommitVariableDbTransaction(txn_id);
@@ -1581,7 +1578,7 @@ std::future<CraneExpected<step_id_t>> JobScheduler::SubmitStepAsync(
 }
 
 std::future<CraneErrCode> JobScheduler::HoldReleaseJobAsync(job_id_t job_id,
-                                                              int64_t secs) {
+                                                            int64_t secs) {
   std::promise<CraneErrCode> promise;
   std::future<CraneErrCode> future = promise.get_future();
 
@@ -1592,8 +1589,7 @@ std::future<CraneErrCode> JobScheduler::HoldReleaseJobAsync(job_id_t job_id,
   return std::move(future);
 }
 
-CraneErrCode JobScheduler::ChangeJobTimeLimit(job_id_t job_id,
-                                                int64_t secs) {
+CraneErrCode JobScheduler::ChangeJobTimeLimit(job_id_t job_id, int64_t secs) {
   if (!CheckIfTimeLimitSecIsValid(secs)) return CraneErrCode::ERR_INVALID_PARAM;
 
   std::vector<CranedId> craned_ids;
@@ -1639,15 +1635,14 @@ CraneErrCode JobScheduler::ChangeJobTimeLimit(job_id_t job_id,
     }
 
     if (!found) {
-      CRANE_DEBUG("Job #{} not in Pd/Rn queue for time limit change!",
-                  job_id);
+      CRANE_DEBUG("Job #{} not in Pd/Rn queue for time limit change!", job_id);
       return CraneErrCode::ERR_NON_EXISTENT;
     }
 
     job->time_limit = absl::Seconds(secs);
     job->MutableJobToCtld()->mutable_time_limit()->set_seconds(secs);
     g_embedded_db_client->UpdateJobToCtldIfExists(0, job->JobDbId(),
-                                                   job->JobToCtld());
+                                                  job->JobToCtld());
   }
 
   // Only send request to the executing node
@@ -1656,8 +1651,8 @@ CraneErrCode JobScheduler::ChangeJobTimeLimit(job_id_t job_id,
     if (stub && !stub->Invalid()) {
       CraneErrCode err = stub->ChangeJobTimeLimit(job_id, secs);
       if (err != CraneErrCode::SUCCESS) {
-        CRANE_ERROR("Failed to change time limit of job #{} on Node {}",
-                    job_id, craned_id);
+        CRANE_ERROR("Failed to change time limit of job #{} on Node {}", job_id,
+                    craned_id);
         return err;
       }
     }
@@ -1666,8 +1661,7 @@ CraneErrCode JobScheduler::ChangeJobTimeLimit(job_id_t job_id,
   return CraneErrCode::SUCCESS;
 }
 
-CraneErrCode JobScheduler::ChangeJobPriority(job_id_t job_id,
-                                               double priority) {
+CraneErrCode JobScheduler::ChangeJobPriority(job_id_t job_id, double priority) {
   m_pending_job_map_mtx_.Lock();
 
   auto pd_iter = m_pending_job_map_.find(job_id);
@@ -1710,7 +1704,7 @@ CraneErrCode JobScheduler::ChangeJobExtraAttrs(
   job->extra_attr = new_extra_attr;
   job->MutableJobToCtld()->set_extra_attr(new_extra_attr);
   g_embedded_db_client->UpdateJobToCtldIfExists(0, job->JobDbId(),
-                                                 job->JobToCtld());
+                                                job->JobToCtld());
   return CraneErrCode::SUCCESS;
 }
 
@@ -1848,7 +1842,7 @@ JobScheduler::SubmitJobToScheduler(std::unique_ptr<JobInCtld> job) {
 }
 
 CraneErrCode JobScheduler::SetHoldForJobInRamAndDb_(job_id_t job_id,
-                                                      bool hold) {
+                                                    bool hold) {
   m_pending_job_map_mtx_.Lock();
 
   auto pd_iter = m_pending_job_map_.find(job_id);
@@ -1868,14 +1862,13 @@ CraneErrCode JobScheduler::SetHoldForJobInRamAndDb_(job_id_t job_id,
   m_pending_job_map_mtx_.Unlock();
 
   if (!g_embedded_db_client->UpdateRuntimeAttrOfJobIfExists(0, db_id,
-                                                             runtime_attr))
+                                                            runtime_attr))
     CRANE_ERROR("Failed to update runtime attr of job #{} to DB", job_id);
 
   return CraneErrCode::SUCCESS;
 }
 
-CraneErrCode JobScheduler::TerminateRunningStepNoLock_(
-    CommonStepInCtld* step) {
+CraneErrCode JobScheduler::TerminateRunningStepNoLock_(CommonStepInCtld* step) {
   auto* common_step = static_cast<CommonStepInCtld*>(step);
   bool need_to_be_terminated = false;
   if (step->type == crane::grpc::Interactive) {
@@ -1892,8 +1885,8 @@ CraneErrCode JobScheduler::TerminateRunningStepNoLock_(
     for (CranedId const& craned_id : step->ExecutionNodes()) {
       m_cancel_job_queue_.enqueue(
           CancelRunningJobQueueElem{.job_id = step->job_id,
-                                     .step_id = step->StepId(),
-                                     .craned_id = craned_id});
+                                    .step_id = step->StepId(),
+                                    .craned_id = craned_id});
       m_cancel_job_async_handle_->send();
     }
   }
@@ -2539,8 +2532,7 @@ std::expected<void, std::string> JobScheduler::CreateResv_(
       }
 
       bool failed = false;
-      for (job_id_t job_id :
-           craned_meta->rn_job_res_map | std::views::keys) {
+      for (job_id_t job_id : craned_meta->rn_job_res_map | std::views::keys) {
         const auto& job = m_running_job_map_.at(job_id);
         absl::Time job_end_time = job->StartTime() + job->time_limit;
 
@@ -2821,7 +2813,7 @@ void JobScheduler::CleanJobTimerQueueCb_(
                   secs);
 
       auto on_timer_cb = [this, job_id](const uvw::timer_event&,
-                                         uvw::timer_handle& handle) {
+                                        uvw::timer_handle& handle) {
         CraneErrCode err = SetHoldForJobInRamAndDb_(job_id, false);
         if (err != CraneErrCode::SUCCESS)
           CRANE_ERROR("Failed to release job #{} after hold.", job_id);
@@ -2989,13 +2981,13 @@ void JobScheduler::CleanCancelJobQueueCb_() {
       g_account_meta_container->FreeQosSubmitResource(*job);
 
       job->TriggerDependencyEvents(crane::grpc::DependencyType::AFTER,
-                                    cancel_time);
+                                   cancel_time);
       job->TriggerDependencyEvents(crane::grpc::DependencyType::AFTER_ANY,
-                                    cancel_time);
+                                   cancel_time);
       job->TriggerDependencyEvents(crane::grpc::AFTER_OK,
-                                    absl::InfiniteFuture());
+                                   absl::InfiniteFuture());
       job->TriggerDependencyEvents(crane::grpc::AFTER_NOT_OK,
-                                    absl::InfiniteFuture());
+                                   absl::InfiniteFuture());
 
       if (job->type == crane::grpc::Interactive) {
         auto& meta = std::get<InteractiveMeta>(job->meta);
@@ -3019,8 +3011,7 @@ void JobScheduler::CleanCancelJobQueueCb_() {
 
     std::unordered_set<JobInCtld*> pd_job_raw_ptrs;
 
-    for (auto& job : pending_job_ptr_vec)
-      pd_job_raw_ptrs.emplace(job.get());
+    for (auto& job : pending_job_ptr_vec) pd_job_raw_ptrs.emplace(job.get());
     ProcessFinalJobs_(pd_job_raw_ptrs);
   }
 
@@ -3302,42 +3293,41 @@ void JobScheduler::StartCraneCtldPrologThread(JobInCtld* job) {
   if (!g_config.JobLifecycleHook.CranectldPrologs.empty()) {
     // TODO: cbatch job must be requeue
     job->DaemonStep()->SetCtldPrologPending(true);
-    g_thread_pool->detach_task(
-        [this, job_id = job->JobId(), env = job->env]() {
-          // run prolog ctld script
-          RunPrologEpilogArgs run_prolog_args{
-              .scripts = g_config.JobLifecycleHook.CranectldPrologs,
-              .envs = env,
-              .timeout_sec = g_config.JobLifecycleHook.PrologTimeout,
-              .run_uid = 0,
-              .run_gid = 0,
-              .output_size = g_config.JobLifecycleHook.MaxOutputSize};
-          run_prolog_args.timeout_sec = g_config.JobLifecycleHook.PrologTimeout;
-          if (g_config.JobLifecycleHook.PrologEpilogTimeout > 0) {
-            run_prolog_args.timeout_sec =
-                g_config.JobLifecycleHook.PrologEpilogTimeout;
-          }
-          CRANE_TRACE(
-              "[Job #{}]: Running CraneCtldProlog as UID {} with timeout {}s",
-              job_id, run_prolog_args.run_uid, run_prolog_args.timeout_sec);
-          auto run_prolog_result = util::os::RunPrologOrEpiLog(run_prolog_args);
+    g_thread_pool->detach_task([this, job_id = job->JobId(), env = job->env]() {
+      // run prolog ctld script
+      RunPrologEpilogArgs run_prolog_args{
+          .scripts = g_config.JobLifecycleHook.CranectldPrologs,
+          .envs = env,
+          .timeout_sec = g_config.JobLifecycleHook.PrologTimeout,
+          .run_uid = 0,
+          .run_gid = 0,
+          .output_size = g_config.JobLifecycleHook.MaxOutputSize};
+      run_prolog_args.timeout_sec = g_config.JobLifecycleHook.PrologTimeout;
+      if (g_config.JobLifecycleHook.PrologEpilogTimeout > 0) {
+        run_prolog_args.timeout_sec =
+            g_config.JobLifecycleHook.PrologEpilogTimeout;
+      }
+      CRANE_TRACE(
+          "[Job #{}]: Running CraneCtldProlog as UID {} with timeout {}s",
+          job_id, run_prolog_args.run_uid, run_prolog_args.timeout_sec);
+      auto run_prolog_result = util::os::RunPrologOrEpiLog(run_prolog_args);
 
-          auto now = google::protobuf::util::TimeUtil::GetCurrentTime();
-          if (!run_prolog_result) {
-            auto status = run_prolog_result.error();
-            CRANE_DEBUG("[Job #{}]: CraneCtldProlog failed status={}:{}",
-                        job_id, status.exit_code, status.signal_num);
-            this->StepStatusChangeAsync(
-                job_id, kDaemonStepId, kCtldPrologInternalNodeIndex,
-                crane::grpc::JobStatus::Cancelled, ExitCode::EC_PROLOG_ERR,
-                "CraneCtldPrologError", now);
-          } else {
-            CRANE_DEBUG("[Job #{}]: CraneCtldProlog success", job_id);
-            this->StepStatusChangeAsync(
-                job_id, kDaemonStepId, kCtldPrologInternalNodeIndex,
-                crane::grpc::JobStatus::Running, 0, "", now);
-          }
-        });
+      auto now = google::protobuf::util::TimeUtil::GetCurrentTime();
+      if (!run_prolog_result) {
+        auto status = run_prolog_result.error();
+        CRANE_DEBUG("[Job #{}]: CraneCtldProlog failed status={}:{}", job_id,
+                    status.exit_code, status.signal_num);
+        this->StepStatusChangeAsync(
+            job_id, kDaemonStepId, kCtldPrologInternalNodeIndex,
+            crane::grpc::JobStatus::Cancelled, ExitCode::EC_PROLOG_ERR,
+            "CraneCtldPrologError", now);
+      } else {
+        CRANE_DEBUG("[Job #{}]: CraneCtldProlog success", job_id);
+        this->StepStatusChangeAsync(
+            job_id, kDaemonStepId, kCtldPrologInternalNodeIndex,
+            crane::grpc::JobStatus::Running, 0, "", now);
+      }
+    });
   }
 }
 
@@ -3346,12 +3336,12 @@ void JobScheduler::StepStatusChangeAsync(
     crane::grpc::JobStatus new_status, uint32_t exit_code, std::string reason,
     google::protobuf::Timestamp timestamp) {
   m_job_status_change_queue_.enqueue({.job_id = job_id,
-                                       .step_id = step_id,
-                                       .exit_code = exit_code,
-                                       .new_status = new_status,
-                                       .craned_index = craned_index,
-                                       .reason = std::move(reason),
-                                       .timestamp = std::move(timestamp)});
+                                      .step_id = step_id,
+                                      .exit_code = exit_code,
+                                      .new_status = new_status,
+                                      .craned_index = craned_index,
+                                      .reason = std::move(reason),
+                                      .timestamp = std::move(timestamp)});
   m_job_status_change_async_handle_->send();
 }
 
@@ -3449,7 +3439,7 @@ void JobScheduler::CleanJobStatusChangeQueueCb_() {
 
       uint32_t job_exit_code = job_finished_status.value().second;
       job->TriggerDependencyEvents(crane::grpc::DependencyType::AFTER_ANY,
-                                    end_time);
+                                   end_time);
       job->TriggerDependencyEvents(
           crane::grpc::DependencyType::AFTER_OK,
           job_exit_code == 0 ? end_time : absl::InfiniteFuture());
@@ -3474,8 +3464,7 @@ void JobScheduler::CleanJobStatusChangeQueueCb_() {
         g_meta_container->FreeResourceFromNode(craned_id, job_id);
       }
       if (job->reservation != "")
-        g_meta_container->FreeResourceFromResv(job->reservation,
-                                               job->JobId());
+        g_meta_container->FreeResourceFromResv(job->reservation, job->JobId());
       g_account_meta_container->FreeQosResource(*job);
       if (!job->licenses_count.empty())
         g_licenses_manager->FreeLicense(job->licenses_count);
@@ -3752,7 +3741,7 @@ void JobScheduler::CleanJobStatusChangeQueueCb_() {
   // Jobs will update in embedded db
   for (auto* job : context.rn_job_raw_ptrs) {
     if (!g_embedded_db_client->UpdateRuntimeAttrOfJob(txn_id, job->JobDbId(),
-                                                       job->RuntimeAttr()))
+                                                      job->RuntimeAttr()))
       CRANE_ERROR("[Job #{}] Failed to call UpdateRuntimeAttrOfJob()",
                   job->JobId());
   }
@@ -3887,7 +3876,7 @@ void JobScheduler::QueryJobsInRam(
 
   bool no_job_states_constraint = request->filter_states().empty();
   std::unordered_set<int> req_job_states(request->filter_states().begin(),
-                                          request->filter_states().end());
+                                         request->filter_states().end());
   auto job_rng_filter_state = [&](auto* job_ptr) {
     JobInCtld& job = *job_ptr;
     return no_job_states_constraint ||
@@ -3896,7 +3885,7 @@ void JobScheduler::QueryJobsInRam(
 
   bool no_job_types_constraint = request->filter_job_types().empty();
   std::unordered_set<int> req_job_types(request->filter_job_types().begin(),
-                                         request->filter_job_types().end());
+                                        request->filter_job_types().end());
   auto job_rng_filter_job_type = [&](auto* job_ptr) {
     return no_job_types_constraint || req_job_types.contains(job_ptr->type);
   };
@@ -4689,7 +4678,7 @@ void JobScheduler::PersistAndTransferJobsToMongodb_(
   g_embedded_db_client->BeginVariableDbTransaction(&txn_id);
   for (JobInCtld* job : jobs) {
     if (!g_embedded_db_client->UpdateRuntimeAttrOfJob(txn_id, job->JobDbId(),
-                                                       job->RuntimeAttr()))
+                                                      job->RuntimeAttr()))
       CRANE_ERROR("Failed to call UpdateRuntimeAttrOfJob() for job #{}",
                   job->JobId());
   }
@@ -4763,8 +4752,8 @@ CraneExpected<void> JobScheduler::AcquireJobAttributes(JobInCtld* job) {
       job->req_node_res_view.GetAllocatableRes().memory_sw_bytes =
           part_meta.default_mem_per_node;
       user_set_mem_per_node = true;
-      CRANE_TRACE("default_mem_per_node for job #{} is set to {}",
-                  job->JobId(), part_meta.default_mem_per_node);
+      CRANE_TRACE("default_mem_per_node for job #{} is set to {}", job->JobId(),
+                  part_meta.default_mem_per_node);
     } else if (part_meta.default_mem_per_cpu != 0) {
       auto job_mem_per_cpu = part_meta.default_mem_per_cpu;
       job->req_task_res_view.GetAllocatableRes().memory_bytes =
@@ -4774,8 +4763,8 @@ CraneExpected<void> JobScheduler::AcquireJobAttributes(JobInCtld* job) {
           static_cast<double>(job->req_task_res_view.CpuCount()) *
           job_mem_per_cpu;
       user_set_mem_per_cpu = true;
-      CRANE_TRACE("default_mem_per_cpu for job #{} is set to {}",
-                  job->JobId(), job_mem_per_cpu);
+      CRANE_TRACE("default_mem_per_cpu for job #{} is set to {}", job->JobId(),
+                  job_mem_per_cpu);
     } else {
       CRANE_ERROR(
           "Neither mem_per_cpu nor mem_per_node is set for job #{} and "
@@ -4843,13 +4832,13 @@ CraneExpected<void> JobScheduler::AcquireJobAttributes(JobInCtld* job) {
     else
       job->ntasks_per_node_max = std::min(job->ntasks_per_node_max, dist_max);
 
-    job->ntasks_per_node_min = std::max(
-        job->ntasks_per_node_min,
-        job->ntasks - (job->node_num - 1) * job->ntasks_per_node_max);
+    job->ntasks_per_node_min =
+        std::max(job->ntasks_per_node_min,
+                 job->ntasks - (job->node_num - 1) * job->ntasks_per_node_max);
 
-    job->ntasks_per_node_max = std::min(
-        job->ntasks_per_node_max,
-        job->ntasks - (job->node_num - 1) * job->ntasks_per_node_min);
+    job->ntasks_per_node_max =
+        std::min(job->ntasks_per_node_max,
+                 job->ntasks - (job->node_num - 1) * job->ntasks_per_node_min);
   }
 
   if (job->ntasks_per_node_min > job->ntasks_per_node_max) {
@@ -4868,12 +4857,12 @@ CraneExpected<void> JobScheduler::AcquireJobAttributes(JobInCtld* job) {
       job->ntasks_per_node_min, job->ntasks_per_node_max);
 
   job->req_total_res_view = job->req_node_res_view * job->node_num +
-                             job->req_task_res_view * job->ntasks;
+                            job->req_task_res_view * job->ntasks;
   CRANE_TRACE("Job #{} total res:{}", job->JobId(),
               util::ReadableResourceView(job->req_total_res_view));
 
-  auto check_qos_result = g_account_manager->CheckQosLimitOnJob(
-      job->Username(), job->account, job);
+  auto check_qos_result =
+      g_account_manager->CheckQosLimitOnJob(job->Username(), job->account, job);
   if (!check_qos_result) {
     CRANE_ERROR("Failed to call CheckQosLimitOnJob: {}",
                 CraneErrStr(check_qos_result.error()));
@@ -4898,8 +4887,7 @@ CraneExpected<void> JobScheduler::AcquireJobAttributes(JobInCtld* job) {
 
   if (!job->JobToCtld().licenses_count().empty()) {
     auto check_licenses_result = g_licenses_manager->CheckLicensesLegal(
-        job->JobToCtld().licenses_count(),
-        job->JobToCtld().is_licenses_or());
+        job->JobToCtld().licenses_count(), job->JobToCtld().is_licenses_or());
     if (!check_licenses_result) {
       CRANE_ERROR("Failed to call CheckLicensesLegal: {}",
                   check_licenses_result.error());
@@ -4999,8 +4987,7 @@ CraneExpected<void> JobScheduler::CheckJobValidity(JobInCtld* job) {
 
       auto resv_meta = g_meta_container->GetResvMetaPtr(job->reservation);
 
-      if (resv_meta->part_id != "" &&
-          resv_meta->part_id != job->partition_id) {
+      if (resv_meta->part_id != "" && resv_meta->part_id != job->partition_id) {
         CRANE_TRACE("Partition {} not allowed for reservation {} for job #{}",
                     job->partition_id, job->reservation, job->JobId());
         return std::unexpected(CraneErrCode::ERR_INVALID_PARAM);
@@ -5257,7 +5244,7 @@ CraneExpected<void> JobScheduler::CheckStepValidity(StepInCtld* step) {
 }
 
 void JobScheduler::TerminateJobsOnCraned(const CranedId& craned_id,
-                                           uint32_t exit_code) {
+                                         uint32_t exit_code) {
   CRANE_TRACE("Terminate jobs on craned {}", craned_id);
 
   // The order of LockGuards matters.

--- a/src/CraneCtld/JobScheduler.h
+++ b/src/CraneCtld/JobScheduler.h
@@ -47,7 +47,7 @@ class MinCpuTimeRatioFirst : public IUpdateNodeCostPolicy {
 };
 
 struct RnJobInScheduler {
-  task_id_t job_id;
+  job_id_t job_id;
   absl::Duration time_limit;
 
   PartitionId partition_id;
@@ -64,8 +64,8 @@ struct RnJobInScheduler {
   ResourceV2 allocated_res;
   ResourceView allocated_res_view;
 
-  RnJobInScheduler(TaskInCtld* job)
-      : job_id(job->TaskId()),
+  RnJobInScheduler(JobInCtld* job)
+      : job_id(job->JobId()),
         time_limit(job->time_limit),
         partition_id(job->partition_id),
         reservation(job->reservation),
@@ -80,7 +80,7 @@ struct RnJobInScheduler {
 };
 
 struct PdJobInScheduler {
-  task_id_t job_id;
+  job_id_t job_id;
   absl::Duration time_limit;
 
   PartitionId partition_id;
@@ -112,7 +112,7 @@ struct PdJobInScheduler {
   ResourceV2 allocated_res;
   std::vector<CranedId> craned_ids;
 
-  google::protobuf::RepeatedPtrField<crane::grpc::TaskToCtld::License>
+  google::protobuf::RepeatedPtrField<crane::grpc::JobToCtld::License>
       req_licenses;
   bool is_license_or;
   std::unordered_map<LicenseId, uint32_t> actual_licenses;
@@ -122,8 +122,8 @@ struct PdJobInScheduler {
   std::string username;
   std::list<std::string> account_chain;
 
-  PdJobInScheduler(TaskInCtld* job)
-      : job_id(job->TaskId()),
+  PdJobInScheduler(JobInCtld* job)
+      : job_id(job->JobId()),
         time_limit(job->time_limit),
         partition_id(job->partition_id),
         reservation(job->reservation),
@@ -142,8 +142,8 @@ struct PdJobInScheduler {
         qos_priority(job->qos_priority),
         account(job->account),
         priority(job->mandated_priority),
-        req_licenses(job->TaskToCtld().licenses_count()),
-        is_license_or(job->TaskToCtld().is_licenses_or()),
+        req_licenses(job->JobToCtld().licenses_count()),
+        is_license_or(job->JobToCtld().is_licenses_or()),
         qos(job->qos),
         username(job->Username()),
         account_chain(job->account_chain) {}
@@ -246,7 +246,7 @@ class SchedulerAlgo {
   static constexpr bool kAlgoTraceOutput = false;
   // TODO: move to config
   static constexpr bool kAlgoRedundantNode = false;
-  static constexpr uint32_t kAlgoMaxTaskNumPerNode = 1000;
+  static constexpr uint32_t kAlgoMaxJobNumPerNode = 1000;
   static constexpr absl::Duration kAlgoMaxTimeWindow = absl::Hours(24 * 7);
 
   struct NodeState {
@@ -315,16 +315,16 @@ class SchedulerAlgo {
                                 const absl::Time& end_time,
                                 const ResourceInNode& res) {
       bool ok;
-      auto task_duration_begin_it = time_avail_res_map.upper_bound(start_time);
-      if (task_duration_begin_it == time_avail_res_map.end()) {
-        --task_duration_begin_it;  // task_duration_begin_it->first <=
+      auto job_duration_begin_it = time_avail_res_map.upper_bound(start_time);
+      if (job_duration_begin_it == time_avail_res_map.end()) {
+        --job_duration_begin_it;  // job_duration_begin_it->first <=
                                    // start_time < end_time
         // Case #1
-        //                     task duration
+        //                     job duration
         //                   |<-------------->|
         // *-----------------*----------------------> inf
         //                   ^
-        //        task_duration_begin_it
+        //        job_duration_begin_it
         //
         // *-----------------*----------------|-----> inf
         //                           ^        ^
@@ -332,11 +332,11 @@ class SchedulerAlgo {
         //                      subtract resource here
         //
         // OR Case #2
-        //                        task duration
+        //                        job duration
         //                      |<-------------->|
         // *-----------------*----------------------> inf
         //                   ^
-        //        task_duration_begin_it
+        //        job_duration_begin_it
         //
         // *-----------------*--|----------------|--> inf
         //                      ^      ^         ^
@@ -345,73 +345,73 @@ class SchedulerAlgo {
 
         TimeAvailResMap::iterator inserted_it;
         std::tie(inserted_it, ok) = time_avail_res_map.emplace(
-            end_time, task_duration_begin_it->second);
+            end_time, job_duration_begin_it->second);
         CRANE_ASSERT_MSG(ok == true, "Insertion must be successful.");
 
-        if (task_duration_begin_it->first == start_time) {
+        if (job_duration_begin_it->first == start_time) {
           // Case #1, subtract resource at start_time
-          CRANE_ASSERT(res <= task_duration_begin_it->second);
-          task_duration_begin_it->second -= res;
+          CRANE_ASSERT(res <= job_duration_begin_it->second);
+          job_duration_begin_it->second -= res;
         } else {
           // Case #2, insert subtracted resource at start_time
           std::tie(inserted_it, ok) = time_avail_res_map.emplace(
-              start_time, task_duration_begin_it->second);
+              start_time, job_duration_begin_it->second);
           CRANE_ASSERT_MSG(ok == true, "Insertion must be successful.");
 
           CRANE_ASSERT(res <= inserted_it->second);
           inserted_it->second -= res;
         }
       } else {
-        --task_duration_begin_it;  // task_duration_begin_it->first <=
+        --job_duration_begin_it;  // job_duration_begin_it->first <=
                                    // start_time < end_time
         // Case #3
-        //                    task duration
+        //                    job duration
         //                |<-------------->|
         // *-------*----------*---------*------------
         //         ^                    ^
-        //  task_duration_begin_it     task_duration_end_it
+        //  job_duration_begin_it     job_duration_end_it
         // *-------*------|---*---------*--|---------
         //                ^  ^     ^     ^ ^
         //       insert here |     |     | insert here
         //                 subtract at these points
         //
         // Or Case #4
-        //               task duration
+        //               job duration
         //         |<----------------->|
         // *-------*----------*--------*------------
         //         ^                   ^
-        //  task_duration_begin_it   task_duration_end_it
+        //  job_duration_begin_it   job_duration_end_it
 
         // std::prev can be used without any check here.
         // There will always be one time point (now) before end_time.
 
-        if (task_duration_begin_it->first != start_time) {
+        if (job_duration_begin_it->first != start_time) {
           // Case #3, copy resource before start_time to start_time
           TimeAvailResMap::iterator inserted_it;
           std::tie(inserted_it, ok) = time_avail_res_map.emplace(
-              start_time, task_duration_begin_it->second);
+              start_time, job_duration_begin_it->second);
           CRANE_ASSERT_MSG(ok == true, "Insertion must be successful.");
 
-          task_duration_begin_it = inserted_it;
+          job_duration_begin_it = inserted_it;
         }
-        auto task_duration_end_it = std::prev(time_avail_res_map.upper_bound(
-            end_time));  // task_duration_end_it->first <= end_time
+        auto job_duration_end_it = std::prev(time_avail_res_map.upper_bound(
+            end_time));  // job_duration_end_it->first <= end_time
 
         // Subtract the required resources within the interval.
-        for (auto in_duration_it = task_duration_begin_it;
-             in_duration_it != task_duration_end_it; in_duration_it++) {
+        for (auto in_duration_it = job_duration_begin_it;
+             in_duration_it != job_duration_end_it; in_duration_it++) {
           CRANE_ASSERT(res <= in_duration_it->second);
           in_duration_it->second -= res;
         }
 
-        if (task_duration_end_it->first != end_time) {
+        if (job_duration_end_it->first != end_time) {
           TimeAvailResMap::iterator inserted_it;
           std::tie(inserted_it, ok) = time_avail_res_map.emplace(
-              end_time, task_duration_end_it->second);
+              end_time, job_duration_end_it->second);
           CRANE_ASSERT_MSG(ok == true, "Insertion must be successful.");
 
-          CRANE_ASSERT(res <= task_duration_end_it->second);
-          task_duration_end_it->second -= res;
+          CRANE_ASSERT(res <= job_duration_end_it->second);
+          job_duration_end_it->second -= res;
         }
       }
     }
@@ -625,11 +625,11 @@ class SchedulerAlgo {
                         const TimeAvailResMap::const_iterator& it,
                         const TimeAvailResMap::const_iterator& end,
                         ResMapIterList* tracker_list,
-                        const ResourceInNode* task_res)
+                        const ResourceInNode* job_res)
         : m_craned_id_(craned_id),
           m_it_(it),
           m_end_(end),
-          task_res(task_res),
+          job_res(job_res),
           m_tracker_list_it_(tracker_list->m_tracker_list_.end()) {
       m_satisfied_flag_ = Satisfied();
     }
@@ -650,7 +650,7 @@ class SchedulerAlgo {
    private:
     friend ResMapIterList;
 
-    bool Satisfied() const { return *task_res <= m_it_->second; }
+    bool Satisfied() const { return *job_res <= m_it_->second; }
 
     void MoveToNext() {
       m_satisfied_flag_ = !m_satisfied_flag_;  // target state
@@ -663,7 +663,7 @@ class SchedulerAlgo {
     void MoveToNextUnsatisfied() { while (++m_it_ != m_end_ && Satisfied()); }
     void MoveToNextSatisfied() { while (++m_it_ != m_end_ && !Satisfied()); }
 
-    const ResourceInNode* task_res;
+    const ResourceInNode* job_res;
 
     ResMapIterList::ListContainer::iterator m_tracker_list_it_;
 
@@ -752,8 +752,8 @@ class SchedulerAlgo {
   IPrioritySorter* m_priority_sorter_;
 };
 
-class TaskScheduler {
-  using TaskInEmbeddedDb = crane::grpc::TaskInEmbeddedDb;
+class JobScheduler {
+  using JobInEmbeddedDb = crane::grpc::JobInEmbeddedDb;
 
   using Mutex = absl::Mutex;
   using LockGuard = absl::MutexLock;
@@ -769,64 +769,64 @@ class TaskScheduler {
   using HashSet = absl::flat_hash_set<K>;
 
  public:
-  TaskScheduler();
+  JobScheduler();
 
-  ~TaskScheduler();
+  ~JobScheduler();
 
   bool Init();
 
-  /// \return The future is set to an error code if task submission failed.
-  /// Otherwise, it is set to newly allocated task id.
-  std::future<CraneExpected<task_id_t>> SubmitTaskAsync(
-      std::unique_ptr<TaskInCtld> task);
+  /// \return The future is set to an error code if job submission failed.
+  /// Otherwise, it is set to newly allocated job id.
+  std::future<CraneExpected<job_id_t>> SubmitJobAsync(
+      std::unique_ptr<JobInCtld> job);
 
   std::future<CraneExpected<step_id_t>> SubmitStepAsync(
       std::unique_ptr<CommonStepInCtld> step);
 
-  std::future<CraneErrCode> HoldReleaseTaskAsync(task_id_t task_id,
+  std::future<CraneErrCode> HoldReleaseJobAsync(job_id_t job_id,
                                                  int64_t secs);
 
-  CraneErrCode ChangeTaskTimeLimit(task_id_t task_id, int64_t secs);
+  CraneErrCode ChangeJobTimeLimit(job_id_t job_id, int64_t secs);
 
-  CraneErrCode ChangeTaskPriority(task_id_t task_id, double priority);
+  CraneErrCode ChangeJobPriority(job_id_t job_id, double priority);
 
-  CraneErrCode ChangeTaskExtraAttrs(task_id_t task_id,
+  CraneErrCode ChangeJobExtraAttrs(job_id_t job_id,
                                     const std::string& new_extra_attr);
 
   std::optional<std::future<CraneRichError>> JobSubmitLuaCheck(
-      TaskInCtld* task);
+      JobInCtld* job);
 
-  void JobModifyLuaCheck(const crane::grpc::ModifyTaskRequest& request,
-                         crane::grpc::ModifyTaskReply* response,
-                         std::list<task_id_t>* task_ids);
+  void JobModifyLuaCheck(const crane::grpc::ModifyJobRequest& request,
+                         crane::grpc::ModifyJobReply* response,
+                         std::list<job_id_t>* job_ids);
 
-  CraneExpected<std::future<CraneExpected<task_id_t>>> SubmitTaskToScheduler(
-      std::unique_ptr<TaskInCtld> task);
+  CraneExpected<std::future<CraneExpected<job_id_t>>> SubmitJobToScheduler(
+      std::unique_ptr<JobInCtld> job);
 
-  void StepStatusChangeWithReasonAsync(uint32_t task_id, step_id_t step_id,
+  void StepStatusChangeWithReasonAsync(uint32_t job_id, step_id_t step_id,
                                        const CranedId& craned_index,
-                                       crane::grpc::TaskStatus new_status,
+                                       crane::grpc::JobStatus new_status,
                                        uint32_t exit_code,
                                        std::optional<std::string>&& reason,
                                        google::protobuf::Timestamp timestamp) {
     // TODO: Add reason implementation here!
-    StepStatusChangeAsync(task_id, step_id, craned_index, new_status, exit_code,
+    StepStatusChangeAsync(job_id, step_id, craned_index, new_status, exit_code,
                           reason.value_or(""), std::move(timestamp));
   }
 
-  void StartCraneCtldPrologThread(TaskInCtld* job);
+  void StartCraneCtldPrologThread(JobInCtld* job);
 
   void StepStatusChangeAsync(job_id_t job_id, step_id_t step_id,
                              const CranedId& craned_index,
-                             crane::grpc::TaskStatus new_status,
+                             crane::grpc::JobStatus new_status,
                              uint32_t exit_code, std::string reason,
                              google::protobuf::Timestamp timestamp);
 
-  void TerminateTasksOnCraned(const CranedId& craned_id, uint32_t exit_code);
+  void TerminateJobsOnCraned(const CranedId& craned_id, uint32_t exit_code);
 
-  void QueryTasksInRam(
-      const crane::grpc::QueryTasksInfoRequest* request,
-      std::unordered_map<job_id_t, crane::grpc::TaskInfo>* job_info_map);
+  void QueryJobsInRam(
+      const crane::grpc::QueryJobsInfoRequest* request,
+      std::unordered_map<job_id_t, crane::grpc::JobInfo>* job_info_map);
 
   void QueryRnJobOnCtldForNodeConfig(const CranedId& craned_id,
                                      crane::grpc::ConfigureCranedRequest* req);
@@ -835,8 +835,8 @@ class TaskScheduler {
       const std::unordered_map<job_id_t, std::set<step_id_t>>& steps,
       const CranedId& excluded_node);
 
-  crane::grpc::CancelTaskReply CancelPendingOrRunningTask(
-      const crane::grpc::CancelTaskRequest& request);
+  crane::grpc::CancelJobReply CancelPendingOrRunningJob(
+      const crane::grpc::CancelJobRequest& request);
 
   crane::grpc::AttachContainerStepReply AttachContainerStep(
       const crane::grpc::AttachContainerStepRequest& request);
@@ -846,40 +846,40 @@ class TaskScheduler {
 
   CraneErrCode TerminatePendingOrRunningIaStep(job_id_t job_id,
                                                step_id_t step_id) {
-    LockGuard pending_guard(&m_pending_task_map_mtx_);
-    LockGuard running_guard(&m_running_task_map_mtx_);
+    LockGuard pending_guard(&m_pending_job_map_mtx_);
+    LockGuard running_guard(&m_running_job_map_mtx_);
 
-    auto pd_it = m_pending_task_map_.find(job_id);
-    if (pd_it != m_pending_task_map_.end()) {
-      auto& task = pd_it->second;
-      if (task->type != crane::grpc::Interactive) {
+    auto pd_it = m_pending_job_map_.find(job_id);
+    if (pd_it != m_pending_job_map_.end()) {
+      auto& job = pd_it->second;
+      if (job->type != crane::grpc::Interactive) {
         return CraneErrCode::ERR_INVALID_PARAM;
       }
-      auto& meta = std::get<InteractiveMeta>(task->meta);
+      auto& meta = std::get<InteractiveMeta>(job->meta);
       meta.has_been_cancelled_on_front_end = true;
 
-      m_cancel_task_queue_.enqueue(
-          CancelPendingTaskQueueElem{.task = std::move(task)});
-      m_cancel_task_async_handle_->send();
-      m_pending_task_map_.erase(pd_it);
+      m_cancel_job_queue_.enqueue(
+          CancelPendingJobQueueElem{.job = std::move(job)});
+      m_cancel_job_async_handle_->send();
+      m_pending_job_map_.erase(pd_it);
       return CraneErrCode::SUCCESS;
     }
 
-    auto rn_it = m_running_task_map_.find(job_id);
-    if (rn_it == m_running_task_map_.end())
+    auto rn_it = m_running_job_map_.find(job_id);
+    if (rn_it == m_running_job_map_.end())
       return CraneErrCode::ERR_NON_EXISTENT;
 
     CommonStepInCtld* step;
-    auto& task = rn_it->second;
-    step = task->GetStep(step_id);
+    auto& job = rn_it->second;
+    step = job->GetStep(step_id);
     if (step) {
       if (step->type == crane::grpc::Interactive) {
         auto& meta = step->ia_meta.value();
         meta.has_been_cancelled_on_front_end = true;
-        if (step->Status() == crane::grpc::TaskStatus::Pending) {
-          m_cancel_task_queue_.enqueue(
-              CancelPendingStepQueueElem{.step = task->EraseStep(step_id)});
-          m_cancel_task_async_handle_->send();
+        if (step->Status() == crane::grpc::JobStatus::Pending) {
+          m_cancel_job_queue_.enqueue(
+              CancelPendingStepQueueElem{.step = job->EraseStep(step_id)});
+          m_cancel_job_async_handle_->send();
           return CraneErrCode::SUCCESS;
         }
       } else {
@@ -894,12 +894,12 @@ class TaskScheduler {
 
   CraneErrCode TerminateRunningStep(
       std::unordered_map<job_id_t, std::unordered_set<step_id_t>> job_steps) {
-    LockGuard running_guard(&m_running_task_map_mtx_);
+    LockGuard running_guard(&m_running_job_map_mtx_);
 
     std::vector<CommonStepInCtld*> steps;
     for (auto& [job_id, step_ids] : job_steps) {
-      auto iter = m_running_task_map_.find(job_id);
-      if (iter == m_running_task_map_.end())
+      auto iter = m_running_job_map_.find(job_id);
+      if (iter == m_running_job_map_.end())
         return CraneErrCode::ERR_NON_EXISTENT;
       auto* job = iter->second.get();
       for (auto step_id : step_ids) {
@@ -916,9 +916,9 @@ class TaskScheduler {
     return CraneErrCode::SUCCESS;
   }
 
-  static CraneExpected<void> HandleUnsetOptionalInTaskToCtld(TaskInCtld* task);
-  static CraneExpected<void> AcquireTaskAttributes(TaskInCtld* task);
-  static CraneExpected<void> CheckTaskValidity(TaskInCtld* task);
+  static CraneExpected<void> HandleUnsetOptionalInJobToCtld(JobInCtld* job);
+  static CraneExpected<void> AcquireJobAttributes(JobInCtld* job);
+  static CraneExpected<void> CheckJobValidity(JobInCtld* job);
 
   static CraneExpected<void> AcquireStepAttributes(StepInCtld* step);
   static CraneExpected<void> CheckStepValidity(StepInCtld* step);
@@ -933,7 +933,7 @@ class TaskScheduler {
   crane::grpc::DeleteReservationReply PurgeAllReservations();
 
   // For failed dependency, timestamp should be absl::InfiniteFuture()
-  void AddDependencyEvent(task_id_t dependent, task_id_t dependee,
+  void AddDependencyEvent(job_id_t dependent, job_id_t dependee,
                           absl::Time timestamp) {
     m_dependency_event_queue_.enqueue(
         DependencyEvent{.dependent_job_id = dependent,
@@ -942,27 +942,27 @@ class TaskScheduler {
   }
 
  private:
-  void RequeueRecoveredTaskIntoPendingQueueLock_(
-      std::unique_ptr<TaskInCtld> task);
+  void RequeueRecoveredJobIntoPendingQueueLock_(
+      std::unique_ptr<JobInCtld> job);
 
-  void PutRecoveredTaskIntoRunningQueueLock_(std::unique_ptr<TaskInCtld> task);
-  void HandleFailToRecoverRngJob_(task_id_t task_id);
+  void PutRecoveredJobIntoRunningQueueLock_(std::unique_ptr<JobInCtld> job);
+  void HandleFailToRecoverRngJob_(job_id_t job_id);
 
   static void ProcessFinalSteps_(std::unordered_set<StepInCtld*> const& steps);
   static void PersistAndTransferStepsToMongodb_(
       std::unordered_set<StepInCtld*> const& steps);
 
-  static void ProcessFinalTasks_(const std::unordered_set<TaskInCtld*>& tasks);
+  static void ProcessFinalJobs_(const std::unordered_set<JobInCtld*>& jobs);
 
-  static void CallPluginHookForFinalTasks_(
-      std::unordered_set<TaskInCtld*> const& tasks);
+  static void CallPluginHookForFinalJobs_(
+      std::unordered_set<JobInCtld*> const& jobs);
 
-  static void PersistAndTransferTasksToMongodb_(
-      std::unordered_set<TaskInCtld*> const& tasks);
+  static void PersistAndTransferJobsToMongodb_(
+      std::unordered_set<JobInCtld*> const& jobs);
 
   CraneErrCode TerminateRunningStepNoLock_(CommonStepInCtld* step);
 
-  CraneErrCode SetHoldForTaskInRamAndDb_(task_id_t task_id, bool hold);
+  CraneErrCode SetHoldForJobInRamAndDb_(job_id_t job_id, bool hold);
 
   std::expected<void, std::string> CreateResv_(
       const crane::grpc::CreateReservationRequest& request);
@@ -971,46 +971,46 @@ class TaskScheduler {
 
   std::unique_ptr<SchedulerAlgo> m_node_selection_algo_;
 
-  // Ordered by task id. Those who comes earlier are in the head,
-  // Because they have smaller task id.
-  TreeMap<task_id_t, std::unique_ptr<TaskInCtld>> m_pending_task_map_
-      ABSL_GUARDED_BY(m_pending_task_map_mtx_);
-  Mutex m_pending_task_map_mtx_;
+  // Ordered by job id. Those who comes earlier are in the head,
+  // Because they have smaller job id.
+  TreeMap<job_id_t, std::unique_ptr<JobInCtld>> m_pending_job_map_
+      ABSL_GUARDED_BY(m_pending_job_map_mtx_);
+  Mutex m_pending_job_map_mtx_;
 
   std::atomic_uint32_t m_pending_map_cached_size_;
 
-  HashMap<task_id_t, std::unique_ptr<TaskInCtld>> m_running_task_map_
-      ABSL_GUARDED_BY(m_running_task_map_mtx_);
-  Mutex m_running_task_map_mtx_ ABSL_ACQUIRED_AFTER(m_pending_task_map_mtx_);
+  HashMap<job_id_t, std::unique_ptr<JobInCtld>> m_running_job_map_
+      ABSL_GUARDED_BY(m_running_job_map_mtx_);
+  Mutex m_running_job_map_mtx_ ABSL_ACQUIRED_AFTER(m_pending_job_map_mtx_);
 
-  // Task Indexes
-  HashMap<CranedId, HashSet<uint32_t /* Task ID*/>> m_node_to_tasks_map_
-      ABSL_GUARDED_BY(m_task_indexes_mtx_);
-  Mutex m_task_indexes_mtx_ ABSL_ACQUIRED_AFTER(m_running_task_map_mtx_);
+  // Job Indexes
+  HashMap<CranedId, HashSet<uint32_t /* Job ID*/>> m_node_to_jobs_map_
+      ABSL_GUARDED_BY(m_job_indexes_mtx_);
+  Mutex m_job_indexes_mtx_ ABSL_ACQUIRED_AFTER(m_running_job_map_mtx_);
 
   HashMap<job_id_t, std::uint32_t> m_job_pending_step_num_map_
       ABSL_GUARDED_BY(m_step_num_mutex_);
-  Mutex m_step_num_mutex_ ABSL_ACQUIRED_BEFORE(m_task_indexes_mtx_);
+  Mutex m_step_num_mutex_ ABSL_ACQUIRED_BEFORE(m_job_indexes_mtx_);
 
   std::unique_ptr<IPrioritySorter> m_priority_sorter_;
 
   // If this variable is set to true, all threads must stop in a certain time.
   std::atomic_bool m_thread_stop_{};
 
-  // RPC worker pool for RPC calls with mutex `m_pending_task_map_mtx_` or
-  // `m_running_task_map_mtx_` or `m_task_indexes_mtx_` held. Put there RPCs in
+  // RPC worker pool for RPC calls with mutex `m_pending_job_map_mtx_` or
+  // `m_running_job_map_mtx_` or `m_job_indexes_mtx_` held. Put there RPCs in
   // global thread pool can be dangerous is some cases, e.g., deadlock may
   // happen. So we create a separate thread pool for those RPCs. Consider a
   // scenario:
-  // There is task `A` (Like CraneStub::ConfigureCraned) in thread pool: Try to
+  // There is job `A` (Like CraneStub::ConfigureCraned) in thread pool: Try to
   // acquire `mutex` and send something via RPC.
   //
   // And another thread (like StepStatusChangeThread): Acquired `mutex` and
-  // create task `B` to send something to craned, and a latch is used to wait
+  // create job `B` to send something to craned, and a latch is used to wait
   // for RPCs completion in the thread.
   //
-  // If too many tasks like `A` are in the thread pool, all threads
-  // may be occupied, then task `B` can never be scheduled, and therefore
+  // If too many jobs like `A` are in the thread pool, all threads
+  // may be occupied, then job `B` can never be scheduled, and therefore
   // the latch will cause a deadlock.
   std::unique_ptr<BS::thread_pool> m_rpc_worker_pool_;
 
@@ -1020,78 +1020,78 @@ class TaskScheduler {
   std::thread m_step_schedule_thread_;
   void StepScheduleThread_();
 
-  std::thread m_task_release_thread_;
-  void ReleaseTaskThread_(const std::shared_ptr<uvw::loop>& uvw_loop);
+  std::thread m_job_release_thread_;
+  void ReleaseJobThread_(const std::shared_ptr<uvw::loop>& uvw_loop);
 
-  std::thread m_task_cancel_thread_;
-  void CancelTaskThread_(const std::shared_ptr<uvw::loop>& uvw_loop);
+  std::thread m_job_cancel_thread_;
+  void CancelJobThread_(const std::shared_ptr<uvw::loop>& uvw_loop);
 
-  std::thread m_task_submit_thread_;
-  void SubmitTaskThread_(const std::shared_ptr<uvw::loop>& uvw_loop);
+  std::thread m_job_submit_thread_;
+  void SubmitJobThread_(const std::shared_ptr<uvw::loop>& uvw_loop);
 
   std::thread m_step_submit_thread_;
   void StepSubmitThread_(const std::shared_ptr<uvw::loop>& uvw_loop);
 
-  std::thread m_task_status_change_thread_;
-  void TaskStatusChangeThread_(const std::shared_ptr<uvw::loop>& uvw_loop);
+  std::thread m_job_status_change_thread_;
+  void JobStatusChangeThread_(const std::shared_ptr<uvw::loop>& uvw_loop);
 
   // Working as channels in golang.
-  std::shared_ptr<uvw::timer_handle> m_task_timer_handle_;
-  void CleanTaskTimerCb_();
+  std::shared_ptr<uvw::timer_handle> m_job_timer_handle_;
+  void CleanJobTimerCb_();
 
-  std::unordered_map<task_id_t, std::shared_ptr<uvw::timer_handle>>
-      m_task_timer_handles_;
+  std::unordered_map<job_id_t, std::shared_ptr<uvw::timer_handle>>
+      m_job_timer_handles_;
 
-  std::shared_ptr<uvw::async_handle> m_task_timeout_async_handle_;
+  std::shared_ptr<uvw::async_handle> m_job_timeout_async_handle_;
 
-  using TaskTimerQueueElem =
-      std::pair<std::pair<task_id_t, int64_t>, std::promise<CraneErrCode>>;
-  ConcurrentQueue<TaskTimerQueueElem> m_task_timer_queue_;
+  using JobTimerQueueElem =
+      std::pair<std::pair<job_id_t, int64_t>, std::promise<CraneErrCode>>;
+  ConcurrentQueue<JobTimerQueueElem> m_job_timer_queue_;
 
-  void TaskTimerAsyncCb_();
+  void JobTimerAsyncCb_();
 
-  std::shared_ptr<uvw::async_handle> m_clean_task_timer_queue_handle_;
-  void CleanTaskTimerQueueCb_(const std::shared_ptr<uvw::loop>& uvw_loop);
+  std::shared_ptr<uvw::async_handle> m_clean_job_timer_queue_handle_;
+  void CleanJobTimerQueueCb_(const std::shared_ptr<uvw::loop>& uvw_loop);
 
-  std::shared_ptr<uvw::timer_handle> m_cancel_task_timer_handle_;
-  void CancelTaskTimerCb_();
+  std::shared_ptr<uvw::timer_handle> m_cancel_job_timer_handle_;
+  void CancelJobTimerCb_();
 
-  struct CancelPendingTaskQueueElem {
-    std::unique_ptr<TaskInCtld> task;
+  struct CancelPendingJobQueueElem {
+    std::unique_ptr<JobInCtld> job;
   };
 
   struct CancelPendingStepQueueElem {
     std::unique_ptr<CommonStepInCtld> step;
   };
 
-  struct CancelRunningTaskQueueElem {
+  struct CancelRunningJobQueueElem {
     job_id_t job_id;
     step_id_t step_id;
     CranedId craned_id;
   };
 
-  using CancelTaskQueueElem =
-      std::variant<CancelPendingTaskQueueElem, CancelPendingStepQueueElem,
-                   CancelRunningTaskQueueElem>;
+  using CancelJobQueueElem =
+      std::variant<CancelPendingJobQueueElem, CancelPendingStepQueueElem,
+                   CancelRunningJobQueueElem>;
 
-  std::shared_ptr<uvw::async_handle> m_cancel_task_async_handle_;
-  ConcurrentQueue<CancelTaskQueueElem> m_cancel_task_queue_;
-  void CancelTaskAsyncCb_();
+  std::shared_ptr<uvw::async_handle> m_cancel_job_async_handle_;
+  ConcurrentQueue<CancelJobQueueElem> m_cancel_job_queue_;
+  void CancelJobAsyncCb_();
 
-  std::shared_ptr<uvw::async_handle> m_clean_cancel_queue_handle_;
-  void CleanCancelQueueCb_();
+  std::shared_ptr<uvw::async_handle> m_clean_cancel_job_queue_handle_;
+  void CleanCancelJobQueueCb_();
 
-  std::shared_ptr<uvw::timer_handle> m_submit_task_timer_handle_;
-  void SubmitTaskTimerCb_();
+  std::shared_ptr<uvw::timer_handle> m_submit_job_timer_handle_;
+  void SubmitJobTimerCb_();
 
-  std::shared_ptr<uvw::async_handle> m_submit_task_async_handle_;
-  ConcurrentQueue<std::pair<std::unique_ptr<TaskInCtld>,
-                            std::promise<CraneExpected<task_id_t>>>>
-      m_submit_task_queue_;
-  void SubmitTaskAsyncCb_();
+  std::shared_ptr<uvw::async_handle> m_submit_job_async_handle_;
+  ConcurrentQueue<std::pair<std::unique_ptr<JobInCtld>,
+                            std::promise<CraneExpected<job_id_t>>>>
+      m_submit_job_queue_;
+  void SubmitJobAsyncCb_();
 
-  std::shared_ptr<uvw::async_handle> m_clean_submit_queue_handle_;
-  void CleanSubmitQueueCb_();
+  std::shared_ptr<uvw::async_handle> m_clean_submit_job_queue_handle_;
+  void CleanSubmitJobQueueCb_();
 
   std::shared_ptr<uvw::timer_handle> m_submit_step_timer_handle_;
   void SubmitStepTimerCb_();
@@ -1105,26 +1105,26 @@ class TaskScheduler {
   std::shared_ptr<uvw::async_handle> m_clean_step_submit_queue_handle_;
   void CleanStepSubmitQueueCb_();
 
-  std::shared_ptr<uvw::timer_handle> m_task_status_change_timer_handle_;
-  void TaskStatusChangeTimerCb_();
+  std::shared_ptr<uvw::timer_handle> m_job_status_change_timer_handle_;
+  void JobStatusChangeTimerCb_();
 
-  std::shared_ptr<uvw::async_handle> m_task_status_change_async_handle_;
+  std::shared_ptr<uvw::async_handle> m_job_status_change_async_handle_;
 
-  struct TaskStatusChangeArg {
+  struct JobStatusChangeArg {
     job_id_t job_id;
     step_id_t step_id;
     uint32_t exit_code;
-    crane::grpc::TaskStatus new_status;
+    crane::grpc::JobStatus new_status;
     CranedId craned_index;
     std::string reason;
     google::protobuf::Timestamp timestamp;
   };
 
-  ConcurrentQueue<TaskStatusChangeArg> m_task_status_change_queue_;
-  void TaskStatusChangeAsyncCb_();
+  ConcurrentQueue<JobStatusChangeArg> m_job_status_change_queue_;
+  void JobStatusChangeAsyncCb_();
 
-  std::shared_ptr<uvw::async_handle> m_clean_task_status_change_handle_;
-  void CleanTaskStatusChangeQueueCb_();
+  std::shared_ptr<uvw::async_handle> m_clean_job_status_change_handle_;
+  void CleanJobStatusChangeQueueCb_();
 
   // TODO: Move to Reservation Mini-Scheduler.
   std::thread m_resv_clean_thread_;
@@ -1140,8 +1140,8 @@ class TaskScheduler {
   void CleanResvTimerQueueCb_(const std::shared_ptr<uvw::loop>& uvw_loop);
 
   struct DependencyEvent {
-    task_id_t dependent_job_id;
-    task_id_t dependee_job_id;
+    job_id_t dependent_job_id;
+    job_id_t dependee_job_id;
     absl::Time event_time;
   };
 
@@ -1150,4 +1150,4 @@ class TaskScheduler {
 
 }  // namespace Ctld
 
-inline std::unique_ptr<Ctld::TaskScheduler> g_task_scheduler;
+inline std::unique_ptr<Ctld::JobScheduler> g_job_scheduler;

--- a/src/CraneCtld/JobScheduler.h
+++ b/src/CraneCtld/JobScheduler.h
@@ -318,7 +318,7 @@ class SchedulerAlgo {
       auto job_duration_begin_it = time_avail_res_map.upper_bound(start_time);
       if (job_duration_begin_it == time_avail_res_map.end()) {
         --job_duration_begin_it;  // job_duration_begin_it->first <=
-                                   // start_time < end_time
+                                  // start_time < end_time
         // Case #1
         //                     job duration
         //                   |<-------------->|
@@ -344,8 +344,8 @@ class SchedulerAlgo {
         //                      subtract resource here
 
         TimeAvailResMap::iterator inserted_it;
-        std::tie(inserted_it, ok) = time_avail_res_map.emplace(
-            end_time, job_duration_begin_it->second);
+        std::tie(inserted_it, ok) =
+            time_avail_res_map.emplace(end_time, job_duration_begin_it->second);
         CRANE_ASSERT_MSG(ok == true, "Insertion must be successful.");
 
         if (job_duration_begin_it->first == start_time) {
@@ -363,7 +363,7 @@ class SchedulerAlgo {
         }
       } else {
         --job_duration_begin_it;  // job_duration_begin_it->first <=
-                                   // start_time < end_time
+                                  // start_time < end_time
         // Case #3
         //                    job duration
         //                |<-------------->|
@@ -406,8 +406,8 @@ class SchedulerAlgo {
 
         if (job_duration_end_it->first != end_time) {
           TimeAvailResMap::iterator inserted_it;
-          std::tie(inserted_it, ok) = time_avail_res_map.emplace(
-              end_time, job_duration_end_it->second);
+          std::tie(inserted_it, ok) =
+              time_avail_res_map.emplace(end_time, job_duration_end_it->second);
           CRANE_ASSERT_MSG(ok == true, "Insertion must be successful.");
 
           CRANE_ASSERT(res <= job_duration_end_it->second);
@@ -783,18 +783,16 @@ class JobScheduler {
   std::future<CraneExpected<step_id_t>> SubmitStepAsync(
       std::unique_ptr<CommonStepInCtld> step);
 
-  std::future<CraneErrCode> HoldReleaseJobAsync(job_id_t job_id,
-                                                 int64_t secs);
+  std::future<CraneErrCode> HoldReleaseJobAsync(job_id_t job_id, int64_t secs);
 
   CraneErrCode ChangeJobTimeLimit(job_id_t job_id, int64_t secs);
 
   CraneErrCode ChangeJobPriority(job_id_t job_id, double priority);
 
   CraneErrCode ChangeJobExtraAttrs(job_id_t job_id,
-                                    const std::string& new_extra_attr);
+                                   const std::string& new_extra_attr);
 
-  std::optional<std::future<CraneRichError>> JobSubmitLuaCheck(
-      JobInCtld* job);
+  std::optional<std::future<CraneRichError>> JobSubmitLuaCheck(JobInCtld* job);
 
   void JobModifyLuaCheck(const crane::grpc::ModifyJobRequest& request,
                          crane::grpc::ModifyJobReply* response,
@@ -942,8 +940,7 @@ class JobScheduler {
   }
 
  private:
-  void RequeueRecoveredJobIntoPendingQueueLock_(
-      std::unique_ptr<JobInCtld> job);
+  void RequeueRecoveredJobIntoPendingQueueLock_(std::unique_ptr<JobInCtld> job);
 
   void PutRecoveredJobIntoRunningQueueLock_(std::unique_ptr<JobInCtld> job);
   void HandleFailToRecoverRngJob_(job_id_t job_id);

--- a/src/CraneCtld/LicensesManager.cpp
+++ b/src/CraneCtld/LicensesManager.cpp
@@ -18,7 +18,7 @@
 
 #include "LicensesManager.h"
 
-#include "TaskScheduler.h"
+#include "JobScheduler.h"
 
 namespace Ctld {
 
@@ -132,7 +132,7 @@ void LicensesManager::GetLicensesInfo(
 }
 
 std::expected<void, std::string> LicensesManager::CheckLicensesLegal(
-    const google::protobuf::RepeatedPtrField<crane::grpc::TaskToCtld::License>&
+    const google::protobuf::RepeatedPtrField<crane::grpc::JobToCtld::License>&
         lic_id_to_count,
     bool is_license_or) {
   auto licenses_map = m_licenses_map_.GetMapConstSharedPtr();

--- a/src/CraneCtld/LicensesManager.h
+++ b/src/CraneCtld/LicensesManager.h
@@ -56,7 +56,7 @@ class LicensesManager {
 
   std::expected<void, std::string> CheckLicensesLegal(
       const google::protobuf::RepeatedPtrField<
-          crane::grpc::TaskToCtld::License>& lic_id_to_count,
+          crane::grpc::JobToCtld::License>& lic_id_to_count,
       bool is_license_or);
 
   void CheckLicenseCountSufficient(std::vector<PdJobInScheduler*>* job_ptr_vec);

--- a/src/CraneCtld/LicensesManager.h
+++ b/src/CraneCtld/LicensesManager.h
@@ -55,8 +55,8 @@ class LicensesManager {
                        crane::grpc::QueryLicensesInfoReply* response);
 
   std::expected<void, std::string> CheckLicensesLegal(
-      const google::protobuf::RepeatedPtrField<
-          crane::grpc::JobToCtld::License>& lic_id_to_count,
+      const google::protobuf::RepeatedPtrField<crane::grpc::JobToCtld::License>&
+          lic_id_to_count,
       bool is_license_or);
 
   void CheckLicenseCountSufficient(std::vector<PdJobInScheduler*>* job_ptr_vec);

--- a/src/CraneCtld/Lua/LuaJobHandler.cpp
+++ b/src/CraneCtld/Lua/LuaJobHandler.cpp
@@ -75,8 +75,7 @@ CraneRichError LuaJobHandler::JobSubmit(const std::string& lua_script,
   PushPartitionList_(job->Username(), job->account, &part_list);
   auto& lua_state = lua_env->GetLuaState();
   sol::function submit = lua_state["crane_job_submit"];
-  sol::protected_function_result lua_result =
-      submit(job, part_list, job->uid);
+  sol::protected_function_result lua_result = submit(job, part_list, job->uid);
 
   if (!lua_result.valid()) {
     sol::error err = lua_result;

--- a/src/CraneCtld/Lua/LuaJobHandler.cpp
+++ b/src/CraneCtld/Lua/LuaJobHandler.cpp
@@ -20,7 +20,7 @@
 
 #include "AccountManager.h"
 #include "CranedMetaContainer.h"
-#include "TaskScheduler.h"
+#include "JobScheduler.h"
 
 namespace Ctld {
 
@@ -31,7 +31,7 @@ const std::vector<std::string> LuaJobHandler::kReqFxns = {"crane_job_submit",
 #endif
 
 CraneRichError LuaJobHandler::JobSubmit(const std::string& lua_script,
-                                        TaskInCtld* task) {
+                                        JobInCtld* job) {
   CraneRichError result = FormatRichErr(CraneErrCode::SUCCESS, "");
 #ifdef HAVE_LUA
   auto lua_env = std::make_unique<crane::LuaEnvironment>();
@@ -48,9 +48,9 @@ CraneRichError LuaJobHandler::JobSubmit(const std::string& lua_script,
         sol::state_view lua(ts);
         sol::object next = lua["next"];
 
-        crane::grpc::QueryTasksInfoRequest req;
-        std::unordered_map<job_id_t, crane::grpc::TaskInfo> job_info_map;
-        g_task_scheduler->QueryTasksInRam(&req, &job_info_map);
+        crane::grpc::QueryJobsInfoRequest req;
+        std::unordered_map<job_id_t, crane::grpc::JobInfo> job_info_map;
+        g_job_scheduler->QueryJobsInRam(&req, &job_info_map);
 
         sol::table all_jobs = lua.create_table();
         for (auto& [job_id, job_info] : job_info_map) {
@@ -72,11 +72,11 @@ CraneRichError LuaJobHandler::JobSubmit(const std::string& lua_script,
                          "Failed to load lua script");
 
   std::vector<crane::grpc::PartitionInfo> part_list;
-  PushPartitionList_(task->Username(), task->account, &part_list);
+  PushPartitionList_(job->Username(), job->account, &part_list);
   auto& lua_state = lua_env->GetLuaState();
   sol::function submit = lua_state["crane_job_submit"];
   sol::protected_function_result lua_result =
-      submit(task, part_list, task->uid);
+      submit(job, part_list, job->uid);
 
   if (!lua_result.valid()) {
     sol::error err = lua_result;
@@ -94,7 +94,7 @@ CraneRichError LuaJobHandler::JobSubmit(const std::string& lua_script,
 }
 
 CraneRichError LuaJobHandler::JobModify(const std::string& lua_script,
-                                        TaskInCtld* task) {
+                                        JobInCtld* job) {
   CraneRichError result = FormatRichErr(CraneErrCode::SUCCESS, "");
 #ifdef HAVE_LUA
   auto lua_env = std::make_unique<crane::LuaEnvironment>();
@@ -114,15 +114,15 @@ CraneRichError LuaJobHandler::JobModify(const std::string& lua_script,
     return FormatRichErr(CraneErrCode::ERR_LUA_FAILED,
                          "Failed to load lua script");
 
-  crane::grpc::TaskInfo task_info;
-  task->SetFieldsOfTaskInfo(&task_info);
+  crane::grpc::JobInfo job_info;
+  job->SetFieldsOfJobInfo(&job_info);
   std::vector<crane::grpc::PartitionInfo> part_list;
-  PushPartitionList_(task->Username(), task->account, &part_list);
+  PushPartitionList_(job->Username(), job->account, &part_list);
 
   auto& lua_state = lua_env->GetLuaState();
   sol::function modify = lua_state["crane_job_modify"];
   sol::protected_function_result lua_result =
-      modify(task, task_info, part_list, task->uid);
+      modify(job, job_info, part_list, job->uid);
 
   if (!lua_result.valid()) {
     sol::error err = lua_result;
@@ -156,7 +156,7 @@ void LuaJobHandler::RegisterGlobalFunctions_(
 
   lua_env.GetCraneTable().set_function(
       "get_job_env_field",
-      [](TaskInCtld& job, const std::string& env_name) -> std::string {
+      [](JobInCtld& job, const std::string& env_name) -> std::string {
         auto iter = job.env.find(env_name);
         if (iter == job.env.end()) return std::string{""};
         return iter->second;
@@ -164,7 +164,7 @@ void LuaJobHandler::RegisterGlobalFunctions_(
 
   lua_env.GetCraneTable().set_function(
       "set_job_env_field",
-      [](const std::string& name, const std::string& value, TaskInCtld* job) {
+      [](const std::string& name, const std::string& value, JobInCtld* job) {
         job->env.insert_or_assign(name, value);
       });
 
@@ -210,77 +210,77 @@ void LuaJobHandler::RegisterTypes_(const crane::LuaEnvironment& lua_env) {
   );
 
   // job_desc
-  lua_env.GetLuaState().new_usertype<TaskInCtld>("TaskInCtld",
-    "time_limit", sol::property([](const TaskInCtld& t) {
+  lua_env.GetLuaState().new_usertype<JobInCtld>("JobInCtld",
+    "time_limit", sol::property([](const JobInCtld& t) {
       return  absl::ToInt64Seconds(t.time_limit);
-    }, [](TaskInCtld& t, int64_t time_limit) {
+    }, [](JobInCtld& t, int64_t time_limit) {
       t.time_limit = absl::Seconds(time_limit);
     }),
-    "partition_id", &TaskInCtld::partition_id,
-    "req_node_res_view", &TaskInCtld::req_node_res_view,
-    "req_task_res_view", &TaskInCtld::req_task_res_view,
-    "req_total_res_view", &TaskInCtld::req_total_res_view,
-    "type", &TaskInCtld::type, "uid", &TaskInCtld::uid,
-    "gid", &TaskInCtld::gid, "account", &TaskInCtld::account,
-    "name", &TaskInCtld::name, "qos", &TaskInCtld::qos,
-    "node_num", &TaskInCtld::node_num,
+    "partition_id", &JobInCtld::partition_id,
+    "req_node_res_view", &JobInCtld::req_node_res_view,
+    "req_task_res_view", &JobInCtld::req_task_res_view,
+    "req_total_res_view", &JobInCtld::req_total_res_view,
+    "type", &JobInCtld::type, "uid", &JobInCtld::uid,
+    "gid", &JobInCtld::gid, "account", &JobInCtld::account,
+    "name", &JobInCtld::name, "qos", &JobInCtld::qos,
+    "node_num", &JobInCtld::node_num,
     // TODO: expose ntasks_per_node_min to Lua
-    "ntasks_per_node_min", &TaskInCtld::ntasks_per_node_min,
-    "ntasks_per_node_max", &TaskInCtld::ntasks_per_node_max,
+    "ntasks_per_node_min", &JobInCtld::ntasks_per_node_min,
+    "ntasks_per_node_max", &JobInCtld::ntasks_per_node_max,
     "included_nodes", sol::property(
-          [](const TaskInCtld& t) {
+          [](const JobInCtld& t) {
             return t.included_nodes | std::ranges::to<std::vector>();
           },
-          [](TaskInCtld& t, const std::vector<std::string>& nodes) {
+          [](JobInCtld& t, const std::vector<std::string>& nodes) {
             t.included_nodes.clear();
             t.included_nodes.insert(nodes.begin(), nodes.end());
           }),
       "excluded_nodes", sol::property(
-          [](const TaskInCtld& t) {
+          [](const JobInCtld& t) {
             return t.excluded_nodes | std::ranges::to<std::vector>();
           },
-          [](TaskInCtld& t, const std::vector<std::string>& nodes) {
+          [](JobInCtld& t, const std::vector<std::string>& nodes) {
             t.excluded_nodes.clear();
             t.excluded_nodes.insert(nodes.begin(), nodes.end());
           }),
-      "requeue_if_failed", &TaskInCtld::requeue_if_failed,
-      "get_user_env", &TaskInCtld::get_user_env,
-      "cmd_line", &TaskInCtld::cmd_line,
+      "requeue_if_failed", &JobInCtld::requeue_if_failed,
+      "get_user_env", &JobInCtld::get_user_env,
+      "cmd_line", &JobInCtld::cmd_line,
       "env", sol::property(
-          [&](const TaskInCtld& t) {
+          [&](const JobInCtld& t) {
             sol::table tbl = lua_env.GetLuaState().create_table();
             for (const auto& [name, value] : t.env) tbl[name] = value;
             return tbl;
           },
-          [](TaskInCtld& t, const sol::table& tbl) {
+          [](JobInCtld& t, const sol::table& tbl) {
             t.env.clear();
             for (const auto& [name, value] : tbl) {
               t.env[name.as<std::string>()] = value.as<std::string>();
             }
           }),
-      "cwd", &TaskInCtld::cwd, "extra_attr", &TaskInCtld::extra_attr,
-      "reservation", &TaskInCtld::reservation,
+      "cwd", &JobInCtld::cwd, "extra_attr", &JobInCtld::extra_attr,
+      "reservation", &JobInCtld::reservation,
       "begin_time", sol::property(
-        [](const TaskInCtld& t) -> int64_t {
+        [](const JobInCtld& t) -> int64_t {
           if (t.begin_time == absl::InfinitePast()) return 0;
           return absl::ToUnixSeconds(t.begin_time);
         },
-      [](TaskInCtld& t, int64_t unix_seconds) {
+      [](JobInCtld& t, int64_t unix_seconds) {
           if (unix_seconds == 0)
             t.begin_time = absl::InfinitePast();
           else
             t.begin_time = absl::FromUnixSeconds(unix_seconds);
         }),
-      "exclusive", &TaskInCtld::exclusive,
+      "exclusive", &JobInCtld::exclusive,
       "licenses_count", sol::property(
-          [&](const TaskInCtld& t) {
+          [&](const JobInCtld& t) {
             sol::table tbl = lua_env.GetLuaState().create_table();
             for (const auto& [name, value] : t.licenses_count) {
               tbl[name] = value;
             }
             return tbl;
           },
-          [](TaskInCtld& t, const sol::table& tbl) {
+          [](JobInCtld& t, const sol::table& tbl) {
             t.licenses_count.clear();
             for (const auto& [name, value] : tbl) {
               t.licenses_count.insert_or_assign(name.as<std::string>(),
@@ -289,109 +289,109 @@ void LuaJobHandler::RegisterTypes_(const crane::LuaEnvironment& lua_env) {
         }));
 
   // crane.jobs
-  using TaskInfo = crane::grpc::TaskInfo;
-  lua_env.GetLuaState().new_usertype<TaskInfo>("TaskInfo",
-    "type", sol::property([](const TaskInfo& t) {
+  using JobInfo = crane::grpc::JobInfo;
+  lua_env.GetLuaState().new_usertype<JobInfo>("JobInfo",
+    "type", sol::property([](const JobInfo& t) {
       return static_cast<int>(t.type());
     }),
-    "task_id", sol::property([](const TaskInfo& t) {
-      return t.task_id();
+    "job_id", sol::property([](const JobInfo& t) {
+      return t.job_id();
     }),
-    "name", sol::property([](TaskInfo& t) {
+    "name", sol::property([](JobInfo& t) {
       return t.name();
     }),
-    "partition", sol::property([](const TaskInfo& t) {
+    "partition", sol::property([](const JobInfo& t) {
       return t.partition();
     }),
-    "uid", sol::property([](const TaskInfo& t) {
+    "uid", sol::property([](const JobInfo& t) {
       return t.uid();
     }),
-    "time_limit", sol::property([](const TaskInfo& t) {
+    "time_limit", sol::property([](const JobInfo& t) {
       return google::protobuf::util::TimeUtil::DurationToSeconds(t.time_limit());
     }),
-    "end_time", sol::property([](const TaskInfo& t) {
+    "end_time", sol::property([](const JobInfo& t) {
       return t.end_time().seconds();
     }),
-    "submit_time", sol::property([](const TaskInfo& t) {
+    "submit_time", sol::property([](const JobInfo& t) {
       return t.submit_time().seconds();
     }),
-    "account", sol::property([](const TaskInfo& t) {
+    "account", sol::property([](const JobInfo& t) {
       return t.account();
     }),
-    "node_num", sol::property([](const TaskInfo& t) {
+    "node_num", sol::property([](const JobInfo& t) {
       return t.node_num();
     }),
-    "cmd_line", sol::property([](const TaskInfo& t) {
+    "cmd_line", sol::property([](const JobInfo& t) {
       return t.cmd_line();
     }),
-    "cwd", sol::property([](const TaskInfo& t) {
+    "cwd", sol::property([](const JobInfo& t) {
       return t.cwd();
     }),
-    "username", sol::property([](const TaskInfo& t) {
+    "username", sol::property([](const JobInfo& t) {
       return t.username();
     }),
-    "qos", sol::property([](const TaskInfo& t) {
+    "qos", sol::property([](const JobInfo& t) {
       return t.qos();
     }),
-    "req_total_res_view", sol::property([](const TaskInfo& t) {
+    "req_total_res_view", sol::property([](const JobInfo& t) {
       return static_cast<ResourceView>(t.req_total_res_view());
     }),
-    "licenses_count", sol::property([&](const TaskInfo& t) {
+    "licenses_count", sol::property([&](const JobInfo& t) {
       sol::table tbl = lua_env.GetLuaState().create_table();
             for (const auto& [name, value] : t.licenses_count()) {
               tbl[name] = value;
             }
             return tbl;
     }),
-    "req_nodes", sol::property([](const TaskInfo& t) {
+    "req_nodes", sol::property([](const JobInfo& t) {
       return t.req_nodes() | std::ranges::to<std::vector>();
     }),
-    "exclude_nodes", sol::property([](const TaskInfo& t) {
+    "exclude_nodes", sol::property([](const JobInfo& t) {
       return t.exclude_nodes() | std::ranges::to<std::vector>();
     }),
-    "extra_attr", sol::property([](const TaskInfo& t) {
+    "extra_attr", sol::property([](const JobInfo& t) {
       return t.extra_attr();
     }),
-    "reservation", sol::property([](const TaskInfo& t) {
+    "reservation", sol::property([](const JobInfo& t) {
       return t.reservation();
     }),
-    "held", sol::property([](const TaskInfo& t) {
+    "held", sol::property([](const JobInfo& t) {
       return t.held();
     }),
-    "status", sol::property([](const TaskInfo& t) {
+    "status", sol::property([](const JobInfo& t) {
       return t.status();
     }),
-    "exit_code", sol::property([](const TaskInfo& t) {
+    "exit_code", sol::property([](const JobInfo& t) {
       return t.exit_code();
     }),
-    "priority", sol::property([](const TaskInfo& t) {
+    "priority", sol::property([](const JobInfo& t) {
       return t.priority();
     }),
-    "pending_reason", sol::property([](const TaskInfo& t) {
+    "pending_reason", sol::property([](const JobInfo& t) {
       if (t.has_pending_reason())
         return t.pending_reason();
 
       return std::string{""};
     }),
-    "craned_list", sol::property([](const TaskInfo& t) {
+    "craned_list", sol::property([](const JobInfo& t) {
       if (t.has_craned_list())
         return t.craned_list();
 
       return std::string{""};
     }),
-    "elapsed_time", sol::property([](const TaskInfo& t) {
+    "elapsed_time", sol::property([](const JobInfo& t) {
       return google::protobuf::util::TimeUtil::DurationToSeconds(t.elapsed_time());
     }),
-    "execution_node", sol::property([](const TaskInfo& t) {
+    "execution_node", sol::property([](const JobInfo& t) {
       return t.execution_node() | std::ranges::to<std::vector>();
     }),
-    "exclusive", sol::property([](const TaskInfo& t) {
+    "exclusive", sol::property([](const JobInfo& t) {
       return t.exclusive();
     }),
-    "allocated_res_view", sol::property([](const TaskInfo& t) {
+    "allocated_res_view", sol::property([](const JobInfo& t) {
       return static_cast<ResourceView>(t.allocated_res_view());
     }),
-    "env", sol::property([&](const TaskInfo& t) {
+    "env", sol::property([&](const JobInfo& t) {
       sol::table tbl = lua_env.GetLuaState().create_table();
       for (const auto& [name, value] : t.env()) tbl[name] = value;
         return tbl;

--- a/src/CraneCtld/Lua/LuaJobHandler.h
+++ b/src/CraneCtld/Lua/LuaJobHandler.h
@@ -37,9 +37,9 @@ class LuaJobHandler {
   LuaJobHandler& operator=(LuaJobHandler&&) = delete;
 
   static CraneRichError JobSubmit(const std::string& lua_script,
-                                  TaskInCtld* task);
+                                  JobInCtld* job);
   static CraneRichError JobModify(const std::string& lua_script,
-                                  TaskInCtld* task);
+                                  JobInCtld* job);
 
  private:
 #ifdef HAVE_LUA

--- a/src/CraneCtld/RpcService/CranedKeeper.cpp
+++ b/src/CraneCtld/RpcService/CranedKeeper.cpp
@@ -269,8 +269,7 @@ CraneErrCode CranedStub::FreeSteps(
   return CraneErrCode::SUCCESS;
 }
 
-CraneErrCode CranedStub::ChangeJobTimeLimit(uint32_t job_id,
-                                            uint64_t seconds) {
+CraneErrCode CranedStub::ChangeJobTimeLimit(uint32_t job_id, uint64_t seconds) {
   using crane::grpc::ChangeJobTimeLimitReply;
   using crane::grpc::ChangeJobTimeLimitRequest;
 

--- a/src/CraneCtld/RpcService/CranedKeeper.cpp
+++ b/src/CraneCtld/RpcService/CranedKeeper.cpp
@@ -19,7 +19,7 @@
 #include "CranedKeeper.h"
 
 #include "CranedMetaContainer.h"
-#include "TaskScheduler.h"
+#include "JobScheduler.h"
 #include "protos/Crane.pb.h"
 
 namespace Ctld {
@@ -48,7 +48,7 @@ void CranedStub::ConfigureCraned(const CranedId &craned_id,
   request.set_ok(true);
   *request.mutable_token() = token;
 
-  g_task_scheduler->QueryRnJobOnCtldForNodeConfig(craned_id, &request);
+  g_job_scheduler->QueryRnJobOnCtldForNodeConfig(craned_id, &request);
 
   ClientContext context;
   google::protobuf::Empty reply;
@@ -88,7 +88,7 @@ CraneErrCode CranedStub::TerminateSteps(
   status = m_stub_->TerminateSteps(&context, request, &reply);
   if (!status.ok()) {
     CRANE_DEBUG(
-        "TerminateRunningTask RPC for Node {} returned with status not ok: {}",
+        "TerminateRunningJob RPC for Node {} returned with status not ok: {}",
         m_craned_id_, status.error_message());
     HandleGrpcErrorCode_(status.error_code());
     return CraneErrCode::ERR_RPC_FAILURE;
@@ -119,7 +119,7 @@ CraneErrCode CranedStub::TerminateOrphanedSteps(
   status = m_stub_->TerminateOrphanedStep(&context, request, &reply);
   if (!status.ok()) {
     CRANE_DEBUG(
-        "TerminateOrphanedTasks RPC for Node {} returned status not ok: {}",
+        "TerminateOrphanedJobs RPC for Node {} returned status not ok: {}",
         m_craned_id_, status.error_message());
     HandleGrpcErrorCode_(status.error_code());
     return CraneErrCode::ERR_RPC_FAILURE;
@@ -161,7 +161,7 @@ CraneErrCode CranedStub::AllocJobs(
   return CraneErrCode::SUCCESS;
 }
 
-CraneErrCode CranedStub::FreeJobs(const std::vector<task_id_t> &task) {
+CraneErrCode CranedStub::FreeJobs(const std::vector<job_id_t> &jobs) {
   using crane::grpc::FreeJobsReply;
   using crane::grpc::FreeJobsRequest;
 
@@ -173,7 +173,7 @@ CraneErrCode CranedStub::FreeJobs(const std::vector<task_id_t> &task) {
   context.set_deadline(std::chrono::system_clock::now() +
                        std::chrono::seconds(kCtldRpcTimeoutSeconds));
 
-  request.mutable_job_id_list()->Assign(task.begin(), task.end());
+  request.mutable_job_id_list()->Assign(jobs.begin(), jobs.end());
 
   status = m_stub_->FreeJobs(&context, request, &reply);
   if (!status.ok()) {
@@ -269,7 +269,7 @@ CraneErrCode CranedStub::FreeSteps(
   return CraneErrCode::SUCCESS;
 }
 
-CraneErrCode CranedStub::ChangeJobTimeLimit(uint32_t task_id,
+CraneErrCode CranedStub::ChangeJobTimeLimit(uint32_t job_id,
                                             uint64_t seconds) {
   using crane::grpc::ChangeJobTimeLimitReply;
   using crane::grpc::ChangeJobTimeLimitRequest;
@@ -281,12 +281,12 @@ CraneErrCode CranedStub::ChangeJobTimeLimit(uint32_t task_id,
 
   context.set_deadline(std::chrono::system_clock::now() +
                        std::chrono::seconds(kCtldRpcTimeoutSeconds));
-  request.set_task_id(task_id);
+  request.set_job_id(job_id);
   request.set_time_limit_seconds(seconds);
   status = m_stub_->ChangeJobTimeLimit(&context, request, &reply);
 
   if (!status.ok()) {
-    CRANE_ERROR("ChangeTaskTimeLimitAsync to Craned {} failed: {} ",
+    CRANE_ERROR("ChangeJobTimeLimitAsync to Craned {} failed: {} ",
                 m_craned_id_, status.error_message());
     HandleGrpcErrorCode_(status.error_code());
     return CraneErrCode::ERR_RPC_FAILURE;

--- a/src/CraneCtld/RpcService/CranedKeeper.h
+++ b/src/CraneCtld/RpcService/CranedKeeper.h
@@ -73,7 +73,7 @@ class CranedStub {
 
   CraneErrCode AllocJobs(const std::vector<crane::grpc::JobToD> &jobs);
 
-  CraneErrCode FreeJobs(const std::vector<task_id_t> &task);
+  CraneErrCode FreeJobs(const std::vector<job_id_t> &jobs);
 
   CraneErrCode AllocSteps(const std::vector<crane::grpc::StepToD> &steps);
 
@@ -89,7 +89,7 @@ class CranedStub {
   CraneErrCode TerminateOrphanedSteps(
       const std::unordered_map<job_id_t, std::set<step_id_t>> &steps);
 
-  CraneErrCode ChangeJobTimeLimit(uint32_t task_id, uint64_t seconds);
+  CraneErrCode ChangeJobTimeLimit(uint32_t job_id, uint64_t seconds);
 
   crane::grpc::AttachContainerStepReply AttachContainerStep(
       const crane::grpc::AttachContainerStepRequest &request);

--- a/src/CraneCtld/RpcService/CtldGrpcServer.cpp
+++ b/src/CraneCtld/RpcService/CtldGrpcServer.cpp
@@ -26,10 +26,10 @@
 #include "CranedMetaContainer.h"
 #include "CtldPublicDefs.h"
 #include "EmbeddedDbClient.h"
+#include "JobScheduler.h"
 #include "LicensesManager.h"
 #include "Lua/LuaJobHandler.h"
 #include "Security/VaultClient.h"
-#include "JobScheduler.h"
 #include "absl/strings/ascii.h"
 #include "crane/PluginClient.h"
 #include "protos/PublicDefs.pb.h"
@@ -144,7 +144,7 @@ grpc::Status CtldForInternalServiceImpl::CranedRegister(
   if (!orphaned_steps.empty()) {
     auto now = google::protobuf::util::TimeUtil::GetCurrentTime();
     g_job_scheduler->TerminateOrphanedSteps(orphaned_steps,
-                                             request->craned_id());
+                                            request->craned_id());
     for (const auto& [job_id, steps] : orphaned_steps) {
       // Reverse order: we should process larger step_id first to avoid warnings
       // abort daemon/primary steps
@@ -451,7 +451,7 @@ grpc::Status CtldForInternalServiceImpl::CforedStream(
           if (g_job_scheduler->TerminatePendingOrRunningIaStep(
                   payload.job_id(), payload.step_id()) != CraneErrCode::SUCCESS)
             stream_writer->WriteJobCompletionAckReply(payload.job_id(),
-                                                       payload.step_id());
+                                                      payload.step_id());
           else {
             CRANE_TRACE(
                 "[Step #{}.{}] Termination succeeded. "
@@ -482,9 +482,8 @@ grpc::Status CtldForInternalServiceImpl::CforedStream(
       stream_writer->Invalidate();
       m_ctld_server_->m_mtx_.Lock();
 
-      auto running_steps =
-          m_ctld_server_->m_cfored_running_jobs_[cfored_name] |
-          std::ranges::to<std::unordered_map>();
+      auto running_steps = m_ctld_server_->m_cfored_running_jobs_[cfored_name] |
+                           std::ranges::to<std::unordered_map>();
       m_ctld_server_->m_cfored_running_jobs_.erase(cfored_name);
       m_ctld_server_->m_mtx_.Unlock();
 
@@ -863,8 +862,8 @@ grpc::Status CraneCtldServiceImpl::ModifyJob(
   CraneErrCode err;
   if (request->attribute() == ModifyJobRequest::TimeLimit) {
     for (auto job_id : job_ids) {
-      err = g_job_scheduler->ChangeJobTimeLimit(
-          job_id, request->time_limit_seconds());
+      err = g_job_scheduler->ChangeJobTimeLimit(job_id,
+                                                request->time_limit_seconds());
       if (err == CraneErrCode::SUCCESS) {
         response->add_modified_jobs(job_id);
       } else if (err == CraneErrCode::ERR_NON_EXISTENT) {
@@ -884,7 +883,7 @@ grpc::Status CraneCtldServiceImpl::ModifyJob(
   } else if (request->attribute() == ModifyJobRequest::Priority) {
     for (auto job_id : job_ids) {
       err = g_job_scheduler->ChangeJobPriority(job_id,
-                                                 request->mandated_priority());
+                                               request->mandated_priority());
       if (err == CraneErrCode::SUCCESS) {
         response->add_modified_jobs(job_id);
       } else if (err == CraneErrCode::ERR_NON_EXISTENT) {
@@ -902,8 +901,8 @@ grpc::Status CraneCtldServiceImpl::ModifyJob(
     std::vector<std::pair<job_id_t, std::future<CraneErrCode>>> results;
     results.reserve(job_ids.size());
     for (auto job_id : job_ids) {
-      results.emplace_back(
-          job_id, g_job_scheduler->HoldReleaseJobAsync(job_id, secs));
+      results.emplace_back(job_id,
+                           g_job_scheduler->HoldReleaseJobAsync(job_id, secs));
     }
     for (auto& [job_id, res] : results) {
       err = res.get();
@@ -1150,12 +1149,12 @@ grpc::Status CraneCtldServiceImpl::QueryJobsInfo(
       it = job_info_map.erase(it);
     }
 
-    std::sort(
-        job_info_list->begin(), job_info_list->end(),
-        [](const crane::grpc::JobInfo& a, const crane::grpc::JobInfo& b) {
-          return (a.status() == b.status()) ? (a.priority() > b.priority())
-                                            : (a.status() < b.status());
-        });
+    std::sort(job_info_list->begin(), job_info_list->end(),
+              [](const crane::grpc::JobInfo& a, const crane::grpc::JobInfo& b) {
+                return (a.status() == b.status())
+                           ? (a.priority() > b.priority())
+                           : (a.status() < b.status());
+              });
 
     if (job_info_list->size() > limit)
       job_info_list->DeleteSubrange(limit, job_info_list->size() - limit);

--- a/src/CraneCtld/RpcService/CtldGrpcServer.cpp
+++ b/src/CraneCtld/RpcService/CtldGrpcServer.cpp
@@ -29,7 +29,7 @@
 #include "LicensesManager.h"
 #include "Lua/LuaJobHandler.h"
 #include "Security/VaultClient.h"
-#include "TaskScheduler.h"
+#include "JobScheduler.h"
 #include "absl/strings/ascii.h"
 #include "crane/PluginClient.h"
 #include "protos/PublicDefs.pb.h"
@@ -44,7 +44,7 @@ grpc::Status CtldForInternalServiceImpl::StepStatusChange(
     return grpc::Status{grpc::StatusCode::UNAVAILABLE,
                         "CraneCtld Server is not ready"};
 
-  g_task_scheduler->StepStatusChangeAsync(
+  g_job_scheduler->StepStatusChangeAsync(
       request->job_id(), request->step_id(), request->craned_id(),
       request->new_status(), request->exit_code(), request->reason(),
       request->timestamp());
@@ -143,15 +143,15 @@ grpc::Status CtldForInternalServiceImpl::CranedRegister(
              util::JobStepsToString(orphaned_steps));
   if (!orphaned_steps.empty()) {
     auto now = google::protobuf::util::TimeUtil::GetCurrentTime();
-    g_task_scheduler->TerminateOrphanedSteps(orphaned_steps,
+    g_job_scheduler->TerminateOrphanedSteps(orphaned_steps,
                                              request->craned_id());
     for (const auto& [job_id, steps] : orphaned_steps) {
       // Reverse order: we should process larger step_id first to avoid warnings
       // abort daemon/primary steps
       for (const auto step_id : steps | std::views::reverse)
-        g_task_scheduler->StepStatusChangeWithReasonAsync(
+        g_job_scheduler->StepStatusChangeWithReasonAsync(
             job_id, step_id, request->craned_id(),
-            crane::grpc::TaskStatus::Failed, ExitCode::EC_CRANED_DOWN,
+            crane::grpc::JobStatus::Failed, ExitCode::EC_CRANED_DOWN,
             "Craned re-registered but step lost.", now);
     }
   }
@@ -221,7 +221,7 @@ grpc::Status CtldForInternalServiceImpl::CforedStream(
     return grpc::Status{grpc::StatusCode::UNAVAILABLE,
                         "CraneCtld Server is not ready"};
 
-  using crane::grpc::InteractiveTaskType;
+  using crane::grpc::InteractiveJobType;
   using crane::grpc::StreamCforedRequest;
   using crane::grpc::StreamCtldReply;
   using grpc::Status;
@@ -242,15 +242,15 @@ grpc::Status CtldForInternalServiceImpl::CforedStream(
   auto cb_step_res_allocated =
       [writer_weak_ptr](const StepInteractiveMeta::StepResAllocArgs& arg) {
         if (auto writer = writer_weak_ptr.lock(); writer)
-          writer->WriteTaskResAllocReply(arg);
+          writer->WriteJobResAllocReply(arg);
       };
   auto cb_step_cancel =
       [writer_weak_ptr](StepInteractiveMeta::StepCancelArgs const& args) {
         auto& [job_id, step_id] = args;
-        CRANE_TRACE("[Step #{}.{}] Sending TaskCancelRequest in task_cancel",
+        CRANE_TRACE("[Step #{}.{}] Sending JobCancelRequest in job_cancel",
                     job_id, step_id);
         if (auto writer = writer_weak_ptr.lock(); writer)
-          writer->WriteTaskCancelRequest(job_id, step_id);
+          writer->WriteJobCancelRequest(job_id, step_id);
       };
   auto cb_step_completed =
       [this,
@@ -260,23 +260,23 @@ grpc::Status CtldForInternalServiceImpl::CforedStream(
                     job_id, step_id);
         if (auto writer = writer_weak_ptr.lock(); writer) {
           if (send_completion_ack)
-            writer->WriteTaskCompletionAckReply(job_id, step_id);
+            writer->WriteJobCompletionAckReply(job_id, step_id);
         } else {
           CRANE_ERROR(
               "[Step #{}.{}] Stream writer of has been destroyed. "
-              "TaskCompletionAckReply will not be sent.",
+              "JobCompletionAckReply will not be sent.",
               job_id, step_id);
         }
 
         m_ctld_server_->m_mtx_.Lock();
 
         // If cfored disconnected, the cfored_name should have be
-        // removed from the map and the task completion callback is
-        // generated from cleaning the remaining tasks by calling
-        // g_task_scheduler->TerminateTask(), we should ignore this
-        // callback since the task id has already been cleaned.
-        auto iter = m_ctld_server_->m_cfored_running_tasks_.find(cfored_name);
-        if (iter != m_ctld_server_->m_cfored_running_tasks_.end()) {
+        // removed from the map and the job completion callback is
+        // generated from cleaning the remaining jobs by calling
+        // g_job_scheduler->TerminateJob(), we should ignore this
+        // callback since the job id has already been cleaned.
+        auto iter = m_ctld_server_->m_cfored_running_jobs_.find(cfored_name);
+        if (iter != m_ctld_server_->m_cfored_running_jobs_.end()) {
           auto& cfored_job_map = iter->second;
           auto job_iter = cfored_job_map.find(job_id);
           if (job_iter != cfored_job_map.end()) {
@@ -285,14 +285,14 @@ grpc::Status CtldForInternalServiceImpl::CforedStream(
             if (step_set.empty()) cfored_job_map.erase(job_iter);
             if (!present) {
               CRANE_ERROR(
-                  "[Step #{}.{}] not found in cfored {} running task map "
-                  "when handling task completion callback.",
+                  "[Step #{}.{}] not found in cfored {} running job map "
+                  "when handling job completion callback.",
                   job_id, step_id, cfored_name);
             }
           } else {
             CRANE_ERROR(
-                "Job #{} not found in cfored {} running task map when "
-                "handling task completion callback.",
+                "Job #{} not found in cfored {} running job map when "
+                "handling job completion callback.",
                 job_id, cfored_name);
           }
         }
@@ -337,20 +337,20 @@ grpc::Status CtldForInternalServiceImpl::CforedStream(
       ok = stream->Read(&cfored_request);
       if (ok) {
         switch (cfored_request.type()) {
-        case StreamCforedRequest::TASK_REQUEST: {
-          auto const& payload = cfored_request.payload_task_req();
-          auto task = std::make_unique<TaskInCtld>();
-          task->SetFieldsByTaskToCtld(payload.task());
+        case StreamCforedRequest::JOB_REQUEST: {
+          auto const& payload = cfored_request.payload_job_req();
+          auto job = std::make_unique<JobInCtld>();
+          job->SetFieldsByJobToCtld(payload.job());
 
           InteractiveMeta meta;
           meta.cfored_name = cfored_name;
           meta.cb_step_res_allocated = cb_step_res_allocated;
           meta.cb_step_cancel = cb_step_cancel;
           meta.cb_step_completed = cb_step_completed;
-          task->meta = std::move(meta);
+          job->meta = std::move(meta);
 
           std::expected<std::pair<job_id_t, step_id_t>, std::string> result;
-          auto lua_result = g_task_scheduler->JobSubmitLuaCheck(task.get());
+          auto lua_result = g_job_scheduler->JobSubmitLuaCheck(job.get());
           if (lua_result) {
             auto rich_err = lua_result.value().get();
             if (rich_err.code() != CraneErrCode::SUCCESS) {
@@ -364,9 +364,9 @@ grpc::Status CtldForInternalServiceImpl::CforedStream(
 
           if (result) {
             auto submit_result =
-                g_task_scheduler->SubmitTaskToScheduler(std::move(task));
+                g_job_scheduler->SubmitJobToScheduler(std::move(job));
             if (submit_result.has_value()) {
-              CraneExpected<task_id_t> job_result = submit_result.value().get();
+              CraneExpected<job_id_t> job_result = submit_result.value().get();
               if (job_result.has_value()) {
                 result =
                     std::expected<std::pair<job_id_t, step_id_t>, std::string>{
@@ -379,7 +379,7 @@ grpc::Status CtldForInternalServiceImpl::CforedStream(
             }
           }
 
-          ok = stream_writer->WriteTaskIdReply(payload.pid(), result);
+          ok = stream_writer->WriteJobIdReply(payload.pid(), result);
 
           if (!ok) {
             CRANE_ERROR(
@@ -391,7 +391,7 @@ grpc::Status CtldForInternalServiceImpl::CforedStream(
             if (result.has_value()) {
               auto [job_id, step_id] = result.value();
               m_ctld_server_->m_mtx_.Lock();
-              m_ctld_server_->m_cfored_running_tasks_[cfored_name][job_id]
+              m_ctld_server_->m_cfored_running_jobs_[cfored_name][job_id]
                   .insert(step_id);
               m_ctld_server_->m_mtx_.Unlock();
             }
@@ -411,7 +411,7 @@ grpc::Status CtldForInternalServiceImpl::CforedStream(
           step->ia_meta = std::move(meta);
 
           auto submit_result =
-              g_task_scheduler->SubmitStepAsync(std::move(step));
+              g_job_scheduler->SubmitStepAsync(std::move(step));
           std::expected<std::pair<job_id_t, step_id_t>, std::string> result;
           auto submit_expt = submit_result.get();
           if (submit_expt.has_value()) {
@@ -422,7 +422,7 @@ grpc::Status CtldForInternalServiceImpl::CforedStream(
             result = std::unexpected(CraneErrStr(submit_expt.error()));
           }
 
-          ok = stream_writer->WriteTaskIdReply(payload.pid(), result);
+          ok = stream_writer->WriteJobIdReply(payload.pid(), result);
 
           if (!ok) {
             CRANE_ERROR(
@@ -434,28 +434,28 @@ grpc::Status CtldForInternalServiceImpl::CforedStream(
             if (result.has_value()) {
               auto [job_id, step_id] = result.value();
               m_ctld_server_->m_mtx_.Lock();
-              m_ctld_server_->m_cfored_running_tasks_[cfored_name][job_id]
+              m_ctld_server_->m_cfored_running_jobs_[cfored_name][job_id]
                   .insert(step_id);
               m_ctld_server_->m_mtx_.Unlock();
             }
           }
         } break;
 
-        case StreamCforedRequest::TASK_COMPLETION_REQUEST: {
-          auto const& payload = cfored_request.payload_task_complete_req();
+        case StreamCforedRequest::JOB_COMPLETION_REQUEST: {
+          auto const& payload = cfored_request.payload_job_complete_req();
           CRANE_TRACE("[Step #{}.{}] Recv StepCompletionReq.", payload.job_id(),
                       payload.step_id());
           // Just send ack if step not found (finished step triggered a cancel
           // req to cfored and a completion req from frontend) to kick cfored
           // statemachine. If found, will send ack when process status change.
-          if (g_task_scheduler->TerminatePendingOrRunningIaStep(
+          if (g_job_scheduler->TerminatePendingOrRunningIaStep(
                   payload.job_id(), payload.step_id()) != CraneErrCode::SUCCESS)
-            stream_writer->WriteTaskCompletionAckReply(payload.job_id(),
+            stream_writer->WriteJobCompletionAckReply(payload.job_id(),
                                                        payload.step_id());
           else {
             CRANE_TRACE(
                 "[Step #{}.{}] Termination succeeded. "
-                "Leave TaskCompletionAck to TaskStatusChange.",
+                "Leave JobCompletionAck to JobStatusChange.",
                 payload.job_id(), payload.step_id());
           }
         } break;
@@ -483,12 +483,12 @@ grpc::Status CtldForInternalServiceImpl::CforedStream(
       m_ctld_server_->m_mtx_.Lock();
 
       auto running_steps =
-          m_ctld_server_->m_cfored_running_tasks_[cfored_name] |
+          m_ctld_server_->m_cfored_running_jobs_[cfored_name] |
           std::ranges::to<std::unordered_map>();
-      m_ctld_server_->m_cfored_running_tasks_.erase(cfored_name);
+      m_ctld_server_->m_cfored_running_jobs_.erase(cfored_name);
       m_ctld_server_->m_mtx_.Unlock();
 
-      g_task_scheduler->TerminateRunningStep(running_steps);
+      g_job_scheduler->TerminateRunningStep(running_steps);
 
       return Status::OK;
     }
@@ -496,27 +496,27 @@ grpc::Status CtldForInternalServiceImpl::CforedStream(
   }
 }
 
-grpc::Status CraneCtldServiceImpl::SubmitBatchTask(
+grpc::Status CraneCtldServiceImpl::SubmitBatchJob(
     grpc::ServerContext* context,
-    const crane::grpc::SubmitBatchTaskRequest* request,
-    crane::grpc::SubmitBatchTaskReply* response) {
+    const crane::grpc::SubmitBatchJobRequest* request,
+    crane::grpc::SubmitBatchJobReply* response) {
   if (!g_runtime_status.srv_ready.load(std::memory_order_acquire))
     return grpc::Status{grpc::StatusCode::UNAVAILABLE,
                         "CraneCtld Server is not ready"};
-  if (auto msg = CheckCertAndUIDAllowed_(context, request->task().uid()); msg)
+  if (auto msg = CheckCertAndUIDAllowed_(context, request->job().uid()); msg)
     return {grpc::StatusCode::UNAUTHENTICATED, msg.value()};
 
   // Check job type
-  if (request->task().type() == crane::grpc::TaskType::Container &&
+  if (request->job().type() == crane::grpc::JobType::Container &&
       !g_config.Container.Enabled) {
     response->set_ok(false);
     response->set_code(CraneErrCode::ERR_CRI_DISABLED);
     return grpc::Status::OK;
   }
 
-  auto task = std::make_unique<TaskInCtld>();
-  task->SetFieldsByTaskToCtld(request->task());
-  auto lua_result = g_task_scheduler->JobSubmitLuaCheck(task.get());
+  auto job = std::make_unique<JobInCtld>();
+  job->SetFieldsByJobToCtld(request->job());
+  auto lua_result = g_job_scheduler->JobSubmitLuaCheck(job.get());
   if (lua_result) {
     auto rich_err = lua_result.value().get();
     if (rich_err.code() != CraneErrCode::SUCCESS) {
@@ -527,15 +527,15 @@ grpc::Status CraneCtldServiceImpl::SubmitBatchTask(
     }
   }
 
-  auto result = g_task_scheduler->SubmitTaskToScheduler(std::move(task));
+  auto result = g_job_scheduler->SubmitJobToScheduler(std::move(job));
   if (result.has_value()) {
-    CraneExpected<task_id_t> task_result = result.value().get();
-    if (task_result.has_value()) {
+    CraneExpected<job_id_t> job_result = result.value().get();
+    if (job_result.has_value()) {
       response->set_ok(true);
-      response->set_task_id(task_result.value());
+      response->set_job_id(job_result.value());
     } else {
       response->set_ok(false);
-      response->set_code(task_result.error());
+      response->set_code(job_result.error());
     }
   } else {
     response->set_ok(false);
@@ -559,7 +559,7 @@ grpc::Status CraneCtldServiceImpl::SubmitContainerStep(
   response->set_job_id(request->step().job_id());
 
   // Only container steps are accepted here.
-  if (request->step().type() != crane::grpc::TaskType::Container) {
+  if (request->step().type() != crane::grpc::JobType::Container) {
     response->set_ok(false);
     response->set_code(CraneErrCode::ERR_INVALID_PARAM);
     return grpc::Status::OK;
@@ -581,7 +581,7 @@ grpc::Status CraneCtldServiceImpl::SubmitContainerStep(
   auto step = std::make_unique<CommonStepInCtld>();
   step->SetFieldsByStepToCtld(request->step());
 
-  auto submit_future = g_task_scheduler->SubmitStepAsync(std::move(step));
+  auto submit_future = g_job_scheduler->SubmitStepAsync(std::move(step));
   auto submit_result = submit_future.get();
 
   if (submit_result.has_value()) {
@@ -595,49 +595,49 @@ grpc::Status CraneCtldServiceImpl::SubmitContainerStep(
   return grpc::Status::OK;
 }
 
-grpc::Status CraneCtldServiceImpl::SubmitBatchTasks(
+grpc::Status CraneCtldServiceImpl::SubmitBatchJobs(
     grpc::ServerContext* context,
-    const crane::grpc::SubmitBatchTasksRequest* request,
-    crane::grpc::SubmitBatchTasksReply* response) {
+    const crane::grpc::SubmitBatchJobsRequest* request,
+    crane::grpc::SubmitBatchJobsReply* response) {
   if (!g_runtime_status.srv_ready.load(std::memory_order_acquire))
     return grpc::Status{grpc::StatusCode::UNAVAILABLE,
                         "CraneCtld Server is not ready"};
-  if (auto msg = CheckCertAndUIDAllowed_(context, request->task().uid()); msg)
+  if (auto msg = CheckCertAndUIDAllowed_(context, request->job().uid()); msg)
     return {grpc::StatusCode::UNAUTHENTICATED, msg.value()};
 
-  // Check task type
-  if (request->task().type() == crane::grpc::TaskType::Container &&
+  // Check job type
+  if (request->job().type() == crane::grpc::JobType::Container &&
       !g_config.Container.Enabled) {
-    response->add_task_id_list(0);
+    response->add_job_id_list(0);
     response->add_code_list(CraneErrCode::ERR_CRI_DISABLED);
     return grpc::Status::OK;
   }
 
-  std::vector<CraneExpected<std::future<CraneExpected<task_id_t>>>> results;
+  std::vector<CraneExpected<std::future<CraneExpected<job_id_t>>>> results;
 
-  uint32_t task_count = request->count();
-  const auto& task_to_ctld = request->task();
-  results.reserve(task_count);
+  uint32_t job_count = request->count();
+  const auto& job_to_ctld = request->job();
+  results.reserve(job_count);
 
-  for (int i = 0; i < task_count; i++) {
-    auto task = std::make_unique<TaskInCtld>();
-    task->SetFieldsByTaskToCtld(task_to_ctld);
+  for (int i = 0; i < job_count; i++) {
+    auto job = std::make_unique<JobInCtld>();
+    job->SetFieldsByJobToCtld(job_to_ctld);
 
-    auto result = g_task_scheduler->SubmitTaskToScheduler(std::move(task));
+    auto result = g_job_scheduler->SubmitJobToScheduler(std::move(job));
     results.emplace_back(std::move(result));
   }
 
   for (auto& res : results) {
     if (res.has_value()) {
-      CraneExpected<task_id_t> task_result = res.value().get();
-      if (task_result.has_value()) {
-        response->mutable_task_id_list()->Add(task_result.value());
+      CraneExpected<job_id_t> job_result = res.value().get();
+      if (job_result.has_value()) {
+        response->mutable_job_id_list()->Add(job_result.value());
       } else {
-        response->mutable_task_id_list()->Add(0);
-        response->mutable_code_list()->Add(task_result.error());
+        response->mutable_job_id_list()->Add(0);
+        response->mutable_code_list()->Add(job_result.error());
       }
     } else {
-      response->mutable_task_id_list()->Add(0);
+      response->mutable_job_id_list()->Add(0);
       response->mutable_code_list()->Add(res.error());
     }
   }
@@ -645,23 +645,23 @@ grpc::Status CraneCtldServiceImpl::SubmitBatchTasks(
   return grpc::Status::OK;
 }
 
-grpc::Status CraneCtldServiceImpl::CancelTask(
-    grpc::ServerContext* context, const crane::grpc::CancelTaskRequest* request,
-    crane::grpc::CancelTaskReply* response) {
+grpc::Status CraneCtldServiceImpl::CancelJob(
+    grpc::ServerContext* context, const crane::grpc::CancelJobRequest* request,
+    crane::grpc::CancelJobReply* response) {
   if (auto msg = CheckCertAndUIDAllowed_(context, request->operator_uid()); msg)
     return {grpc::StatusCode::UNAUTHENTICATED, msg.value()};
   if (!g_runtime_status.srv_ready.load(std::memory_order_acquire))
     return grpc::Status{grpc::StatusCode::UNAVAILABLE,
                         "CraneCtld Server is not ready"};
 
-  *response = g_task_scheduler->CancelPendingOrRunningTask(*request);
+  *response = g_job_scheduler->CancelPendingOrRunningJob(*request);
   return grpc::Status::OK;
 }
 
-grpc::Status CraneCtldServiceImpl::ResetNextTaskId(
+grpc::Status CraneCtldServiceImpl::ResetNextJobId(
     grpc::ServerContext* context,
-    const crane::grpc::ResetNextTaskIdRequest* request,
-    crane::grpc::ResetNextTaskIdReply* response) {
+    const crane::grpc::ResetNextJobIdRequest* request,
+    crane::grpc::ResetNextJobIdReply* response) {
   if (!g_runtime_status.srv_ready.load(std::memory_order_acquire))
     return grpc::Status{grpc::StatusCode::UNAVAILABLE,
                         "CraneCtld Server is not ready"};
@@ -678,22 +678,22 @@ grpc::Status CraneCtldServiceImpl::ResetNextTaskId(
   }
 
   // Field value 0 means "don't change"; >0 means "reset to this value"
-  task_id_t next_task_id = request->next_task_id();
-  int64_t next_task_db_id = request->next_task_db_id();
+  job_id_t next_job_id = request->next_job_id();
+  int64_t next_job_db_id = request->next_job_db_id();
 
-  if (next_task_id == 0 && next_task_db_id == 0) {
+  if (next_job_id == 0 && next_job_db_id == 0) {
     response->set_ok(false);
     response->set_reason(
-        "At least one of next_task_id or next_task_db_id must be specified "
+        "At least one of next_job_id or next_job_db_id must be specified "
         "(>0)");
     return grpc::Status::OK;
   }
 
-  if (g_embedded_db_client->ResetNextTaskId(next_task_id, next_task_db_id)) {
+  if (g_embedded_db_client->ResetNextJobId(next_job_id, next_job_db_id)) {
     response->set_ok(true);
   } else {
     response->set_ok(false);
-    response->set_reason("Failed to reset task ID counters in embedded DB");
+    response->set_reason("Failed to reset job ID counters in embedded DB");
   }
 
   return grpc::Status::OK;
@@ -728,10 +728,10 @@ grpc::Status CraneCtldServiceImpl::ResetNextStepDbId(
   return grpc::Status::OK;
 }
 
-grpc::Status CraneCtldServiceImpl::PurgeTaskHistory(
+grpc::Status CraneCtldServiceImpl::PurgeJobHistory(
     grpc::ServerContext* context,
-    const crane::grpc::PurgeTaskHistoryRequest* request,
-    crane::grpc::PurgeTaskHistoryReply* response) {
+    const crane::grpc::PurgeJobHistoryRequest* request,
+    crane::grpc::PurgeJobHistoryReply* response) {
   if (!g_runtime_status.srv_ready.load(std::memory_order_acquire))
     return grpc::Status{grpc::StatusCode::UNAVAILABLE,
                         "CraneCtld Server is not ready"};
@@ -745,11 +745,11 @@ grpc::Status CraneCtldServiceImpl::PurgeTaskHistory(
     return grpc::Status::OK;
   }
 
-  if (g_embedded_db_client->PurgeAllTaskHistory()) {
+  if (g_embedded_db_client->PurgeAllJobHistory()) {
     response->set_ok(true);
   } else {
     response->set_ok(false);
-    response->set_reason("Failed to purge task history from embedded DB");
+    response->set_reason("Failed to purge job history from embedded DB");
   }
 
   return grpc::Status::OK;
@@ -828,21 +828,21 @@ grpc::Status CraneCtldServiceImpl::QueryLicensesInfo(
   return grpc::Status::OK;
 }
 
-grpc::Status CraneCtldServiceImpl::ModifyTask(
-    grpc::ServerContext* context, const crane::grpc::ModifyTaskRequest* request,
-    crane::grpc::ModifyTaskReply* response) {
+grpc::Status CraneCtldServiceImpl::ModifyJob(
+    grpc::ServerContext* context, const crane::grpc::ModifyJobRequest* request,
+    crane::grpc::ModifyJobReply* response) {
   if (!g_runtime_status.srv_ready.load(std::memory_order_acquire))
     return grpc::Status{grpc::StatusCode::UNAVAILABLE,
                         "CraneCtld Server is not ready"};
   if (auto msg = CheckCertAndUIDAllowed_(context, request->uid()); msg)
     return {grpc::StatusCode::UNAUTHENTICATED, msg.value()};
 
-  using ModifyTaskRequest = crane::grpc::ModifyTaskRequest;
+  using ModifyJobRequest = crane::grpc::ModifyJobRequest;
 
   auto res = g_account_manager->CheckUidIsAdmin(request->uid());
   if (!res) {
-    for (auto task_id : request->task_ids()) {
-      response->add_not_modified_tasks(task_id);
+    for (auto job_id : request->job_ids()) {
+      response->add_not_modified_jobs(job_id);
       if (res.error() == CraneErrCode::ERR_INVALID_USER) {
         response->add_not_modified_reasons("User is not a user of Crane");
       } else if (res.error() == CraneErrCode::ERR_USER_NO_PRIVILEGE) {
@@ -852,76 +852,76 @@ grpc::Status CraneCtldServiceImpl::ModifyTask(
     return grpc::Status::OK;
   }
 
-  std::list<task_id_t> task_ids;
+  std::list<job_id_t> job_ids;
 
   if (g_config.JobSubmitLuaScript.empty()) {
-    task_ids.assign(request->task_ids().begin(), request->task_ids().end());
+    job_ids.assign(request->job_ids().begin(), request->job_ids().end());
   } else {
-    g_task_scheduler->JobModifyLuaCheck(*request, response, &task_ids);
+    g_job_scheduler->JobModifyLuaCheck(*request, response, &job_ids);
   }
 
   CraneErrCode err;
-  if (request->attribute() == ModifyTaskRequest::TimeLimit) {
-    for (auto task_id : task_ids) {
-      err = g_task_scheduler->ChangeTaskTimeLimit(
-          task_id, request->time_limit_seconds());
+  if (request->attribute() == ModifyJobRequest::TimeLimit) {
+    for (auto job_id : job_ids) {
+      err = g_job_scheduler->ChangeJobTimeLimit(
+          job_id, request->time_limit_seconds());
       if (err == CraneErrCode::SUCCESS) {
-        response->add_modified_tasks(task_id);
+        response->add_modified_jobs(job_id);
       } else if (err == CraneErrCode::ERR_NON_EXISTENT) {
-        response->add_not_modified_tasks(task_id);
+        response->add_not_modified_jobs(job_id);
         response->add_not_modified_reasons(fmt::format(
-            "Task #{} was not found in running or pending queue.", task_id));
+            "Job #{} was not found in running or pending queue.", job_id));
       } else if (err == CraneErrCode::ERR_INVALID_PARAM) {
-        response->add_not_modified_tasks(task_id);
+        response->add_not_modified_jobs(job_id);
         response->add_not_modified_reasons("Invalid time limit value.");
       } else {
-        response->add_not_modified_tasks(task_id);
+        response->add_not_modified_jobs(job_id);
         response->add_not_modified_reasons(
-            fmt::format("Failed to change the time limit of Task#{}: {}.",
-                        task_id, CraneErrStr(err)));
+            fmt::format("Failed to change the time limit of Job#{}: {}.",
+                        job_id, CraneErrStr(err)));
       }
     }
-  } else if (request->attribute() == ModifyTaskRequest::Priority) {
-    for (auto task_id : task_ids) {
-      err = g_task_scheduler->ChangeTaskPriority(task_id,
+  } else if (request->attribute() == ModifyJobRequest::Priority) {
+    for (auto job_id : job_ids) {
+      err = g_job_scheduler->ChangeJobPriority(job_id,
                                                  request->mandated_priority());
       if (err == CraneErrCode::SUCCESS) {
-        response->add_modified_tasks(task_id);
+        response->add_modified_jobs(job_id);
       } else if (err == CraneErrCode::ERR_NON_EXISTENT) {
-        response->add_not_modified_tasks(task_id);
+        response->add_not_modified_jobs(job_id);
         response->add_not_modified_reasons(
-            fmt::format("Task #{} was not found in pending queue.", task_id));
+            fmt::format("Job #{} was not found in pending queue.", job_id));
       } else {
-        response->add_not_modified_tasks(task_id);
+        response->add_not_modified_jobs(job_id);
         response->add_not_modified_reasons(
             fmt::format("Failed to change priority: {}.", CraneErrStr(err)));
       }
     }
-  } else if (request->attribute() == ModifyTaskRequest::Hold) {
+  } else if (request->attribute() == ModifyJobRequest::Hold) {
     int64_t secs = request->hold_seconds();
-    std::vector<std::pair<task_id_t, std::future<CraneErrCode>>> results;
-    results.reserve(task_ids.size());
-    for (auto task_id : task_ids) {
+    std::vector<std::pair<job_id_t, std::future<CraneErrCode>>> results;
+    results.reserve(job_ids.size());
+    for (auto job_id : job_ids) {
       results.emplace_back(
-          task_id, g_task_scheduler->HoldReleaseTaskAsync(task_id, secs));
+          job_id, g_job_scheduler->HoldReleaseJobAsync(job_id, secs));
     }
-    for (auto& [task_id, res] : results) {
+    for (auto& [job_id, res] : results) {
       err = res.get();
       if (err == CraneErrCode::SUCCESS) {
-        response->add_modified_tasks(task_id);
+        response->add_modified_jobs(job_id);
       } else if (err == CraneErrCode::ERR_NON_EXISTENT) {
-        response->add_not_modified_tasks(task_id);
+        response->add_not_modified_jobs(job_id);
         response->add_not_modified_reasons(
-            fmt::format("Task #{} was not found in pending queue.", task_id));
+            fmt::format("Job #{} was not found in pending queue.", job_id));
       } else {
-        response->add_not_modified_tasks(false);
+        response->add_not_modified_jobs(false);
         response->add_not_modified_reasons(
             fmt::format("Failed to hold/release job: {}.", CraneErrStr(err)));
       }
     }
   } else {
-    for (auto task_id : task_ids) {
-      response->add_not_modified_tasks(task_id);
+    for (auto job_id : job_ids) {
+      response->add_not_modified_jobs(job_id);
       response->add_not_modified_reasons("Invalid function.");
     }
   }
@@ -929,10 +929,10 @@ grpc::Status CraneCtldServiceImpl::ModifyTask(
   return grpc::Status::OK;
 }
 
-grpc::Status CraneCtldServiceImpl::ModifyTasksExtraAttrs(
+grpc::Status CraneCtldServiceImpl::ModifyJobsExtraAttrs(
     grpc::ServerContext* context,
-    const crane::grpc::ModifyTasksExtraAttrsRequest* request,
-    crane::grpc::ModifyTasksExtraAttrsReply* response) {
+    const crane::grpc::ModifyJobsExtraAttrsRequest* request,
+    crane::grpc::ModifyJobsExtraAttrsReply* response) {
   if (!g_runtime_status.srv_ready.load(std::memory_order_acquire))
     return grpc::Status{grpc::StatusCode::UNAVAILABLE,
                         "CraneCtld Server is not ready"};
@@ -941,8 +941,8 @@ grpc::Status CraneCtldServiceImpl::ModifyTasksExtraAttrs(
 
   auto res = g_account_manager->CheckUidIsAdmin(request->uid());
   if (!res) {
-    for (const auto [task_id, _] : request->extra_attrs_list()) {
-      response->add_not_modified_tasks(task_id);
+    for (const auto [job_id, _] : request->extra_attrs_list()) {
+      response->add_not_modified_jobs(job_id);
       if (res.error() == CraneErrCode::ERR_INVALID_USER) {
         response->add_not_modified_reasons("User is not a user of Crane");
       } else if (res.error() == CraneErrCode::ERR_USER_NO_PRIVILEGE) {
@@ -953,16 +953,16 @@ grpc::Status CraneCtldServiceImpl::ModifyTasksExtraAttrs(
   }
 
   CraneErrCode err;
-  for (const auto [task_id, extra_attrs] : request->extra_attrs_list()) {
-    err = g_task_scheduler->ChangeTaskExtraAttrs(task_id, extra_attrs);
+  for (const auto [job_id, extra_attrs] : request->extra_attrs_list()) {
+    err = g_job_scheduler->ChangeJobExtraAttrs(job_id, extra_attrs);
     if (err == CraneErrCode::SUCCESS) {
-      response->add_modified_tasks(task_id);
+      response->add_modified_jobs(job_id);
     } else if (err == CraneErrCode::ERR_NON_EXISTENT) {
-      response->add_not_modified_tasks(task_id);
+      response->add_not_modified_jobs(job_id);
       response->add_not_modified_reasons(
-          fmt::format("Task #{} was not found in pd/r queue.", task_id));
+          fmt::format("Job #{} was not found in pd/r queue.", job_id));
     } else {
-      response->add_not_modified_tasks(task_id);
+      response->add_not_modified_jobs(job_id);
       response->add_not_modified_reasons(
           fmt::format("Failed to change extra_attrs: {}.", CraneErrStr(err)));
     }
@@ -1126,33 +1126,33 @@ grpc::Status CraneCtldServiceImpl::ResetPartitionAcl(
   return grpc::Status::OK;
 }
 
-grpc::Status CraneCtldServiceImpl::QueryTasksInfo(
+grpc::Status CraneCtldServiceImpl::QueryJobsInfo(
     grpc::ServerContext* context,
-    const crane::grpc::QueryTasksInfoRequest* request,
-    crane::grpc::QueryTasksInfoReply* response) {
+    const crane::grpc::QueryJobsInfoRequest* request,
+    crane::grpc::QueryJobsInfoReply* response) {
   if (!g_runtime_status.srv_ready.load(std::memory_order_acquire))
     return grpc::Status{grpc::StatusCode::UNAVAILABLE,
                         "CraneCtld Server is not ready"};
-  std::unordered_map<job_id_t, crane::grpc::TaskInfo> job_info_map;
-  // Query tasks in RAM
-  g_task_scheduler->QueryTasksInRam(request, &job_info_map);
+  std::unordered_map<job_id_t, crane::grpc::JobInfo> job_info_map;
+  // Query jobs in RAM
+  g_job_scheduler->QueryJobsInRam(request, &job_info_map);
 
-  size_t num_limit = request->num_limit() == 0 ? kDefaultQueryTaskNumLimit
+  size_t num_limit = request->num_limit() == 0 ? kDefaultQueryJobNumLimit
                                                : request->num_limit();
 
   auto sort_truncate_and_move_to_proto = [&job_info_map,
                                           response](size_t limit) -> void {
-    auto* job_info_list = response->mutable_task_info_list();
+    auto* job_info_list = response->mutable_job_info_list();
     job_info_list->Reserve(job_info_map.size());
     for (auto it = job_info_map.begin(); it != job_info_map.end();) {
-      auto* new_task_info = job_info_list->Add();
-      *new_task_info = std::move(it->second);
+      auto* new_job_info = job_info_list->Add();
+      *new_job_info = std::move(it->second);
       it = job_info_map.erase(it);
     }
 
     std::sort(
         job_info_list->begin(), job_info_list->end(),
-        [](const crane::grpc::TaskInfo& a, const crane::grpc::TaskInfo& b) {
+        [](const crane::grpc::JobInfo& a, const crane::grpc::JobInfo& b) {
           return (a.status() == b.status()) ? (a.priority() > b.priority())
                                             : (a.status() < b.status());
         });
@@ -1162,8 +1162,8 @@ grpc::Status CraneCtldServiceImpl::QueryTasksInfo(
   };
 
   if (job_info_map.size() >= num_limit ||
-      !request->option_include_completed_tasks()) {
-    if (request->option_include_completed_tasks()) {
+      !request->option_include_completed_jobs()) {
+    if (request->option_include_completed_jobs()) {
       // Fetch job finished steps in Mongodb
       if (!g_db_client->FetchJobStepRecords(request, &job_info_map)) {
         CRANE_ERROR("Failed to call g_db_client->FetchJobStepRecords");
@@ -1175,8 +1175,8 @@ grpc::Status CraneCtldServiceImpl::QueryTasksInfo(
     return grpc::Status::OK;
   }
 
-  // Query completed tasks in Mongodb
-  // (only for cacct, which sets `option_include_completed_tasks` to true)
+  // Query completed jobs in Mongodb
+  // (only for cacct, which sets `option_include_completed_jobs` to true)
   if (!g_db_client->FetchJobRecords(request, &job_info_map,
                                     num_limit - job_info_map.size())) {
     CRANE_ERROR("Failed to call g_db_client->FetchJobRecords");
@@ -1298,13 +1298,13 @@ grpc::Status CraneCtldServiceImpl::AddQos(
       static_cast<ResourceView>(qos_info->max_tres_per_account());
   qos.flags.FromInt64(qos_info->flags());
 
-  int64_t sec = qos_info->max_time_limit_per_task();
+  int64_t sec = qos_info->max_time_limit_per_job();
   if (!CheckIfTimeLimitSecIsValid(sec)) {
     response->set_ok(false);
     response->set_code(CraneErrCode::ERR_TIME_LIMIT);
     return grpc::Status::OK;
   }
-  qos.max_time_limit_per_task = absl::Seconds(sec);
+  qos.max_time_limit_per_job = absl::Seconds(sec);
 
   qos.max_wall = absl::Seconds(qos_info->max_wall());
 
@@ -1693,8 +1693,8 @@ grpc::Status CraneCtldServiceImpl::QueryQosInfo(
     qos_info->set_max_cpus_per_user(qos.max_cpus_per_user);
     qos_info->set_max_submit_jobs_per_user(qos.max_submit_jobs_per_user);
     qos_info->set_max_submit_jobs_per_account(qos.max_submit_jobs_per_account);
-    qos_info->set_max_time_limit_per_task(
-        absl::ToInt64Seconds(qos.max_time_limit_per_task));
+    qos_info->set_max_time_limit_per_job(
+        absl::ToInt64Seconds(qos.max_time_limit_per_job));
     qos_info->set_max_jobs(qos.max_jobs);
     qos_info->set_max_submit_jobs(qos.max_submit_jobs);
     qos_info->set_max_wall(absl::ToInt64Seconds(qos.max_wall));
@@ -2220,7 +2220,7 @@ grpc::Status CraneCtldServiceImpl::CreateReservation(
     return grpc::Status::OK;
   }
 
-  *response = g_task_scheduler->CreateResv(*request);
+  *response = g_job_scheduler->CreateResv(*request);
   return grpc::Status::OK;
 }
 
@@ -2243,7 +2243,7 @@ grpc::Status CraneCtldServiceImpl::DeleteReservation(
 
   if (absl::AsciiStrToUpper(request->reservation_name()) == "ALL" &&
       request->force()) {
-    *response = g_task_scheduler->PurgeAllReservations();
+    *response = g_job_scheduler->PurgeAllReservations();
     return grpc::Status::OK;
   }
 
@@ -2254,7 +2254,7 @@ grpc::Status CraneCtldServiceImpl::DeleteReservation(
     return grpc::Status::OK;
   }
 
-  *response = g_task_scheduler->DeleteResv(*request);
+  *response = g_job_scheduler->DeleteResv(*request);
   return grpc::Status::OK;
 }
 
@@ -2477,7 +2477,7 @@ grpc::Status CraneCtldServiceImpl::AttachContainerStep(
   if (auto msg = CheckCertAndUIDAllowed_(context, request->uid()); msg)
     return {grpc::StatusCode::UNAUTHENTICATED, msg.value()};
 
-  *response = g_task_scheduler->AttachContainerStep(*request);
+  *response = g_job_scheduler->AttachContainerStep(*request);
 
   return grpc::Status::OK;
 }
@@ -2527,7 +2527,7 @@ grpc::Status CraneCtldServiceImpl::ExecInContainerStep(
   if (auto msg = CheckCertAndUIDAllowed_(context, request->uid()); msg)
     return {grpc::StatusCode::UNAUTHENTICATED, msg.value()};
 
-  *response = g_task_scheduler->ExecInContainerStep(*request);
+  *response = g_job_scheduler->ExecInContainerStep(*request);
 
   return grpc::Status::OK;
 }

--- a/src/CraneCtld/RpcService/CtldGrpcServer.cpp
+++ b/src/CraneCtld/RpcService/CtldGrpcServer.cpp
@@ -913,7 +913,7 @@ grpc::Status CraneCtldServiceImpl::ModifyJob(
         response->add_not_modified_reasons(
             fmt::format("Job #{} was not found in pending queue.", job_id));
       } else {
-        response->add_not_modified_jobs(false);
+        response->add_not_modified_jobs(job_id);
         response->add_not_modified_reasons(
             fmt::format("Failed to hold/release job: {}.", CraneErrStr(err)));
       }

--- a/src/CraneCtld/RpcService/CtldGrpcServer.h
+++ b/src/CraneCtld/RpcService/CtldGrpcServer.h
@@ -88,7 +88,7 @@ class CforedStreamWriter {
           allocated_craned_expt.value().first);
       auto &craned_list = allocated_craned_expt.value().second;
       job_res_alloc_reply->mutable_craned_ids()->Assign(craned_list.begin(),
-                                                         craned_list.end());
+                                                        craned_list.end());
     } else {
       job_res_alloc_reply->set_ok(false);
       job_res_alloc_reply->set_failure_reason(
@@ -101,8 +101,7 @@ class CforedStreamWriter {
   bool WriteJobCompletionAckReply(job_id_t job_id, step_id_t step_id) {
     LockGuard guard(&m_stream_mtx_);
     if (!m_valid_) return false;
-    CRANE_TRACE("Sending JobCompletionAckReply to cfored of job id {}",
-                job_id);
+    CRANE_TRACE("Sending JobCompletionAckReply to cfored of job id {}", job_id);
     StreamCtldReply reply;
     reply.set_type(StreamCtldReply::JOB_COMPLETION_ACK_REPLY);
 
@@ -241,8 +240,8 @@ class CraneCtldServiceImpl final : public crane::grpc::CraneCtld::Service {
       crane::grpc::SubmitBatchJobsReply *response) override;
 
   grpc::Status CancelJob(grpc::ServerContext *context,
-                          const crane::grpc::CancelJobRequest *request,
-                          crane::grpc::CancelJobReply *response) override;
+                         const crane::grpc::CancelJobRequest *request,
+                         crane::grpc::CancelJobReply *response) override;
 
   grpc::Status QueryJobsInfo(
       grpc::ServerContext *context,
@@ -270,8 +269,8 @@ class CraneCtldServiceImpl final : public crane::grpc::CraneCtld::Service {
       crane::grpc::QueryLicensesInfoReply *response) override;
 
   grpc::Status ModifyJob(grpc::ServerContext *context,
-                          const crane::grpc::ModifyJobRequest *request,
-                          crane::grpc::ModifyJobReply *response) override;
+                         const crane::grpc::ModifyJobRequest *request,
+                         crane::grpc::ModifyJobReply *response) override;
 
   grpc::Status ModifyJobsExtraAttrs(
       grpc::ServerContext *context,

--- a/src/CraneCtld/RpcService/CtldGrpcServer.h
+++ b/src/CraneCtld/RpcService/CtldGrpcServer.h
@@ -46,83 +46,83 @@ class CforedStreamWriter {
                                crane::grpc::StreamCforedRequest> *stream)
       : m_stream_(stream), m_valid_(true) {}
 
-  bool WriteTaskIdReply(
+  bool WriteJobIdReply(
       pid_t calloc_pid,
       std::expected<std::pair<job_id_t, step_id_t>, std::string> res) {
     LockGuard guard(&m_stream_mtx_);
     if (!m_valid_) return false;
 
     StreamCtldReply reply;
-    reply.set_type(StreamCtldReply::TASK_ID_REPLY);
-    auto *task_id_reply = reply.mutable_payload_task_id_reply();
+    reply.set_type(StreamCtldReply::JOB_ID_REPLY);
+    auto *job_id_reply = reply.mutable_payload_job_id_reply();
     if (res.has_value()) {
-      task_id_reply->set_ok(true);
-      task_id_reply->set_pid(calloc_pid);
+      job_id_reply->set_ok(true);
+      job_id_reply->set_pid(calloc_pid);
       auto [job_id, step_id] = res.value();
-      task_id_reply->set_job_id(job_id);
-      task_id_reply->set_step_id(step_id);
+      job_id_reply->set_job_id(job_id);
+      job_id_reply->set_step_id(step_id);
     } else {
-      task_id_reply->set_ok(false);
-      task_id_reply->set_pid(calloc_pid);
-      task_id_reply->set_failure_reason(std::move(res.error()));
+      job_id_reply->set_ok(false);
+      job_id_reply->set_pid(calloc_pid);
+      job_id_reply->set_failure_reason(std::move(res.error()));
     }
 
     return m_stream_->Write(reply);
   }
 
-  bool WriteTaskResAllocReply(
+  bool WriteJobResAllocReply(
       const StepInteractiveMeta::StepResAllocArgs &args) {
     LockGuard guard(&m_stream_mtx_);
     if (!m_valid_) return false;
 
     StreamCtldReply reply;
-    reply.set_type(StreamCtldReply::TASK_RES_ALLOC_REPLY);
+    reply.set_type(StreamCtldReply::JOB_RES_ALLOC_REPLY);
     auto &[job_id, step_id, allocated_craned_expt] = args;
-    auto *task_res_alloc_reply = reply.mutable_payload_task_res_alloc_reply();
-    task_res_alloc_reply->set_job_id(job_id);
-    task_res_alloc_reply->set_step_id(step_id);
+    auto *job_res_alloc_reply = reply.mutable_payload_job_res_alloc_reply();
+    job_res_alloc_reply->set_job_id(job_id);
+    job_res_alloc_reply->set_step_id(step_id);
 
     if (allocated_craned_expt.has_value()) {
-      task_res_alloc_reply->set_ok(true);
-      task_res_alloc_reply->set_allocated_craned_regex(
+      job_res_alloc_reply->set_ok(true);
+      job_res_alloc_reply->set_allocated_craned_regex(
           allocated_craned_expt.value().first);
       auto &craned_list = allocated_craned_expt.value().second;
-      task_res_alloc_reply->mutable_craned_ids()->Assign(craned_list.begin(),
+      job_res_alloc_reply->mutable_craned_ids()->Assign(craned_list.begin(),
                                                          craned_list.end());
     } else {
-      task_res_alloc_reply->set_ok(false);
-      task_res_alloc_reply->set_failure_reason(
+      job_res_alloc_reply->set_ok(false);
+      job_res_alloc_reply->set_failure_reason(
           std::move(allocated_craned_expt.error()));
     }
 
     return m_stream_->Write(reply);
   }
 
-  bool WriteTaskCompletionAckReply(job_id_t job_id, step_id_t step_id) {
+  bool WriteJobCompletionAckReply(job_id_t job_id, step_id_t step_id) {
     LockGuard guard(&m_stream_mtx_);
     if (!m_valid_) return false;
-    CRANE_TRACE("Sending TaskCompletionAckReply to cfored of task id {}",
+    CRANE_TRACE("Sending JobCompletionAckReply to cfored of job id {}",
                 job_id);
     StreamCtldReply reply;
-    reply.set_type(StreamCtldReply::TASK_COMPLETION_ACK_REPLY);
+    reply.set_type(StreamCtldReply::JOB_COMPLETION_ACK_REPLY);
 
-    auto *task_completion_ack = reply.mutable_payload_task_completion_ack();
-    task_completion_ack->set_job_id(job_id);
-    task_completion_ack->set_step_id(step_id);
+    auto *job_completion_ack = reply.mutable_payload_job_completion_ack();
+    job_completion_ack->set_job_id(job_id);
+    job_completion_ack->set_step_id(step_id);
 
     return m_stream_->Write(reply);
   }
 
-  bool WriteTaskCancelRequest(job_id_t job_id, step_id_t step_id) {
+  bool WriteJobCancelRequest(job_id_t job_id, step_id_t step_id) {
     LockGuard guard(&m_stream_mtx_);
     if (!m_valid_) return false;
 
     StreamCtldReply reply;
-    reply.set_type(StreamCtldReply::TASK_CANCEL_REQUEST);
+    reply.set_type(StreamCtldReply::JOB_CANCEL_REQUEST);
 
-    auto *task_cancel_req = reply.mutable_payload_task_cancel_request();
-    task_cancel_req->set_job_id(job_id);
-    task_cancel_req->set_step_id(step_id);
+    auto *job_cancel_req = reply.mutable_payload_job_cancel_request();
+    job_cancel_req->set_job_id(job_id);
+    job_cancel_req->set_step_id(step_id);
 
     return m_stream_->Write(reply);
   }
@@ -224,10 +224,10 @@ class CraneCtldServiceImpl final : public crane::grpc::CraneCtld::Service {
  public:
   explicit CraneCtldServiceImpl(CtldServer *server) : m_ctld_server_(server) {}
 
-  grpc::Status SubmitBatchTask(
+  grpc::Status SubmitBatchJob(
       grpc::ServerContext *context,
-      const crane::grpc::SubmitBatchTaskRequest *request,
-      crane::grpc::SubmitBatchTaskReply *response) override;
+      const crane::grpc::SubmitBatchJobRequest *request,
+      crane::grpc::SubmitBatchJobReply *response) override;
 
   grpc::Status SubmitContainerStep(
       grpc::ServerContext *context,
@@ -235,19 +235,19 @@ class CraneCtldServiceImpl final : public crane::grpc::CraneCtld::Service {
       crane::grpc::SubmitContainerStepReply *response) override;
 
   // This gRPC is for testing purposes only
-  grpc::Status SubmitBatchTasks(
+  grpc::Status SubmitBatchJobs(
       grpc::ServerContext *context,
-      const crane::grpc::SubmitBatchTasksRequest *request,
-      crane::grpc::SubmitBatchTasksReply *response) override;
+      const crane::grpc::SubmitBatchJobsRequest *request,
+      crane::grpc::SubmitBatchJobsReply *response) override;
 
-  grpc::Status CancelTask(grpc::ServerContext *context,
-                          const crane::grpc::CancelTaskRequest *request,
-                          crane::grpc::CancelTaskReply *response) override;
+  grpc::Status CancelJob(grpc::ServerContext *context,
+                          const crane::grpc::CancelJobRequest *request,
+                          crane::grpc::CancelJobReply *response) override;
 
-  grpc::Status QueryTasksInfo(
+  grpc::Status QueryJobsInfo(
       grpc::ServerContext *context,
-      const crane::grpc::QueryTasksInfoRequest *request,
-      crane::grpc::QueryTasksInfoReply *response) override;
+      const crane::grpc::QueryJobsInfoRequest *request,
+      crane::grpc::QueryJobsInfoReply *response) override;
 
   grpc::Status QueryCranedInfo(
       grpc::ServerContext *context,
@@ -269,29 +269,29 @@ class CraneCtldServiceImpl final : public crane::grpc::CraneCtld::Service {
       const crane::grpc::QueryLicensesInfoRequest *request,
       crane::grpc::QueryLicensesInfoReply *response) override;
 
-  grpc::Status ModifyTask(grpc::ServerContext *context,
-                          const crane::grpc::ModifyTaskRequest *request,
-                          crane::grpc::ModifyTaskReply *response) override;
+  grpc::Status ModifyJob(grpc::ServerContext *context,
+                          const crane::grpc::ModifyJobRequest *request,
+                          crane::grpc::ModifyJobReply *response) override;
 
-  grpc::Status ModifyTasksExtraAttrs(
+  grpc::Status ModifyJobsExtraAttrs(
       grpc::ServerContext *context,
-      const crane::grpc::ModifyTasksExtraAttrsRequest *request,
-      crane::grpc::ModifyTasksExtraAttrsReply *response) override;
+      const crane::grpc::ModifyJobsExtraAttrsRequest *request,
+      crane::grpc::ModifyJobsExtraAttrsReply *response) override;
 
-  grpc::Status ResetNextTaskId(
+  grpc::Status ResetNextJobId(
       grpc::ServerContext *context,
-      const crane::grpc::ResetNextTaskIdRequest *request,
-      crane::grpc::ResetNextTaskIdReply *response) override;
+      const crane::grpc::ResetNextJobIdRequest *request,
+      crane::grpc::ResetNextJobIdReply *response) override;
 
   grpc::Status ResetNextStepDbId(
       grpc::ServerContext *context,
       const crane::grpc::ResetNextStepDbIdRequest *request,
       crane::grpc::ResetNextStepDbIdReply *response) override;
 
-  grpc::Status PurgeTaskHistory(
+  grpc::Status PurgeJobHistory(
       grpc::ServerContext *context,
-      const crane::grpc::PurgeTaskHistoryRequest *request,
-      crane::grpc::PurgeTaskHistoryReply *response) override;
+      const crane::grpc::PurgeJobHistoryRequest *request,
+      crane::grpc::PurgeJobHistoryReply *response) override;
 
   grpc::Status ModifyNode(
       grpc::ServerContext *context,
@@ -492,7 +492,7 @@ class CtldServer {
   Mutex m_mtx_;
   HashMap<std::string /* cfored_name */,
           HashMap<job_id_t, std::unordered_set<step_id_t>>>
-      m_cfored_running_tasks_ ABSL_GUARDED_BY(m_mtx_);
+      m_cfored_running_jobs_ ABSL_GUARDED_BY(m_mtx_);
 
   std::unique_ptr<CtldForInternalServiceImpl> m_internal_service_impl_;
   std::unique_ptr<Server> m_internal_server_;

--- a/src/Craned/Common/CgroupManager.cpp
+++ b/src/Craned/Common/CgroupManager.cpp
@@ -718,7 +718,7 @@ CgroupManager::GetJobBpfMapCgroupsV2_(
 
   absl::flat_hash_map<CgroupStrParsedIds, std::vector<BpfKey>> results;
 
-  auto add_task = [&results, &cg_ino_job_id_map](BpfKey *key) {
+  auto add_job = [&results, &cg_ino_job_id_map](BpfKey *key) {
     // Skip log level record.
     if (key->cgroup_id == 0) {
       return;
@@ -735,11 +735,11 @@ CgroupManager::GetJobBpfMapCgroupsV2_(
     return results;
   }
 
-  add_task(pre_key.get());
+  add_job(pre_key.get());
   auto cur_key = std::make_unique<BpfKey>();
   while (bpf_map__get_next_key(bpf_runtime_info.BpfDevMap(), pre_key.get(),
                                cur_key.get(), sizeof(BpfKey)) == 0) {
-    add_task(cur_key.get());
+    add_job(cur_key.get());
     pre_key.swap(cur_key);
   }
   if (init_ebpf) bpf_runtime_info.CloseBpfObj();
@@ -1397,7 +1397,7 @@ void BpfRuntimeInfo::Destroy() {
   }
   // always one key for logging
   if (bpf_map_count == 1) {
-    // All task end
+    // All jobs end
     RmBpfDeviceMap();
   }
 }

--- a/src/Craned/Core/Craned.cpp
+++ b/src/Craned/Core/Craned.cpp
@@ -1288,7 +1288,7 @@ void GlobalVariableInit() {
   CreateRequiredDirectories();
 
   // Mask SIGPIPE to prevent Craned from crushing due to
-  // SIGPIPE while communicating with spawned task processes.
+  // SIGPIPE while communicating with spawned job processes.
   signal(SIGPIPE, SIG_IGN);
 
   PasswordEntry::InitializeEntrySize();

--- a/src/Craned/Core/CranedForPamServer.cpp
+++ b/src/Craned/Core/CranedForPamServer.cpp
@@ -28,7 +28,7 @@ grpc::Status CranedForPamServiceImpl::QueryStepFromPortForward(
     const crane::grpc::QueryStepFromPortForwardRequest *request,
     crane::grpc::QueryStepFromPortForwardReply *response) {
   bool ok;
-  bool task_id_found = false;
+  bool job_id_found = false;
   bool remote_is_craned = false;
 
   // May be craned or cfored
@@ -42,21 +42,21 @@ grpc::Status CranedForPamServiceImpl::QueryStepFromPortForward(
   if (ip_ver == 4 && crane::StrToIpv4(crane_addr, &crane_addr4)) {
     if (g_config.Ipv4ToCranedHostname.contains(crane_addr4)) {
       CRANE_TRACE(
-          "Receive QueryTaskIdFromPortForward from Pam module: "
+          "Receive QueryJobIdFromPortForward from Pam module: "
           "ssh_remote_port: {}, ssh_remote_address: {}. "
           "This ssh comes from a CraneD node. uid: {}",
           request->ssh_remote_port(), request->ssh_remote_address(),
           request->uid());
       // In the addresses of CraneD nodes. This ssh request comes from a
-      // CraneD node. Check if the remote port belongs to a task. If so, move
-      // it in to the cgroup of this task.
+      // CraneD node. Check if the remote port belongs to a job. If so, move
+      // it in to the cgroup of this job.
       crane_port = g_config.ListenConf.CranedListenPort;
       remote_is_craned = true;
     }
   } else if (ip_ver == 6 && crane::StrToIpv6(crane_addr, &crane_addr6)) {
     if (g_config.Ipv6ToCranedHostname.contains(crane_addr6)) {
       CRANE_TRACE(
-          "Receive QueryTaskIdFromPortForward from Pam module: "
+          "Receive QueryJobIdFromPortForward from Pam module: "
           "ssh_remote_port: {}, ssh_remote_address: {}. "
           "This ssh comes from a CraneD node. uid: {}",
           request->ssh_remote_port(), request->ssh_remote_address(),
@@ -74,10 +74,10 @@ grpc::Status CranedForPamServiceImpl::QueryStepFromPortForward(
 
   if (!remote_is_craned) {
     // Not in the addresses of CraneD nodes. This ssh request comes from a user.
-    // Check if the user's uid is running a task. If so, move it in to the
-    // cgroup of his first task. If not so, reject this ssh request.
+    // Check if the user's uid is running a job. If so, move it in to the
+    // cgroup of his first job. If not so, reject this ssh request.
     CRANE_TRACE(
-        "Receive QueryTaskIdFromPortForward from Pam module: "
+        "Receive QueryJobIdFromPortForward from Pam module: "
         "ssh_remote_port: {}, ssh_remote_address: {}. "
         "This ssh comes from a user machine. uid: {}",
         request->ssh_remote_port(), request->ssh_remote_address(),
@@ -142,7 +142,7 @@ grpc::Status CranedForPamServiceImpl::QueryStepFromPortForward(
   }
 
   if (!status_remote_service.ok()) {
-    CRANE_WARN("QueryTaskIdFromPort gRPC call failed: {}. Remote is craned: {}",
+    CRANE_WARN("QueryJobIdFromPort gRPC call failed: {}. Remote is craned: {}",
                status_remote_service.error_message(), remote_is_craned);
   }
 
@@ -151,26 +151,26 @@ grpc::Status CranedForPamServiceImpl::QueryStepFromPortForward(
     response->set_job_id(reply_from_remote_service.job_id());
 
     CRANE_TRACE(
-        "ssh client with remote port {} belongs to task #{}. "
-        "Moving this ssh session process into the task's cgroup",
+        "ssh client with remote port {} belongs to job #{}. "
+        "Moving this ssh session process into the job's cgroup",
         request->ssh_remote_port(), reply_from_remote_service.job_id());
     return Status::OK;
   } else {
-    std::optional<TaskInfoOfUid> info_opt =
-        g_job_mgr->QueryTaskInfoOfUid(request->uid());
+    std::optional<JobInfoOfUid> info_opt =
+        g_job_mgr->QueryJobInfoOfUid(request->uid());
     if (info_opt.has_value()) {
       auto info = info_opt.value();
       CRANE_TRACE(
-          "Found a task #{} belonging to uid {}. "
-          "This ssh session process is going to be moved into the task's "
+          "Found a job #{} belonging to uid {}. "
+          "This ssh session process is going to be moved into the job's "
           "cgroup",
-          info.first_task_id, request->uid());
-      response->set_job_id(info.first_task_id);
+          info.first_job_id, request->uid());
+      response->set_job_id(info.first_job_id);
       response->set_ok(true);
     } else {
       CRANE_TRACE(
-          "This ssh session can't be moved into uid {}'s tasks. "
-          "This uid has no task on this node. "
+          "This ssh session can't be moved into uid {}'s jobs. "
+          "This uid has no job on this node. "
           "Reject this ssh request.");
       response->set_ok(false);
     }
@@ -188,14 +188,14 @@ grpc::Status CranedForPamServiceImpl::MigrateSshProcToCgroup(
     return Status(grpc::StatusCode::UNAVAILABLE, "CranedServer is not ready");
   }
 
-  CRANE_TRACE("Moving pid {} to cgroup of task #{}", request->pid(),
-              request->task_id());
+  CRANE_TRACE("Moving pid {} to cgroup of job #{}", request->pid(),
+              request->job_id());
 
   bool ok =
-      g_job_mgr->MigrateProcToCgroupOfJob(request->pid(), request->task_id());
+      g_job_mgr->MigrateProcToCgroupOfJob(request->pid(), request->job_id());
   if (!ok) {
-    CRANE_INFO("GrpcMigrateSshProcToCgroup failed on pid: {}, task #{}",
-               request->pid(), request->task_id());
+    CRANE_INFO("GrpcMigrateSshProcToCgroup failed on pid: {}, job #{}",
+               request->pid(), request->job_id());
     response->set_ok(false);
   } else {
     response->set_ok(true);
@@ -214,14 +214,14 @@ grpc::Status CranedForPamServiceImpl::QuerySshStepEnvVariablesForward(
     return Status(grpc::StatusCode::UNAVAILABLE, "CranedServer is not ready");
   }
 
-  auto task_env_map =
-      g_job_mgr->QuerySshStepEnvVariables(request->task_id(), kDaemonStepId);
-  if (!task_env_map.has_value()) {
-    CRANE_ERROR("Failed to get env of job #{}", request->task_id());
+  auto job_env_map =
+      g_job_mgr->QuerySshStepEnvVariables(request->job_id(), kDaemonStepId);
+  if (!job_env_map.has_value()) {
+    CRANE_ERROR("Failed to get env of job #{}", request->job_id());
     response->set_ok(false);
     return Status::OK;
   }
-  for (const auto &[name, value] : task_env_map.value())
+  for (const auto &[name, value] : job_env_map.value())
     response->mutable_env_map()->emplace(name, value);
   response->set_ok(true);
   return Status::OK;

--- a/src/Craned/Core/CranedPublicDefs.h
+++ b/src/Craned/Core/CranedPublicDefs.h
@@ -36,7 +36,7 @@ using ::Craned::Common::CgroupInterface;
 using ::Craned::Common::CgroupManager;
 using ::Craned::Common::EnvMap;
 using RegToken = google::protobuf::Timestamp;
-using StepStatus = crane::grpc::TaskStatus;
+using StepStatus = crane::grpc::JobStatus;
 
 enum class CallbackInvokeMode : std::uint8_t { SYNC = 0, ASYNC };
 
@@ -55,15 +55,15 @@ inline std::string GetStepIdStr(const crane::grpc::StepToD& step) {
 struct StepStatusChangeQueueElem {
   job_id_t job_id;
   step_id_t step_id;
-  crane::grpc::TaskStatus new_status{};
+  crane::grpc::JobStatus new_status{};
   uint32_t exit_code{};
   std::optional<std::string> reason;
   google::protobuf::Timestamp timestamp;
 };
 
-struct TaskInfoOfUid {
+struct JobInfoOfUid {
   uint32_t job_cnt;
-  uint32_t first_task_id;
+  uint32_t first_job_id;
   bool cgroup_exists;
   std::string cgroup_path;
 };

--- a/src/Craned/Core/CranedServer.cpp
+++ b/src/Craned/Core/CranedServer.cpp
@@ -302,13 +302,13 @@ grpc::Status CranedServiceImpl::QuerySshStepEnvVariables(
     return Status{grpc::StatusCode::UNAVAILABLE, "CranedServer is not ready"};
   }
 
-  auto task_env_map =
-      g_job_mgr->QuerySshStepEnvVariables(request->task_id(), kDaemonStepId);
-  if (task_env_map.error()) {
-    CRANE_ERROR("Failed to get step env of job #{}", request->task_id());
+  auto job_env_map =
+      g_job_mgr->QuerySshStepEnvVariables(request->job_id(), kDaemonStepId);
+  if (job_env_map.error()) {
+    CRANE_ERROR("Failed to get step env of job #{}", request->job_id());
     return Status::OK;
   }
-  for (const auto &[name, value] : task_env_map.value())
+  for (const auto &[name, value] : job_env_map.value())
     response->mutable_env_map()->emplace(name, value);
   response->set_ok(true);
 
@@ -325,12 +325,12 @@ grpc::Status CranedServiceImpl::ChangeJobTimeLimit(
     return Status{grpc::StatusCode::UNAVAILABLE, "CranedServer is not ready"};
   }
 
-  auto err = g_job_mgr->ChangeStepTimelimit(request->task_id(), kPrimaryStepId,
+  auto err = g_job_mgr->ChangeStepTimelimit(request->job_id(), kPrimaryStepId,
                                             request->time_limit_seconds());
 
   if (err.error()) {
-    CRANE_ERROR("[Step #{}.{}] Failed to change task time limit",
-                request->task_id(), kPrimaryStepId);
+    CRANE_ERROR("[Step #{}.{}] Failed to change job time limit",
+                request->job_id(), kPrimaryStepId);
     return Status::OK;
   }
   response->set_ok(true);

--- a/src/Craned/Core/CtldClient.cpp
+++ b/src/Craned/Core/CtldClient.cpp
@@ -548,7 +548,7 @@ void CtldClient::Init() {
         // Craned valid status:
         //   - Terminal states (Completed, Failed, ExceedTimeLimit, Cancelled,
         //     OutOfMemory)
-        //   - Completing (All task finished on CommonStep / Asked to exit on
+        //   - Completing (All steps finished on CommonStep / Asked to exit on
         //     DaemonStep, during Epilog)
         //   - Running
         //   - Starting (Only for CommonStep)
@@ -598,7 +598,7 @@ void CtldClient::Init() {
 
             // Special case: Handle timeout-during-offline scenario
             // This occurs when Craned goes offline and comes back online after
-            // task timeout. Only DaemonStep can be Running here because:
+            // job timeout. Only DaemonStep can be Running here because:
             // - DaemonStep waits for Epilog to complete before terminating
             // - CommonSteps should already be killed by Timer and in terminal
             //   state
@@ -772,18 +772,18 @@ void CtldClient::SetPingFailedCb(std::function<void()>&& cb) {
 }
 
 void CtldClient::StepStatusChangeAsync(
-    StepStatusChangeQueueElem&& task_status_change) {
+    StepStatusChangeQueueElem&& step_status_change) {
   absl::MutexLock lock(&m_step_status_change_mtx_);
 
   CRANE_TRACE(
       "[Step #{}.{}] Step status change added to queue, status {},code {}.",
-      task_status_change.job_id, task_status_change.step_id,
-      task_status_change.new_status, task_status_change.exit_code);
-  m_step_status_change_list_.emplace_back(std::move(task_status_change));
+      step_status_change.job_id, step_status_change.step_id,
+      step_status_change.new_status, step_status_change.exit_code);
+  m_step_status_change_list_.emplace_back(std::move(step_status_change));
 }
 
 void CtldClient::StepStatusChangeAsync(job_id_t job_id, step_id_t step_id,
-                                       crane::grpc::TaskStatus new_status,
+                                       crane::grpc::JobStatus new_status,
                                        uint32_t exit_code,
                                        std::optional<std::string> reason) {
   StepStatusChangeQueueElem elem{
@@ -909,7 +909,7 @@ void CtldClient::AsyncSendThread_() {
   grpc_connectivity_state grpc_state;
   bool prev_connected = false, connected = false;
 
-  // Variable for TaskStatusChange sending part.
+  // Variable for StepStatusChange sending part.
   absl::Condition cond(
       +[](decltype(m_step_status_change_list_)* queue) {
         return !queue->empty();
@@ -961,7 +961,7 @@ void CtldClient::AsyncSendThread_() {
 
     if (g_ctld_client_sm->IsReadyNow() == false) continue;
 
-    // TaskStatusChange sending is done in this grpc channel maintaining thread
+    // StepStatusChange sending is done in this grpc channel maintaining thread
     // if the channel is connected.
     // This is equivalent to sharing some time slice with grpc sending,
     // i.e. this thread is maintaining grpc channel and sending rpc at the same
@@ -996,7 +996,7 @@ bool CtldClient::SendStatusChanges_(
 
     auto status_change = changes.front();
 
-    CRANE_TRACE("[Step #{}.{}] Sending TaskStatusChange.", status_change.job_id,
+    CRANE_TRACE("[Step #{}.{}] Sending StepStatusChange.", status_change.job_id,
                 status_change.step_id);
 
     request.set_craned_id(m_craned_id_);
@@ -1011,7 +1011,7 @@ bool CtldClient::SendStatusChanges_(
     status = m_stub_->StepStatusChange(&context, request, &reply);
     if (!status.ok()) {
       CRANE_ERROR(
-          "Failed to send TaskStatusChange: "
+          "Failed to send StepStatusChange: "
           "{{Step: #{}.{}, NewStatus: {}}}, reason: {} | {}, code: {}",
           status_change.job_id, status_change.step_id, status_change.new_status,
           status.error_message(), context.debug_error_string(),
@@ -1024,7 +1024,7 @@ bool CtldClient::SendStatusChanges_(
         return false;
       }
       // If some messages are not sent due to channel failure,
-      // put them back into m_task_status_change_list_
+      // put them back into m_step_status_change_list_
       if (!changes.empty()) {
         m_step_status_change_mtx_.Lock();
         m_step_status_change_list_.splice(m_step_status_change_list_.begin(),

--- a/src/Craned/Core/CtldClient.h
+++ b/src/Craned/Core/CtldClient.h
@@ -196,11 +196,11 @@ class CtldClient {
 
   void StartHealthCheck();
 
-  void StepStatusChangeAsync(StepStatusChangeQueueElem&& task_status_change);
+  void StepStatusChangeAsync(StepStatusChangeQueueElem&& step_status_change);
 
   // Convenience method for reporting status changes
   void StepStatusChangeAsync(job_id_t job_id, step_id_t step_id,
-                             crane::grpc::TaskStatus new_status,
+                             crane::grpc::JobStatus new_status,
                              uint32_t exit_code,
                              std::optional<std::string> reason = std::nullopt);
 

--- a/src/Craned/Core/JobManager.cpp
+++ b/src/Craned/Core/JobManager.cpp
@@ -144,18 +144,18 @@ JobManager::JobManager() {
         EvCleanGrpcExecuteStepQueueCb_();
       });
 
-  // Task Status Change Event
-  m_task_status_change_async_handle_ =
+  // Step Status Change Event
+  m_step_status_change_async_handle_ =
       m_uvw_loop_->resource<uvw::async_handle>();
-  m_task_status_change_async_handle_->on<uvw::async_event>(
+  m_step_status_change_async_handle_->on<uvw::async_event>(
       [this](const uvw::async_event&, uvw::async_handle&) {
-        EvCleanTaskStatusChangeQueueCb_();
+        EvCleanStepStatusChangeQueueCb_();
       });
 
   m_terminate_step_async_handle_ = m_uvw_loop_->resource<uvw::async_handle>();
   m_terminate_step_async_handle_->on<uvw::async_event>(
       [this](const uvw::async_event&, uvw::async_handle&) {
-        EvCleanTerminateTaskQueueCb_();
+        EvCleanTerminateStepQueueCb_();
       });
   m_terminate_step_timer_handle_ = m_uvw_loop_->resource<uvw::timer_handle>();
   m_terminate_step_timer_handle_->on<uvw::timer_event>(
@@ -185,7 +185,7 @@ JobManager::JobManager() {
 }
 
 CraneErrCode JobManager::Recover(
-    std::unordered_map<task_id_t, JobInD>&& job_map,
+    std::unordered_map<job_id_t, JobInD>&& job_map,
     absl::flat_hash_map<std::pair<job_id_t, step_id_t>,
                         std::unique_ptr<StepInstance>>&& step_map) {
   CRANE_INFO("Job allocation [{}] recovered.",
@@ -200,7 +200,7 @@ CraneErrCode JobManager::Recover(
     if (uid_map->contains(uid)) {
       uid_map->at(uid).RawPtr()->emplace(job_id);
     } else {
-      uid_map->emplace(uid, absl::flat_hash_set<task_id_t>({job_id}));
+      uid_map->emplace(uid, absl::flat_hash_set<job_id_t>({job_id}));
     }
   }
 
@@ -239,21 +239,21 @@ bool JobManager::AllocJobs(std::vector<JobInD>&& jobs) {
   auto uid_map_ptr = m_uid_to_job_ids_map_.GetMapExclusivePtr();
 
   for (auto& job : jobs) {
-    task_id_t job_id = job.job_id;
+    job_id_t job_id = job.job_id;
     uid_t uid = job.Uid();
 
     job_map_ptr->emplace(job_id, std::move(job));
     if (uid_map_ptr->contains(uid)) {
       uid_map_ptr->at(uid).RawPtr()->emplace(job_id);
     } else {
-      uid_map_ptr->emplace(uid, absl::flat_hash_set<task_id_t>({job_id}));
+      uid_map_ptr->emplace(uid, absl::flat_hash_set<job_id_t>({job_id}));
     }
   }
 
   return true;
 }
 
-bool JobManager::FreeJobs(std::set<task_id_t>&& job_ids) {
+bool JobManager::FreeJobs(std::set<job_id_t>&& job_ids) {
   std::vector<JobInD> jobs_to_free;
   std::vector<StepInstance*> steps_to_free;
 
@@ -316,9 +316,9 @@ void JobManager::AllocSteps(std::vector<StepToD>&& steps) {
       CRANE_WARN("Try to allocate step for nonexistent job#{}, ignoring it.",
                  step.job_id());
     } else {
-      // Simply wrap the Task structure within an Execution structure and
-      // pass it to the event loop. The cgroup field of this task is initialized
-      // in the corresponding handler (EvGrpcExecuteTaskCb_).
+      // Simply wrap the job structure within an Execution structure and
+      // pass it to the event loop. The cgroup field of this job is initialized
+      // in the corresponding handler.
       auto step_inst = std::make_unique<StepInstance>(step);
       step_inst->step_to_d = std::move(step);
       EvQueueAllocateStepElem elem{.step_inst = std::move(step_inst),
@@ -554,7 +554,7 @@ CraneExpected<void> JobManager::ChangeStepTimelimit(job_id_t job_id,
                           google::protobuf::util::TimeUtil::GetCurrentTime());
     return std::unexpected{CraneErrCode::ERR_RPC_FAILURE};
   }
-  auto err = stub->ChangeTaskTimeLimit(absl::Seconds(new_timelimit_sec));
+  auto err = stub->ChangeStepTimeLimit(absl::Seconds(new_timelimit_sec));
   if (err != CraneErrCode::SUCCESS) {
     CRANE_ERROR(
         "[Step #{}.{}] Failed to change step timelimit to {} seconds via "
@@ -596,7 +596,7 @@ void JobManager::EvCleanGrpcExecuteStepQueueCb_() {
   EvQueueExecuteStepElem elem;
 
   while (m_grpc_execute_step_queue_.try_dequeue(elem)) {
-    // Once ExecuteTask RPC is processed, the Execution goes into m_job_map_.
+    // Once ExecuteStep RPC is processed, the Execution goes into m_job_map_.
     auto& [job_id, step_id, ok_prom] = elem;
     auto job = m_job_map_.GetValueExclusivePtr(job_id);
 
@@ -653,7 +653,7 @@ bool JobManager::FreeJobAllocation_(std::vector<JobInD>&& jobs) {
                               return job.job_id;
                             }) | std::views::common,
                             ","));
-  std::unordered_map<task_id_t, CgroupInterface*> job_cg_map;
+  std::unordered_map<job_id_t, CgroupInterface*> job_cg_map;
   std::vector<uid_t> uid_vec;
 
   for (auto& job : jobs) {
@@ -737,8 +737,8 @@ bool JobManager::RunPrologWhenAllocSteps_(job_id_t job_id, step_id_t step_id,
       CRANE_DEBUG("[Step #{}.{}]: Prolog in AllocSteps failed status={}:{}",
                   job_id, step_id, status.exit_code, status.signal_num);
       g_ctld_client->UpdateNodeDrainState(true, "Prolog failed");
-      ActivateTaskStatusChangeAsync_(
-          job_id, step_id, crane::grpc::TaskStatus::Failed,
+      ActivateStepStatusChangeAsync_(
+          job_id, step_id, crane::grpc::JobStatus::Failed,
           ExitCode::EC_PROLOG_ERR,
           fmt::format("Failed to run prolog for job#{} ", job_id),
           google::protobuf::util::TimeUtil::GetCurrentTime());
@@ -759,8 +759,8 @@ void JobManager::LaunchStepMt_(std::unique_ptr<StepInstance> step) {
   auto job_ptr = m_job_map_.GetValueExclusivePtr(job_id);
   if (!job_ptr) {
     CRANE_ERROR("[Step #{}.{}] Failed to find job allocation", job_id, step_id);
-    ActivateTaskStatusChangeAsync_(
-        job_id, step_id, crane::grpc::TaskStatus::Failed,
+    ActivateStepStatusChangeAsync_(
+        job_id, step_id, crane::grpc::JobStatus::Failed,
         ExitCode::EC_CGROUP_ERR,
         fmt::format("Failed to get the allocation for job#{} ", job_id),
         google::protobuf::util::TimeUtil::GetCurrentTime());
@@ -774,8 +774,8 @@ void JobManager::LaunchStepMt_(std::unique_ptr<StepInstance> step) {
   if (step->IsContainer() && !g_config.Container.Enabled) {
     CRANE_ERROR("Container support is disabled but job #{} requires it.",
                 job_id);
-    ActivateTaskStatusChangeAsync_(
-        job_id, step_id, crane::grpc::TaskStatus::Failed,
+    ActivateStepStatusChangeAsync_(
+        job_id, step_id, crane::grpc::JobStatus::Failed,
         ExitCode::EC_SPAWN_FAILED, "Container is not enabled in this craned.",
         google::protobuf::util::TimeUtil::GetCurrentTime());
     return;
@@ -791,8 +791,8 @@ void JobManager::LaunchStepMt_(std::unique_ptr<StepInstance> step) {
       job->cgroup = std::move(cg_expt.value());
     } else {
       CRANE_ERROR("Failed to get cgroup for job#{}", job_id);
-      ActivateTaskStatusChangeAsync_(
-          job_id, step_id, crane::grpc::TaskStatus::Failed,
+      ActivateStepStatusChangeAsync_(
+          job_id, step_id, crane::grpc::JobStatus::Failed,
           ExitCode::EC_CGROUP_ERR,
           fmt::format("Failed to get cgroup for job#{} ", job_id),
           google::protobuf::util::TimeUtil::GetCurrentTime());
@@ -808,14 +808,14 @@ void JobManager::LaunchStepMt_(std::unique_ptr<StepInstance> step) {
 
   // err will NOT be kOk ONLY if fork() is not called due to some failure
   // or fork() fails.
-  // In this case, SIGCHLD will NOT be received for this task, and
-  // we should send TaskStatusChange manually.
+  // In this case, SIGCHLD will NOT be received for this job, and
+  // we should send StepStatusChange manually.
   CraneErrCode err = step_ptr->Prepare();
   if (err != CraneErrCode::SUCCESS) {
     CRANE_ERROR("[Step #{}.{}] Failed to prepare.", job_id, step_id);
     step_ptr->err_before_supv_start = true;
-    ActivateTaskStatusChangeAsync_(
-        job_id, step_id, crane::grpc::TaskStatus::Failed,
+    ActivateStepStatusChangeAsync_(
+        job_id, step_id, crane::grpc::JobStatus::Failed,
         ExitCode::EC_CGROUP_ERR,
         fmt::format("Cannot create cgroup for the instance of step {}.{}",
                     job_id, step_id),
@@ -825,8 +825,8 @@ void JobManager::LaunchStepMt_(std::unique_ptr<StepInstance> step) {
   err = step_ptr->SpawnSupervisor(job->GetJobEnvMap());
   if (err != CraneErrCode::SUCCESS) {
     step_ptr->err_before_supv_start = true;
-    ActivateTaskStatusChangeAsync_(
-        job_id, step_id, crane::grpc::TaskStatus::Failed,
+    ActivateStepStatusChangeAsync_(
+        job_id, step_id, crane::grpc::JobStatus::Failed,
         ExitCode::EC_SPAWN_FAILED,
         fmt::format("Cannot spawn a new process inside the instance of job #{}",
                     job_id),
@@ -839,9 +839,9 @@ void JobManager::LaunchStepMt_(std::unique_ptr<StepInstance> step) {
   }
 }
 
-void JobManager::EvCleanTaskStatusChangeQueueCb_() {
+void JobManager::EvCleanStepStatusChangeQueueCb_() {
   StepStatusChangeQueueElem status_change;
-  while (m_task_status_change_queue_.try_dequeue(status_change)) {
+  while (m_step_status_change_queue_.try_dequeue(status_change)) {
     {
       auto job_ptr = m_job_map_.GetValueExclusivePtr(status_change.job_id);
       if (job_ptr) {
@@ -862,8 +862,8 @@ void JobManager::EvCleanTaskStatusChangeQueueCb_() {
   }
 }
 
-void JobManager::ActivateTaskStatusChangeAsync_(
-    job_id_t job_id, step_id_t step_id, crane::grpc::TaskStatus new_status,
+void JobManager::ActivateStepStatusChangeAsync_(
+    job_id_t job_id, step_id_t step_id, crane::grpc::JobStatus new_status,
     uint32_t exit_code, std::optional<std::string> reason,
     const google::protobuf::Timestamp& timestamp) {
   StepStatusChangeQueueElem status_change{.job_id = job_id,
@@ -873,8 +873,8 @@ void JobManager::ActivateTaskStatusChangeAsync_(
                                           .timestamp = std::move(timestamp)};
   if (reason.has_value()) status_change.reason = std::move(reason);
 
-  m_task_status_change_queue_.enqueue(std::move(status_change));
-  m_task_status_change_async_handle_->send();
+  m_step_status_change_queue_.enqueue(std::move(status_change));
+  m_step_status_change_async_handle_->send();
 }
 
 /**
@@ -884,7 +884,7 @@ void JobManager::ActivateTaskStatusChangeAsync_(
  * @param job_id
  * @return True if job and cgroup exists
  */
-bool JobManager::MigrateProcToCgroupOfJob(pid_t pid, task_id_t job_id) {
+bool JobManager::MigrateProcToCgroupOfJob(pid_t pid, job_id_t job_id) {
   auto job = m_job_map_.GetValueExclusivePtr(job_id);
   if (!job) {
     CRANE_DEBUG("Job #{} does not exist when querying its cgroup.", job_id);
@@ -973,25 +973,25 @@ google::protobuf::Timestamp JobManager::GetStepEndTime(job_id_t job_id,
   return step_it->second->end_time;
 }
 
-std::optional<TaskInfoOfUid> JobManager::QueryTaskInfoOfUid(uid_t uid) {
-  CRANE_DEBUG("Query task info for uid {}", uid);
+std::optional<JobInfoOfUid> JobManager::QueryJobInfoOfUid(uid_t uid) {
+  CRANE_DEBUG("Query job info for uid {}", uid);
 
-  TaskInfoOfUid info;
+  JobInfoOfUid info;
   info.job_cnt = 0;
   info.cgroup_exists = false;
 
-  if (auto task_ids = this->m_uid_to_job_ids_map_[uid]; task_ids) {
+  if (auto job_ids = this->m_uid_to_job_ids_map_[uid]; job_ids) {
     info.cgroup_exists = true;
-    info.job_cnt = task_ids->size();
-    info.first_task_id = *task_ids->begin();
+    info.job_cnt = job_ids->size();
+    info.first_job_id = *job_ids->begin();
   } else {
-    CRANE_WARN("Uid {} not found in uid_to_task_ids_map", uid);
+    CRANE_WARN("Uid {} not found in uid_to_job_ids_map", uid);
     return std::nullopt;
   }
   return info;
 }
 
-void JobManager::EvCleanTerminateTaskQueueCb_() {
+void JobManager::EvCleanTerminateStepQueueCb_() {
   StepTerminateQueueElem elem;
   std::vector<StepTerminateQueueElem> not_ready_elems;
 
@@ -999,7 +999,7 @@ void JobManager::EvCleanTerminateTaskQueueCb_() {
 
   while (m_step_terminate_queue_.try_dequeue(elem)) {
     CRANE_TRACE(
-        "Receive TerminateRunningTask Request from internal queue. "
+        "Receive TerminateRunningJob Request from internal queue. "
         "Step: {}.{}",
         elem.job_id, elem.step_id);
 
@@ -1020,7 +1020,7 @@ void JobManager::EvCleanTerminateTaskQueueCb_() {
         g_ctld_client->StepStatusChangeAsync(
             {.job_id = elem.job_id,
              .step_id = elem.step_id,
-             .new_status = crane::grpc::TaskStatus::Cancelled,
+             .new_status = crane::grpc::JobStatus::Cancelled,
              .exit_code = ExitCode::EC_TERMINATED,
              .reason = "Terminated non-existent job.",
              .timestamp = google::protobuf::util::TimeUtil::GetCurrentTime()});
@@ -1038,7 +1038,7 @@ void JobManager::EvCleanTerminateTaskQueueCb_() {
         g_ctld_client->StepStatusChangeAsync(
             {.job_id = elem.job_id,
              .step_id = elem.step_id,
-             .new_status = crane::grpc::TaskStatus::Cancelled,
+             .new_status = crane::grpc::JobStatus::Cancelled,
              .exit_code = ExitCode::EC_TERMINATED,
              .reason = "Terminated non-existent step.",
              .timestamp = google::protobuf::util::TimeUtil::GetCurrentTime()});
@@ -1075,7 +1075,7 @@ void JobManager::EvCleanTerminateTaskQueueCb_() {
           continue;
         }
         auto err =
-            stub->TerminateTask(elem.mark_as_orphaned, elem.terminated_by_user);
+            stub->TerminateStep(elem.mark_as_orphaned, elem.terminated_by_user);
         if (err != CraneErrCode::SUCCESS) {
           // Supervisor dead for some reason.
           CRANE_ERROR("[Step #{}.{}] Failed to terminate.", elem.job_id,
@@ -1084,7 +1084,7 @@ void JobManager::EvCleanTerminateTaskQueueCb_() {
             g_ctld_client->StepStatusChangeAsync(
                 {.job_id = elem.job_id,
                  .step_id = step_id,
-                 .new_status = crane::grpc::TaskStatus::Cancelled,
+                 .new_status = crane::grpc::JobStatus::Cancelled,
                  .exit_code = ExitCode::EC_TERMINATED,
                  .reason = "Terminated failed."});
         }
@@ -1148,7 +1148,7 @@ void JobManager::CleanUpJobAndStepsAsync(std::vector<JobInD>&& jobs,
   std::latch shutdown_step_latch(steps.size());
   for (auto* step : steps) {
     // Only daemon step needs manual shutdown, others will shut down itself when
-    // all task finished.
+    // all jobs finished.
     if (!step->IsDaemonStep() || step->err_before_supv_start) {
       shutdown_step_latch.count_down();
       continue;
@@ -1249,12 +1249,12 @@ void JobManager::CleanUpJobAndStepsAsync(std::vector<JobInD>&& jobs,
 }
 
 void JobManager::StepStatusChangeAsync(
-    job_id_t job_id, step_id_t step_id, crane::grpc::TaskStatus new_status,
+    job_id_t job_id, step_id_t step_id, crane::grpc::JobStatus new_status,
     uint32_t exit_code, std::optional<std::string> reason,
     const google::protobuf::Timestamp& timestamp) {
   CRANE_INFO("[Step #{}.{}] is doing StepStatusChange, new status: {}", job_id,
              step_id, new_status);
-  ActivateTaskStatusChangeAsync_(job_id, step_id, new_status, exit_code,
+  ActivateStepStatusChangeAsync_(job_id, step_id, new_status, exit_code,
                                  std::move(reason), timestamp);
 }
 

--- a/src/Craned/Core/JobManager.h
+++ b/src/Craned/Core/JobManager.h
@@ -54,7 +54,7 @@ struct JobInD {
 
   job_id_t job_id;
   crane::grpc::JobToD job_to_d;
-  crane::grpc::TaskStatus status{crane::grpc::TaskStatus::Configuring};
+  crane::grpc::JobStatus status{crane::grpc::JobStatus::Configuring};
 
   std::unique_ptr<CgroupInterface> cgroup{nullptr};
 
@@ -77,7 +77,7 @@ class JobManager {
   JobManager();
 
   CraneErrCode Recover(
-      std::unordered_map<task_id_t, JobInD>&& job_map,
+      std::unordered_map<job_id_t, JobInD>&& job_map,
       absl::flat_hash_map<std::pair<job_id_t, step_id_t>,
                           std::unique_ptr<StepInstance>>&& step_map);
 
@@ -90,7 +90,7 @@ class JobManager {
    * @param job_ids jobs to free
    * @return true if all job exists
    */
-  bool FreeJobs(std::set<task_id_t>&& job_ids);
+  bool FreeJobs(std::set<job_id_t>&& job_ids);
 
   void AllocSteps(std::vector<StepToD>&& steps);
 
@@ -102,9 +102,9 @@ class JobManager {
 
   CraneExpected<void> ChangeStepTimelimit(job_id_t job_id, step_id_t step_id,
                                           int64_t new_timelimit_sec);
-  std::optional<TaskInfoOfUid> QueryTaskInfoOfUid(uid_t uid);
+  std::optional<JobInfoOfUid> QueryJobInfoOfUid(uid_t uid);
 
-  bool MigrateProcToCgroupOfJob(pid_t pid, task_id_t job_id);
+  bool MigrateProcToCgroupOfJob(pid_t pid, job_id_t job_id);
 
   CraneExpected<EnvMap> QuerySshStepEnvVariables(job_id_t job_id,
                                                  step_id_t step_id);
@@ -138,7 +138,7 @@ class JobManager {
                                std::vector<StepInstance*>&& steps);
 
   void StepStatusChangeAsync(job_id_t job_id, step_id_t step_id,
-                             crane::grpc::TaskStatus new_status,
+                             crane::grpc::JobStatus new_status,
                              uint32_t exit_code,
                              std::optional<std::string> reason,
                              const google::protobuf::Timestamp& timestamp);
@@ -179,16 +179,16 @@ class JobManager {
     std::promise<CraneErrCode> ok_prom;
   };
 
-  struct EvQueueQueryTaskIdFromPid {
-    std::promise<CraneExpected<task_id_t>> task_id_prom;
+  struct EvQueueQueryJobIdFromPid {
+    std::promise<CraneExpected<job_id_t>> job_id_prom;
     pid_t pid;
   };
 
   struct StepTerminateQueueElem {
     job_id_t job_id;
     step_id_t step_id;
-    bool terminated_by_user{false};  // If the task is canceled by user,
-                                     // task->status=Cancelled
+    bool terminated_by_user{false};  // If the job is canceled by user,
+                                     // job->status=Cancelled
     bool mark_as_orphaned{false};
     std::promise<void> terminate_prom;
   };
@@ -208,21 +208,20 @@ class JobManager {
   void LaunchStepMt_(std::unique_ptr<StepInstance> step);
 
   /**
-   * Inform CraneCtld of the status change of a task.
-   * This method is called when the status of a task is changed:
-   * 1. A task is completed successfully. It means that this task returns
+   * Inform CraneCtld of the status change of a job.
+   * This method is called when the status of a job is changed:
+   * 1. A job is completed successfully. It means that this job returns
    *  normally with 0 or a non-zero code. (EvSigchldCb_)
-   * 2. A task is killed by a signal. In this case, the task is considered
+   * 2. A job is killed by a signal. In this case, the job is considered
    *  failed. (EvSigchldCb_)
-   * 3. A task cannot be created because of various reasons.
-   *  (EvGrpcSpawnInteractiveTaskCb_ and EvGrpcExecuteTaskCb_)
+   * 3. A job cannot be created because of various reasons.
    */
-  void ActivateTaskStatusChangeAsync_(
-      job_id_t job_id, step_id_t step_id, crane::grpc::TaskStatus new_status,
+  void ActivateStepStatusChangeAsync_(
+      job_id_t job_id, step_id_t step_id, crane::grpc::JobStatus new_status,
       uint32_t exit_code, std::optional<std::string> reason,
       const google::protobuf::Timestamp& timestamp);
 
-  // Contains all the task that is running on this Craned node.
+  // Contains all the jobs that are running on this Craned node.
   JobMap m_job_map_;
 
   UidMap m_uid_to_job_ids_map_;
@@ -238,16 +237,16 @@ class JobManager {
 
   void EvCleanGrpcExecuteStepQueueCb_();
 
-  void EvCleanTaskStatusChangeQueueCb_();
+  void EvCleanStepStatusChangeQueueCb_();
 
-  void EvCleanTerminateTaskQueueCb_();
+  void EvCleanTerminateStepQueueCb_();
 
   std::shared_ptr<uvw::loop> m_uvw_loop_;
 
   std::shared_ptr<uvw::signal_handle> m_sigchld_handle_;
 
   // When this event is triggered, the JobManager will not accept
-  // any more new tasks and quit as soon as all existing task end.
+  // any more new jobs and quit as soon as all existing jobs end.
   std::shared_ptr<uvw::signal_handle> m_sigint_handle_;
   std::shared_ptr<uvw::signal_handle> m_sigterm_handle_;
 
@@ -264,11 +263,11 @@ class JobManager {
   ConcurrentQueue<EvQueueAllocateStepElem> m_grpc_alloc_step_queue_;
 
   std::shared_ptr<uvw::async_handle> m_grpc_execute_step_async_handle_;
-  // A custom event that handles the ExecuteTask RPC.
+  // A custom event that handles the ExecuteStep RPC.
   ConcurrentQueue<EvQueueExecuteStepElem> m_grpc_execute_step_queue_;
 
-  std::shared_ptr<uvw::async_handle> m_task_status_change_async_handle_;
-  ConcurrentQueue<StepStatusChangeQueueElem> m_task_status_change_queue_;
+  std::shared_ptr<uvw::async_handle> m_step_status_change_async_handle_;
+  ConcurrentQueue<StepStatusChangeQueueElem> m_step_status_change_queue_;
 
   std::shared_ptr<uvw::async_handle> m_terminate_step_async_handle_;
   std::shared_ptr<uvw::timer_handle> m_terminate_step_timer_handle_;
@@ -278,8 +277,8 @@ class JobManager {
   std::function<void()> m_sigint_cb_;
 
   // When SIGINT is triggered or Shutdown() gets called, this variable is set to
-  // true. Then, AddTaskAsyncMethod will not accept any more new tasks and
-  // ev_sigchld_cb_ will stop the event loop when there is no task running.
+  // true. Then, AddJobAsyncMethod will not accept any more new jobs and
+  // ev_sigchld_cb_ will stop the event loop when there is no job running.
   std::atomic_bool m_is_ending_now_{false};
 
   util::mutex m_prolog_serial_mutex_;  // when prolog flags set Serial

--- a/src/Craned/Core/StepInstance.cpp
+++ b/src/Craned/Core/StepInstance.cpp
@@ -287,7 +287,7 @@ CraneErrCode StepInstance::SpawnSupervisor(const EnvMap& job_env_map) {
           g_config.JobLifecycleHook.MaxOutputSize);
     }
 
-    // Populate CDI devices into container_meta for container tasks.
+    // Populate CDI devices into container_meta for container jobs.
     // CDI consistency (all-or-none per name/type) is validated at config
     // parse time in Craned.cpp, so here we only need to fill the list.
     if (this->IsContainer() &&
@@ -526,18 +526,18 @@ void StepInstance::ExecuteStepAsync() {
                               stub = supervisor_stub] {
     auto code = stub->ExecuteStep();
     if (code != CraneErrCode::SUCCESS) {
-      CRANE_ERROR("[Step #{}.{}] Supervisor failed to execute task, code:{}.",
+      CRANE_ERROR("[Step #{}.{}] Supervisor failed to execute step, code:{}.",
                   job_id, step_id, static_cast<int>(code));
       g_ctld_client->StepStatusChangeAsync(StepStatusChangeQueueElem{
           .job_id = job_id,
           .step_id = step_id,
           .new_status = StepStatus::Failed,
           .exit_code = ExitCode::EC_RPC_ERR,
-          .reason = "Supervisor not responding when execute task",
+          .reason = "Supervisor not responding when execute step",
           .timestamp = google::protobuf::util::TimeUtil::GetCurrentTime()});
       // Ctld will send ShutdownSupervisor after status change from
       // daemon supervisor, for common step, will shut down itself when all
-      // task in local step finished.
+      // steps finished locally.
     }
   });
 }

--- a/src/Craned/Core/SupervisorStub.cpp
+++ b/src/Craned/Core/SupervisorStub.cpp
@@ -65,7 +65,7 @@ SupervisorStub::InitAndGetRecoveredMap() {
         CraneExpected<std::tuple<job_id_t, step_id_t, pid_t, StepStatus>>
             supv_ids = stub->CheckStatus();
         if (!supv_ids) {
-          CRANE_ERROR("CheckTaskStatus for {} failed, removing it.",
+          CRANE_ERROR("CheckStepStatus for {} failed, removing it.",
                       file.string());
           std::error_code ec;
           std::filesystem::remove(file, ec);
@@ -98,10 +98,10 @@ SupervisorStub::InitAndGetRecoveredMap() {
 
 CraneErrCode SupervisorStub::ExecuteStep() {
   ClientContext context;
-  crane::grpc::supervisor::TaskExecutionRequest request;
-  crane::grpc::supervisor::TaskExecutionReply reply;
+  crane::grpc::supervisor::StepExecutionRequest request;
+  crane::grpc::supervisor::StepExecutionReply reply;
 
-  auto ok = m_stub_->ExecuteTask(&context, request, &reply);
+  auto ok = m_stub_->ExecuteStep(&context, request, &reply);
   if (!ok.ok()) {
     CRANE_ERROR("ExecuteStep failed: reply {},{}", ok.ok(), ok.error_message());
     return CraneErrCode::ERR_RPC_FAILURE;
@@ -141,37 +141,37 @@ SupervisorStub::CheckStatus() {
   return std::unexpected(CraneErrCode::ERR_RPC_FAILURE);
 }
 
-CraneErrCode SupervisorStub::TerminateTask(bool mark_as_orphaned,
+CraneErrCode SupervisorStub::TerminateStep(bool mark_as_orphaned,
                                            bool terminated_by_user) {
   ClientContext context;
-  crane::grpc::supervisor::TerminateTaskRequest request;
-  crane::grpc::supervisor::TerminateTaskReply reply;
+  crane::grpc::supervisor::TerminateStepRequest request;
+  crane::grpc::supervisor::TerminateStepReply reply;
 
   request.set_mark_orphaned(mark_as_orphaned);
   request.set_terminated_by_user(terminated_by_user);
 
-  auto ok = m_stub_->TerminateTask(&context, request, &reply);
+  auto ok = m_stub_->TerminateStep(&context, request, &reply);
   if (ok.ok() && reply.ok()) {
     return CraneErrCode::SUCCESS;
   }
-  CRANE_ERROR("TerminateTask failed: reply {},{}", reply.ok(),
+  CRANE_ERROR("TerminateStep failed: reply {},{}", reply.ok(),
               ok.error_message());
 
-  CRANE_WARN("TerminateTask failed: reply {},{}", reply.ok(),
+  CRANE_WARN("TerminateStep failed: reply {},{}", reply.ok(),
              ok.error_message());
   return CraneErrCode::ERR_RPC_FAILURE;
 }
 
-CraneErrCode SupervisorStub::ChangeTaskTimeLimit(absl::Duration time_limit) {
+CraneErrCode SupervisorStub::ChangeStepTimeLimit(absl::Duration time_limit) {
   ClientContext context;
-  crane::grpc::supervisor::ChangeTaskTimeLimitRequest request;
-  crane::grpc::supervisor::ChangeTaskTimeLimitReply reply;
+  crane::grpc::supervisor::ChangeStepTimeLimitRequest request;
+  crane::grpc::supervisor::ChangeStepTimeLimitReply reply;
 
   request.set_time_limit_seconds(absl::ToInt64Seconds(time_limit));
-  auto ok = m_stub_->ChangeTaskTimeLimit(&context, request, &reply);
+  auto ok = m_stub_->ChangeStepTimeLimit(&context, request, &reply);
   if (ok.ok() && reply.ok()) return CraneErrCode::SUCCESS;
 
-  CRANE_WARN("ChangeTaskTimeLimit failed: reply {},{}", reply.ok(),
+  CRANE_WARN("ChangeStepTimeLimit failed: reply {},{}", reply.ok(),
              ok.error_message());
   return CraneErrCode::ERR_RPC_FAILURE;
 }

--- a/src/Craned/Core/SupervisorStub.h
+++ b/src/Craned/Core/SupervisorStub.h
@@ -35,9 +35,9 @@ class SupervisorStub {
     std::shared_ptr<SupervisorStub> supervisor_stub;
   };
   /**
-   * @brief Query all existing supervisor for task they hold.
+   * @brief Query all existing supervisor for steps they hold.
    * @return job_id and pid from supervisors. Error when socket file
-   * scanning fails, supervisors are unreachable, or task status queries fail
+   * scanning fails, supervisors are unreachable, or step status queries fail
    * with specific error codes.
    */
   [[nodiscard]] static CraneExpected<absl::flat_hash_map<
@@ -48,8 +48,8 @@ class SupervisorStub {
   CraneExpected<std::tuple<job_id_t, step_id_t, pid_t, StepStatus>>
   CheckStatus();
 
-  CraneErrCode TerminateTask(bool mark_as_orphaned, bool terminated_by_user);
-  CraneErrCode ChangeTaskTimeLimit(absl::Duration time_limit);
+  CraneErrCode TerminateStep(bool mark_as_orphaned, bool terminated_by_user);
+  CraneErrCode ChangeStepTimeLimit(absl::Duration time_limit);
   CraneErrCode MigrateSshProcToCg(pid_t pid);
   CraneErrCode ShutdownSupervisor();
 

--- a/src/Craned/Supervisor/CforedClient.cpp
+++ b/src/Craned/Supervisor/CforedClient.cpp
@@ -24,8 +24,8 @@
 #include "crane/String.h"
 namespace Craned::Supervisor {
 
-using crane::grpc::StreamTaskIOReply;
-using crane::grpc::StreamTaskIORequest;
+using crane::grpc::StreamStepIOReply;
+using crane::grpc::StreamStepIORequest;
 
 CforedClient::CforedClient() {
   m_loop_ = uvw::loop::create();
@@ -160,7 +160,7 @@ uint16_t CforedClient::SetupX11forwarding_() {
     CRANE_TRACE("Accepting connection on x11 proxy.");
 
     x11_local_id_t x11_local_id = next_x11_id_++;
-    this->TaskX11ConnectForward(x11_local_id);
+    this->StepX11ConnectForward(x11_local_id);
     auto x11_fd_info = std::make_shared<X11FdInfo>();
     auto sock = h.parent().resource<uvw::tcp_handle>();
 
@@ -168,7 +168,7 @@ uint16_t CforedClient::SetupX11forwarding_() {
         [x11_local_id, this](uvw::data_event& e, uvw::tcp_handle& s) {
           CRANE_TRACE("[X11 #{}] Read x11 output len [{}]. Forwarding...",
                       x11_local_id, e.length);
-          TaskX11OutPutForward(x11_local_id, std::move(e.data), e.length);
+          StepX11OutPutForward(x11_local_id, std::move(e.data), e.length);
         });
     sock->on<uvw::write_event>(
         [x11_local_id, this](const uvw::write_event&, uvw::tcp_handle&) {
@@ -191,7 +191,7 @@ uint16_t CforedClient::SetupX11forwarding_() {
     sock->on<uvw::close_event>(
         [x11_local_id, this](uvw::close_event&, uvw::tcp_handle& s) {
           CRANE_INFO("[X11 #{}] proxy connection was closed.", x11_local_id);
-          this->TaskX11OutputFinish(x11_local_id);
+          this->StepX11OutputFinish(x11_local_id);
         });
 
     h.accept(*sock);
@@ -431,7 +431,7 @@ void CforedClient::InitChannelAndStub(const std::string& cfored_name) {
 }
 
 void CforedClient::CleanOutputQueueAndWriteToStreamThread_(
-    grpc::ClientAsyncReaderWriter<StreamTaskIORequest, StreamTaskIOReply>*
+    grpc::ClientAsyncReaderWriter<StreamStepIORequest, StreamStepIOReply>*
         stream,
     std::atomic<bool>* write_pending) {
   CRANE_TRACE("CleanOutputQueueThread started.");
@@ -448,7 +448,7 @@ void CforedClient::CleanOutputQueueAndWriteToStreamThread_(
     }
 
     if (ok) {
-      StreamTaskIORequest request;
+      StreamStepIORequest request;
       request.set_type(fwd_req.type);
       std::visit(
           VariantVisitor{
@@ -457,12 +457,12 @@ void CforedClient::CleanOutputQueueAndWriteToStreamThread_(
                 payload->set_msg(req.data.get(), req.len);
               },
               [&request](X11FwdConnectReq& req) {
-                auto* payload = request.mutable_payload_task_x11_fwd_conn_req();
+                auto* payload = request.mutable_payload_step_x11_fwd_conn_req();
                 payload->set_local_id(req.x11_id);
                 payload->set_craned_id(g_config.CranedIdOfThisNode);
               },
               [&request](X11FwdReq& req) {
-                auto* payload = request.mutable_payload_task_x11_output_req();
+                auto* payload = request.mutable_payload_step_x11_output_req();
                 payload->set_local_id(req.x11_id);
                 payload->set_craned_id(g_config.CranedIdOfThisNode);
                 payload->set_msg(req.data.get(), req.len);
@@ -474,7 +474,7 @@ void CforedClient::CleanOutputQueueAndWriteToStreamThread_(
                 payload->set_signaled(status.signaled);
               },
               [&request](X11FwdEofReq& req) {
-                auto* payload = request.mutable_payload_task_x11_eof_req();
+                auto* payload = request.mutable_payload_step_x11_eof_req();
                 payload->set_local_id(req.x11_id);
                 payload->set_craned_id(g_config.CranedIdOfThisNode);
               }},
@@ -512,14 +512,14 @@ void CforedClient::AsyncSendRecvThread_() {
   bool ok;
   Tag tag;
   grpc::ClientContext context;
-  StreamTaskIORequest request;
-  StreamTaskIOReply reply;
+  StreamStepIORequest request;
+  StreamStepIOReply reply;
   grpc::CompletionQueue::NextStatus next_status;
 
   auto stream =
-      m_stub_->AsyncTaskIOStream(&context, &m_cq_, (void*)Tag::Prepare);
+      m_stub_->AsyncStepIOStream(&context, &m_cq_, (void*)Tag::Prepare);
 
-  CRANE_TRACE("Preparing TaskIOStream...");
+  CRANE_TRACE("Preparing StepIOStream...");
 
   State state = State::Registering;
   while (true) {
@@ -556,7 +556,7 @@ void CforedClient::AsyncSendRecvThread_() {
         CRANE_TRACE("Unregistering on cfored {}.", m_cfored_name_);
 
         request.Clear();
-        request.set_type(StreamTaskIORequest::SUPERVISOR_UNREGISTER);
+        request.set_type(StreamStepIORequest::SUPERVISOR_UNREGISTER);
 
         stream->WriteLast(request, grpc::WriteOptions(), (void*)Tag::Write);
 
@@ -597,7 +597,7 @@ void CforedClient::AsyncSendRecvThread_() {
 
       CRANE_ASSERT_MSG_VA(tag == Tag::Prepare, "Tag: {}", int(tag));
 
-      request.set_type(StreamTaskIORequest::SUPERVISOR_REGISTER);
+      request.set_type(StreamStepIORequest::SUPERVISOR_REGISTER);
       request.mutable_payload_register_req()->set_craned_id(
           g_config.CranedIdOfThisNode);
       request.mutable_payload_register_req()->set_job_id(g_config.JobId);
@@ -644,25 +644,25 @@ void CforedClient::AsyncSendRecvThread_() {
       CRANE_ASSERT(tag == Tag::Read);
       const std::string* msg;
 
-      if (reply.type() == StreamTaskIOReply::TASK_X11_INPUT) {
-        msg = &reply.payload_task_x11_input_req().msg();
-        CRANE_TRACE("TASK_X11_INPUT len:{} EOF: {}.", msg->length(),
-                    reply.payload_task_x11_input_req().eof());
-      } else if (reply.type() == StreamTaskIOReply::TASK_INPUT) {
+      if (reply.type() == StreamStepIOReply::STEP_X11_INPUT) {
+        msg = &reply.payload_step_x11_input_req().msg();
+        CRANE_TRACE("STEP_X11_INPUT len:{} EOF: {}.", msg->length(),
+                    reply.payload_step_x11_input_req().eof());
+      } else if (reply.type() == StreamStepIOReply::TASK_INPUT) {
         msg = &reply.payload_task_input_req().msg();
         CRANE_TRACE("TASK_INPUT len:{} EOF:{}.", msg->length(),
                     reply.payload_task_input_req().eof());
       } else [[unlikely]] {
-        CRANE_ERROR("Expect TASK_INPUT or TASK_X11_INPUT, but got {}",
+        CRANE_ERROR("Expect TASK_INPUT or STEP_X11_INPUT, but got {}",
                     (int)reply.type());
         break;
       }
 
       m_mtx_.Lock();
 
-      if (reply.type() == StreamTaskIOReply::TASK_X11_INPUT) {
-        x11_local_id_t x11_id = reply.payload_task_x11_input_req().local_id();
-        bool eof = reply.payload_task_x11_input_req().eof();
+      if (reply.type() == StreamStepIOReply::STEP_X11_INPUT) {
+        x11_local_id_t x11_id = reply.payload_step_x11_input_req().local_id();
+        bool eof = reply.payload_step_x11_input_req().eof();
         auto x11_fd_info_it = m_x11_fd_info_map_.find(x11_id);
         if (x11_fd_info_it != m_x11_fd_info_map_.end()) {
           if (!x11_fd_info_it->second->sock_stopped) {
@@ -723,7 +723,7 @@ void CforedClient::AsyncSendRecvThread_() {
       CRANE_ASSERT(tag == Tag::Read);
       CRANE_TRACE("UNREGISTER_REPLY msg received.");
 
-      if (reply.type() != StreamTaskIOReply::SUPERVISOR_UNREGISTER_REPLY) {
+      if (reply.type() != StreamStepIOReply::SUPERVISOR_UNREGISTER_REPLY) {
         CRANE_TRACE("Expect UNREGISTER_REPLY, but got {}. Ignoring it.",
                     (int)reply.type());
         reply.Clear();
@@ -757,7 +757,7 @@ bool CforedClient::TaskProcessStop(task_id_t task_id, uint32_t exit_code,
   CRANE_DEBUG("[Task #{}] Process stopped with exit_code: {}, signaled: {}.",
               task_id, exit_code, signaled);
   m_task_fwd_req_queue_.enqueue(FwdRequest{
-      .type = StreamTaskIORequest::TASK_EXIT_STATUS,
+      .type = StreamStepIORequest::TASK_EXIT_STATUS,
       .data = TaskFinishStatus{.task_id = task_id,
                                .exit_code = exit_code,
                                .signaled = signaled},
@@ -780,34 +780,34 @@ void CforedClient::TaskOutPutForward(std::unique_ptr<char[]>&& data,
                                      size_t len) {
   CRANE_TRACE("Receive TaskOutputForward len: {}.", len);
   m_task_fwd_req_queue_.enqueue(FwdRequest{
-      .type = StreamTaskIORequest::TASK_OUTPUT,
+      .type = StreamStepIORequest::TASK_OUTPUT,
       .data = IOFwdRequest{.data = std::move(data), .len = len},
   });
 }
-void CforedClient::TaskX11ConnectForward(x11_local_id_t x11_local_id) {
-  CRANE_INFO("Receive TaskX11ConnectForward id:{} .", x11_local_id);
+void CforedClient::StepX11ConnectForward(x11_local_id_t x11_local_id) {
+  CRANE_INFO("Receive StepX11ConnectForward id:{} .", x11_local_id);
   m_task_fwd_req_queue_.enqueue(
-      FwdRequest{.type = StreamTaskIORequest::TASK_X11_CONN,
+      FwdRequest{.type = StreamStepIORequest::STEP_X11_CONN,
                  .data = X11FwdConnectReq{.x11_id = x11_local_id}});
 }
 
-void CforedClient::TaskX11OutPutForward(x11_local_id_t x11_local_id,
+void CforedClient::StepX11OutPutForward(x11_local_id_t x11_local_id,
                                         std::unique_ptr<char[]>&& data,
                                         size_t len) {
-  CRANE_TRACE("Receive TaskX11OutPutForward len: {}.", len);
+  CRANE_TRACE("Receive StepX11OutPutForward len: {}.", len);
   m_task_fwd_req_queue_.enqueue(FwdRequest{
-      .type = StreamTaskIORequest::TASK_X11_OUTPUT,
+      .type = StreamStepIORequest::STEP_X11_OUTPUT,
       .data = X11FwdReq{.x11_id = x11_local_id,
                         .data = std::move(data),
                         .len = len},
   });
 }
 
-void CforedClient::TaskX11OutputFinish(x11_local_id_t x11_local_id) {
+void CforedClient::StepX11OutputFinish(x11_local_id_t x11_local_id) {
   absl::MutexLock lock(&m_mtx_);
-  CRANE_INFO("Receive TaskX11OutputFinish id:{} .", x11_local_id);
+  CRANE_INFO("Receive StepX11OutputFinish id:{} .", x11_local_id);
   m_task_fwd_req_queue_.enqueue(
-      FwdRequest{.type = StreamTaskIORequest::TASK_X11_EOF,
+      FwdRequest{.type = StreamStepIORequest::STEP_X11_EOF,
                  .data = X11FwdEofReq{.x11_id = x11_local_id}});
   m_x11_fd_info_map_.erase(x11_local_id);
 }

--- a/src/Craned/Supervisor/CforedClient.cpp
+++ b/src/Craned/Supervisor/CforedClient.cpp
@@ -584,8 +584,8 @@ void CforedClient::AsyncSendRecvThread_() {
         m_stop_task_io_queue_.enqueue(task_id);
         m_clean_stop_task_io_queue_async_handle_->send();
       }
-      CRANE_ERROR("Terminating all task due to cfored connection failure.");
-      g_task_mgr->TerminateTaskAsync(
+      CRANE_ERROR("Terminating step due to cfored connection failure.");
+      g_task_mgr->TerminateStepAsync(
           false, TerminatedBy::TERMINATION_BY_CFORED_CONN_FAILURE);
       state = State::End;
     }

--- a/src/Craned/Supervisor/CforedClient.h
+++ b/src/Craned/Supervisor/CforedClient.h
@@ -107,16 +107,16 @@ class CforedClient {
 
   void TaskOutPutForward(std::unique_ptr<char[]>&& data, size_t len);
 
-  void TaskX11ConnectForward(x11_local_id_t x11_local_id);
+  void StepX11ConnectForward(x11_local_id_t x11_local_id);
 
-  void TaskX11OutPutForward(x11_local_id_t x11_local_id,
+  void StepX11OutPutForward(x11_local_id_t x11_local_id,
                             std::unique_ptr<char[]>&& data, size_t len);
 
-  void TaskX11OutputFinish(x11_local_id_t x11_local_id);
+  void StepX11OutputFinish(x11_local_id_t x11_local_id);
 
   void CleanOutputQueueAndWriteToStreamThread_(
-      grpc::ClientAsyncReaderWriter<crane::grpc::StreamTaskIORequest,
-                                    crane::grpc::StreamTaskIOReply>* stream,
+      grpc::ClientAsyncReaderWriter<crane::grpc::StreamStepIORequest,
+                                    crane::grpc::StreamStepIOReply>* stream,
       std::atomic<bool>* write_pending);
 
   std::atomic<bool> m_stopped_{false};
@@ -147,7 +147,7 @@ class CforedClient {
   };
 
   struct FwdRequest {
-    crane::grpc::StreamTaskIORequest::SupervisorRequestType type;
+    crane::grpc::StreamStepIORequest::SupervisorRequestType type;
     std::variant<IOFwdRequest, X11FwdConnectReq, X11FwdReq, X11FwdEofReq,
                  TaskFinishStatus>
         data;

--- a/src/Craned/Supervisor/CranedClient.cpp
+++ b/src/Craned/Supervisor/CranedClient.cpp
@@ -40,7 +40,7 @@ void CranedClient::InitChannelAndStub(const std::string& endpoint) {
   m_async_send_thread_ = std::thread([this] { AsyncSendThread_(); });
 }
 
-void CranedClient::StepStatusChangeAsync(crane::grpc::TaskStatus new_status,
+void CranedClient::StepStatusChangeAsync(crane::grpc::JobStatus new_status,
                                          uint32_t exit_code,
                                          std::optional<std::string> reason) {
   StepStatusChangeQueueElem elem{

--- a/src/Craned/Supervisor/CranedClient.h
+++ b/src/Craned/Supervisor/CranedClient.h
@@ -30,14 +30,14 @@ class CranedClient {
   ~CranedClient();
   void Shutdown();
   void InitChannelAndStub(const std::string& endpoint);
-  void StepStatusChangeAsync(crane::grpc::TaskStatus new_status,
+  void StepStatusChangeAsync(crane::grpc::JobStatus new_status,
                              uint32_t exit_code,
                              std::optional<std::string> reason);
 
  private:
   void AsyncSendThread_();
   struct StepStatusChangeQueueElem {
-    crane::grpc::TaskStatus new_status{};
+    crane::grpc::JobStatus new_status{};
     uint32_t exit_code{};
     std::optional<std::string> reason;
     google::protobuf::Timestamp timestamp{};

--- a/src/Craned/Supervisor/Supervisor.cpp
+++ b/src/Craned/Supervisor/Supervisor.cpp
@@ -383,7 +383,7 @@ void StartServer(int grpc_output_fd) {
         ready = false;
       } else {
         // Just wait here for pod setup. if pod failed, daemon step failed.
-        auto ok_prom = g_task_mgr->ExecuteTaskAsync();
+        auto ok_prom = g_task_mgr->ExecuteStepAsync();
         if (auto err = ok_prom.get(); err != CraneErrCode::SUCCESS) {
           CRANE_ERROR("Failed to start daemon step, code: {}",
                       static_cast<int>(err));

--- a/src/Craned/Supervisor/SupervisorPublicDefs.h
+++ b/src/Craned/Supervisor/SupervisorPublicDefs.h
@@ -30,10 +30,10 @@ using Common::CgroupManager;
 using Common::EnvMap;
 
 using StepToSupv = crane::grpc::StepToD;
-using StepStatus = crane::grpc::TaskStatus;
+using StepStatus = crane::grpc::JobStatus;
 struct TaskStatusChangeQueueElem {
   task_id_t task_id{};
-  crane::grpc::TaskStatus new_status{};
+  crane::grpc::JobStatus new_status{};
   uint32_t exit_code{};
   std::optional<std::string> reason;
 };

--- a/src/Craned/Supervisor/SupervisorServer.cpp
+++ b/src/Craned/Supervisor/SupervisorServer.cpp
@@ -23,12 +23,12 @@
 
 namespace Craned::Supervisor {
 
-grpc::Status SupervisorServiceImpl::ExecuteTask(
+grpc::Status SupervisorServiceImpl::ExecuteStep(
     grpc::ServerContext* context,
-    const crane::grpc::supervisor::TaskExecutionRequest* request,
-    crane::grpc::supervisor::TaskExecutionReply* response) {
+    const crane::grpc::supervisor::StepExecutionRequest* request,
+    crane::grpc::supervisor::StepExecutionReply* response) {
   CRANE_ASSERT(g_config.StepSpec.step_type() != crane::grpc::StepType::DAEMON);
-  std::future<CraneErrCode> code_future = g_task_mgr->ExecuteTaskAsync();
+  std::future<CraneErrCode> code_future = g_task_mgr->ExecuteStepAsync();
   code_future.wait();
 
   CraneErrCode ok = code_future.get();
@@ -65,11 +65,11 @@ grpc::Status SupervisorServiceImpl::CheckStatus(
   return Status::OK;
 }
 
-grpc::Status SupervisorServiceImpl::ChangeTaskTimeLimit(
+grpc::Status SupervisorServiceImpl::ChangeStepTimeLimit(
     grpc::ServerContext* context,
-    const crane::grpc::supervisor::ChangeTaskTimeLimitRequest* request,
-    crane::grpc::supervisor::ChangeTaskTimeLimitReply* response) {
-  auto ok = g_task_mgr->ChangeTaskTimeLimitAsync(
+    const crane::grpc::supervisor::ChangeStepTimeLimitRequest* request,
+    crane::grpc::supervisor::ChangeStepTimeLimitReply* response) {
+  auto ok = g_task_mgr->ChangeStepTimeLimitAsync(
       absl::Seconds(request->time_limit_seconds()));
   ok.wait();
   if (ok.get() != CraneErrCode::SUCCESS) {
@@ -80,11 +80,11 @@ grpc::Status SupervisorServiceImpl::ChangeTaskTimeLimit(
   return Status::OK;
 }
 
-grpc::Status SupervisorServiceImpl::TerminateTask(
+grpc::Status SupervisorServiceImpl::TerminateStep(
     grpc::ServerContext* context,
-    const crane::grpc::supervisor::TerminateTaskRequest* request,
-    crane::grpc::supervisor::TerminateTaskReply* response) {
-  g_task_mgr->TerminateTaskAsync(request->mark_orphaned(),
+    const crane::grpc::supervisor::TerminateStepRequest* request,
+    crane::grpc::supervisor::TerminateStepReply* response) {
+  g_task_mgr->TerminateStepAsync(request->mark_orphaned(),
                                  request->terminated_by_user()
                                      ? TerminatedBy::CANCELLED_BY_USER
                                      : TerminatedBy::NONE);
@@ -118,9 +118,9 @@ grpc::Status SupervisorServiceImpl::ShutdownSupervisor(
     // 1. Normal case: Pod remains running with no container (Running)
     // 2. Abnormal case: Pod failed to launch before (Failed)
 
-    // Here is the case #1. Trigger task killing and wait for pod exit,
+    // Here is the case #1. Trigger step killing and wait for pod exit,
     // where ShutdownSupervisor will be called.
-    g_task_mgr->TerminateTaskAsync(false, TerminatedBy::CANCELLED_BY_USER);
+    g_task_mgr->TerminateStepAsync(false, TerminatedBy::CANCELLED_BY_USER);
     return Status::OK;
   }
 

--- a/src/Craned/Supervisor/SupervisorServer.h
+++ b/src/Craned/Supervisor/SupervisorServer.h
@@ -35,10 +35,10 @@ using crane::grpc::supervisor::Supervisor;
 class SupervisorServiceImpl : public Supervisor::Service {
  public:
   SupervisorServiceImpl() = default;
-  grpc::Status ExecuteTask(
+  grpc::Status ExecuteStep(
       grpc::ServerContext* context,
-      const crane::grpc::supervisor::TaskExecutionRequest* request,
-      crane::grpc::supervisor::TaskExecutionReply* response) override;
+      const crane::grpc::supervisor::StepExecutionRequest* request,
+      crane::grpc::supervisor::StepExecutionReply* response) override;
 
   grpc::Status QueryEnvMap(
       grpc::ServerContext* context,
@@ -50,15 +50,15 @@ class SupervisorServiceImpl : public Supervisor::Service {
       const crane::grpc::supervisor::CheckStatusRequest* request,
       crane::grpc::supervisor::CheckStatusReply* response) override;
 
-  grpc::Status ChangeTaskTimeLimit(
+  grpc::Status ChangeStepTimeLimit(
       grpc::ServerContext* context,
-      const crane::grpc::supervisor::ChangeTaskTimeLimitRequest* request,
-      crane::grpc::supervisor::ChangeTaskTimeLimitReply* response) override;
+      const crane::grpc::supervisor::ChangeStepTimeLimitRequest* request,
+      crane::grpc::supervisor::ChangeStepTimeLimitReply* response) override;
 
-  grpc::Status TerminateTask(
+  grpc::Status TerminateStep(
       grpc::ServerContext* context,
-      const crane::grpc::supervisor::TerminateTaskRequest* request,
-      crane::grpc::supervisor::TerminateTaskReply* response) override;
+      const crane::grpc::supervisor::TerminateStepRequest* request,
+      crane::grpc::supervisor::TerminateStepReply* response) override;
 
   grpc::Status MigrateSshProcToCgroup(
       grpc::ServerContext* context,

--- a/src/Craned/Supervisor/TaskManager.cpp
+++ b/src/Craned/Supervisor/TaskManager.cpp
@@ -2584,12 +2584,12 @@ void TaskManager::EvCleanTaskStopQueueCb_() {
     case CraneErrCode::ERR_PROTOBUF:
       TaskFinish_(task_id, crane::grpc::JobStatus::Failed,
                   ExitCode::EC_SPAWN_FAILED, std::nullopt);
-      return;
+      continue;
 
     case CraneErrCode::ERR_CGROUP:
       TaskFinish_(task_id, crane::grpc::JobStatus::Failed,
                   ExitCode::EC_CGROUP_ERR, std::nullopt);
-      return;
+      continue;
 
     default:
       break;

--- a/src/Craned/Supervisor/TaskManager.cpp
+++ b/src/Craned/Supervisor/TaskManager.cpp
@@ -913,7 +913,7 @@ CraneErrCode PodInstance::ResolveUserNsMapping_(
 }
 
 void PodInstance::SetPodLabels_(
-    const crane::grpc::PodTaskAdditionalMeta& pod_meta, uid_t uid,
+    const crane::grpc::PodJobAdditionalMeta& pod_meta, uid_t uid,
     job_id_t job_id, const std::string& job_name) {
   m_pod_config_.mutable_labels()->insert(
       {{std::string(cri::kCriUidKey), std::to_string(uid)},
@@ -924,7 +924,7 @@ void PodInstance::SetPodLabels_(
 }
 
 void PodInstance::SetPodAnnotations_(
-    const crane::grpc::PodTaskAdditionalMeta& pod_meta, uid_t uid,
+    const crane::grpc::PodJobAdditionalMeta& pod_meta, uid_t uid,
     job_id_t job_id, const std::string& job_name, const std::string& hostname) {
   auto prefix = [](std::string_view key) -> std::string {
     return std::string(cri::kCriAnnotationPrefix) + std::string(key);
@@ -944,7 +944,7 @@ void PodInstance::SetPodAnnotations_(
 }
 
 CraneErrCode PodInstance::SetPodSandboxConfig_(
-    const crane::grpc::PodTaskAdditionalMeta& pod_meta) {
+    const crane::grpc::PodJobAdditionalMeta& pod_meta) {
   // All steps in a job share the same pod.
   job_id_t job_id = g_config.JobId;
 
@@ -1393,7 +1393,7 @@ const TaskExitInfo& ContainerInstance::HandleContainerExited(
 }
 
 CraneErrCode ContainerInstance::LoadPodSandboxInfo_(
-    const crane::grpc::PodTaskAdditionalMeta* pod_meta) {
+    const crane::grpc::PodJobAdditionalMeta* pod_meta) {
   using cri::kCriDefaultLabel;
   using cri::kCriJobIdKey;
   using cri::kCriJobNameKey;
@@ -1497,8 +1497,8 @@ void ContainerInstance::SetContainerLabels_(uid_t uid, job_id_t job_id,
 }
 
 CraneErrCode ContainerInstance::SetContainerConfig_(
-    const crane::grpc::ContainerTaskAdditionalMeta& ca_meta,
-    const crane::grpc::PodTaskAdditionalMeta* pod_meta) {
+    const crane::grpc::ContainerJobAdditionalMeta& ca_meta,
+    const crane::grpc::PodJobAdditionalMeta* pod_meta) {
   // There is only one container in a step. So we use step_id and job_id here.
   job_id_t job_id = g_config.JobId;
   step_id_t step_id = g_config.StepId;
@@ -2102,41 +2102,41 @@ TaskManager::TaskManager()
         EvCleanCriEventQueueCb_();
       });
 
-  m_terminate_task_async_handle_ = m_uvw_loop_->resource<uvw::async_handle>();
-  m_terminate_task_async_handle_->on<uvw::async_event>(
+  m_terminate_step_async_handle_ = m_uvw_loop_->resource<uvw::async_handle>();
+  m_terminate_step_async_handle_->on<uvw::async_event>(
       [this](const uvw::async_event&, uvw::async_handle&) {
-        EvCleanTerminateTaskQueueCb_();
+        EvCleanTerminateStepQueueCb_();
       });
-  m_terminate_task_timer_handle_ = m_uvw_loop_->resource<uvw::timer_handle>();
-  m_terminate_task_timer_handle_->on<uvw::timer_event>(
+  m_terminate_step_timer_handle_ = m_uvw_loop_->resource<uvw::timer_handle>();
+  m_terminate_step_timer_handle_->on<uvw::timer_event>(
       [this](const uvw::timer_event&, uvw::timer_handle&) {
-        m_terminate_task_async_handle_->send();
+        m_terminate_step_async_handle_->send();
       });
-  m_terminate_task_timer_handle_->start(
+  m_terminate_step_timer_handle_->start(
       std::chrono::milliseconds(kStepRequestCheckIntervalMs * 3),
       std::chrono::milliseconds(kStepRequestCheckIntervalMs));
 
-  m_change_task_time_limit_async_handle_ =
+  m_change_step_time_limit_async_handle_ =
       m_uvw_loop_->resource<uvw::async_handle>();
-  m_change_task_time_limit_async_handle_->on<uvw::async_event>(
+  m_change_step_time_limit_async_handle_->on<uvw::async_event>(
       [this](const uvw::async_event&, uvw::async_handle&) {
-        EvCleanChangeTaskTimeLimitQueueCb_();
+        EvCleanChangeStepTimeLimitQueueCb_();
       });
-  m_change_task_time_limit_timer_handle_ =
+  m_change_step_time_limit_timer_handle_ =
       m_uvw_loop_->resource<uvw::timer_handle>();
-  m_change_task_time_limit_timer_handle_->on<uvw::timer_event>(
+  m_change_step_time_limit_timer_handle_->on<uvw::timer_event>(
       [this](const uvw::timer_event&, uvw::timer_handle&) {
-        m_change_task_time_limit_async_handle_->send();
+        m_change_step_time_limit_async_handle_->send();
       });
-  m_change_task_time_limit_timer_handle_->start(
+  m_change_step_time_limit_timer_handle_->start(
       std::chrono::milliseconds(kStepRequestCheckIntervalMs * 3),
       std::chrono::milliseconds(kStepRequestCheckIntervalMs));
 
-  m_grpc_execute_task_async_handle_ =
+  m_grpc_execute_step_async_handle_ =
       m_uvw_loop_->resource<uvw::async_handle>();
-  m_grpc_execute_task_async_handle_->on<uvw::async_event>(
+  m_grpc_execute_step_async_handle_->on<uvw::async_event>(
       [this](const uvw::async_event&, uvw::async_handle&) {
-        EvGrpcExecuteTaskCb_();
+        EvGrpcExecuteStepCb_();
       });
 
   m_grpc_query_step_env_async_handle_ =
@@ -2216,7 +2216,7 @@ void TaskManager::Wait() {
   if (m_uvw_thread_.joinable()) m_uvw_thread_.join();
 }
 
-void TaskManager::ShutdownSupervisorAsync(crane::grpc::TaskStatus new_status,
+void TaskManager::ShutdownSupervisorAsync(crane::grpc::JobStatus new_status,
                                           uint32_t exit_code,
                                           std::string reason) {
   CRANE_INFO("All tasks finished, exiting...");
@@ -2231,7 +2231,7 @@ void TaskManager::TaskStopAndDoStatusChange(task_id_t task_id) {
 }
 
 void TaskManager::TaskFinish_(task_id_t task_id,
-                              crane::grpc::TaskStatus new_status,
+                              crane::grpc::JobStatus new_status,
                               uint32_t exit_code,
                               std::optional<std::string> reason) {
   CRANE_TRACE(
@@ -2277,16 +2277,16 @@ void TaskManager::TaskFinish_(task_id_t task_id,
   }
 }
 
-std::future<CraneErrCode> TaskManager::ExecuteTaskAsync() {
-  CRANE_INFO("[Job #{}.{}] Executing task.", m_step_.job_id, m_step_.step_id);
+std::future<CraneErrCode> TaskManager::ExecuteStepAsync() {
+  CRANE_INFO("[Job #{}.{}] Executing step.", m_step_.job_id, m_step_.step_id);
 
   std::promise<CraneErrCode> ok_promise;
   std::future ok_future = ok_promise.get_future();
 
-  auto elem = ExecuteTaskElem{.ok_prom = std::move(ok_promise)};
+  auto elem = ExecuteStepElem{.ok_prom = std::move(ok_promise)};
 
-  m_grpc_execute_task_queue_.enqueue(std::move(elem));
-  m_grpc_execute_task_async_handle_->send();
+  m_grpc_execute_step_queue_.enqueue(std::move(elem));
+  m_grpc_execute_step_async_handle_->send();
   return ok_future;
 }
 
@@ -2299,7 +2299,7 @@ CraneErrCode TaskManager::LaunchExecution_(ITaskInstance* task) {
   CraneErrCode err = task->Prepare();
   if (err != CraneErrCode::SUCCESS) {
     TaskFinish_(
-        task->task_id, crane::grpc::TaskStatus::Failed,
+        task->task_id, crane::grpc::JobStatus::Failed,
         ExitCode::EC_FILE_NOT_FOUND,
         fmt::format("Failed to prepare task, code: {}", static_cast<int>(err)));
     return err;
@@ -2308,7 +2308,7 @@ CraneErrCode TaskManager::LaunchExecution_(ITaskInstance* task) {
   CRANE_INFO("[Task #{}] Spawning process in task", task->task_id);
   err = task->Spawn();
   if (err != CraneErrCode::SUCCESS) {
-    TaskFinish_(task->task_id, crane::grpc::TaskStatus::Failed,
+    TaskFinish_(task->task_id, crane::grpc::JobStatus::Failed,
                 ExitCode::EC_SPAWN_FAILED,
                 fmt::format("Cannot spawn child process in task, code: {}",
                             static_cast<int>(err)));
@@ -2326,27 +2326,27 @@ std::future<CraneExpected<EnvMap>> TaskManager::QueryStepEnvAsync() {
   return env_future;
 }
 
-std::future<CraneErrCode> TaskManager::ChangeTaskTimeLimitAsync(
+std::future<CraneErrCode> TaskManager::ChangeStepTimeLimitAsync(
     absl::Duration time_limit) {
   std::promise<CraneErrCode> ok_promise;
   auto ok_future = ok_promise.get_future();
 
-  ChangeTaskTimeLimitQueueElem elem;
+  ChangeStepTimeLimitQueueElem elem;
   elem.time_limit = time_limit;
   elem.ok_prom = std::move(ok_promise);
 
-  m_task_time_limit_change_queue_.enqueue(std::move(elem));
-  m_change_task_time_limit_async_handle_->send();
+  m_step_time_limit_change_queue_.enqueue(std::move(elem));
+  m_change_step_time_limit_async_handle_->send();
   return ok_future;
 }
 
-void TaskManager::TerminateTaskAsync(bool mark_as_orphaned,
+void TaskManager::TerminateStepAsync(bool mark_as_orphaned,
                                      TerminatedBy terminated_by) {
-  m_task_terminate_queue_.enqueue(TaskTerminateQueueElem{
+  m_step_terminate_queue_.enqueue(StepTerminateQueueElem{
       .termination_reason = terminated_by,
       .mark_as_orphaned = mark_as_orphaned,
   });
-  m_terminate_task_async_handle_->send();
+  m_terminate_step_async_handle_->send();
 }
 
 void TaskManager::CheckStatusAsync(
@@ -2375,7 +2375,7 @@ std::future<CraneErrCode> TaskManager::MigrateSshProcToCgroupAsync(pid_t pid) {
 }
 
 void TaskManager::EvShutdownSupervisorCb_() {
-  std::tuple<crane::grpc::TaskStatus, uint32_t, std::string> final_status;
+  std::tuple<crane::grpc::JobStatus, uint32_t, std::string> final_status;
   bool got_final_status = false;
   do {
     got_final_status = m_shutdown_status_queue_.try_dequeue(final_status);
@@ -2508,28 +2508,28 @@ void TaskManager::EvCleanCriEventQueueCb_() {
   }
 }
 
-void TaskManager::EvTaskTimerCb_() {
-  CRANE_TRACE("task #{} exceeded its time limit. Terminating it...",
-              g_config.JobId);
+void TaskManager::EvStepTimerCb_() {
+  CRANE_TRACE("Step #{}.{} exceeded its time limit. Terminating it...",
+              g_config.JobId, g_config.StepId);
 
   DelTerminationTimer_();
   DelSignalTimers_();
 
   if (m_step_.IsCalloc()) {
     // Now calloc and cbatch steps only have one task with id 0.
-    TaskFinish_(0, crane::grpc::TaskStatus::ExceedTimeLimit,
+    TaskFinish_(0, crane::grpc::JobStatus::ExceedTimeLimit,
                 ExitCode::EC_EXCEED_TIME_LIMIT, std::nullopt);
   } else {
-    m_task_terminate_queue_.enqueue(TaskTerminateQueueElem{
+    m_step_terminate_queue_.enqueue(StepTerminateQueueElem{
         .termination_reason = TerminatedBy::TERMINATION_BY_TIMEOUT});
-    m_terminate_task_async_handle_->send();
+    m_terminate_step_async_handle_->send();
   }
 }
 
 void TaskManager::EvCleanTaskStopQueueCb_() {
   task_id_t task_id;
   while (m_task_stopped_queue_.try_dequeue(task_id)) {
-    CRANE_INFO("[Task #{}] Stopped and is doing TaskStatusChange...", task_id);
+    CRANE_INFO("[Task #{}] Stopped and is doing StepStatusChange...", task_id);
     auto* task = m_step_.GetTaskInstance(task_id);
     if (task->GetExecId().has_value())
       m_exec_id_task_id_map_.erase(*task->GetExecId());
@@ -2582,12 +2582,12 @@ void TaskManager::EvCleanTaskStopQueueCb_() {
 
     switch (task->err_before_exec) {
     case CraneErrCode::ERR_PROTOBUF:
-      TaskFinish_(task_id, crane::grpc::TaskStatus::Failed,
+      TaskFinish_(task_id, crane::grpc::JobStatus::Failed,
                   ExitCode::EC_SPAWN_FAILED, std::nullopt);
       return;
 
     case CraneErrCode::ERR_CGROUP:
-      TaskFinish_(task_id, crane::grpc::TaskStatus::Failed,
+      TaskFinish_(task_id, crane::grpc::JobStatus::Failed,
                   ExitCode::EC_CGROUP_ERR, std::nullopt);
       return;
 
@@ -2608,31 +2608,31 @@ void TaskManager::EvCleanTaskStopQueueCb_() {
         uint32_t exit_code = exit_info.value + ExitCode::kTerminationSignalBase;
         switch (task->terminated_by) {
         case TerminatedBy::CANCELLED_BY_USER:
-          TaskFinish_(task_id, crane::grpc::TaskStatus::Cancelled, exit_code,
+          TaskFinish_(task_id, crane::grpc::JobStatus::Cancelled, exit_code,
                       std::nullopt);
           break;
         case TerminatedBy::TERMINATION_BY_TIMEOUT:
-          TaskFinish_(task_id, crane::grpc::TaskStatus::ExceedTimeLimit,
+          TaskFinish_(task_id, crane::grpc::JobStatus::ExceedTimeLimit,
                       ExitCode::EC_EXCEED_TIME_LIMIT, std::nullopt);
           break;
         case TerminatedBy::TERMINATION_BY_OOM:
-          TaskFinish_(task_id, crane::grpc::TaskStatus::OutOfMemory, exit_code,
+          TaskFinish_(task_id, crane::grpc::JobStatus::OutOfMemory, exit_code,
                       "Detected by oom_kill counter delta");
           break;
         default:
-          TaskFinish_(task_id, crane::grpc::TaskStatus::Failed, exit_code,
+          TaskFinish_(task_id, crane::grpc::JobStatus::Failed, exit_code,
                       std::nullopt);
         }
       } else if (exit_info.value == 0) {
-        TaskFinish_(task_id, crane::grpc::TaskStatus::Completed, 0,
+        TaskFinish_(task_id, crane::grpc::JobStatus::Completed, 0,
                     std::nullopt);
       } else {
         if (task->terminated_by == TerminatedBy::TERMINATION_BY_OOM) {
-          TaskFinish_(task_id, crane::grpc::TaskStatus::OutOfMemory,
+          TaskFinish_(task_id, crane::grpc::JobStatus::OutOfMemory,
                       exit_info.value,
                       "Detected by oom_kill counter delta (no signal)");
         } else {
-          TaskFinish_(task_id, crane::grpc::TaskStatus::Failed, exit_info.value,
+          TaskFinish_(task_id, crane::grpc::JobStatus::Failed, exit_info.value,
                       std::nullopt);
         }
       }
@@ -2640,29 +2640,29 @@ void TaskManager::EvCleanTaskStopQueueCb_() {
       // For a COMPLETING Calloc task with a process running,
       // the end of this process means that this task is done.
       if (exit_info.is_terminated_by_signal)
-        TaskFinish_(task_id, crane::grpc::TaskStatus::Completed,
+        TaskFinish_(task_id, crane::grpc::JobStatus::Completed,
                     exit_info.value + ExitCode::kTerminationSignalBase,
                     std::nullopt);
       else if (exit_info.value == 0)
-        TaskFinish_(task_id, crane::grpc::TaskStatus::Completed, 0,
+        TaskFinish_(task_id, crane::grpc::JobStatus::Completed, 0,
                     std::nullopt);
       else
-        TaskFinish_(task_id, crane::grpc::TaskStatus::Failed, exit_info.value,
+        TaskFinish_(task_id, crane::grpc::JobStatus::Failed, exit_info.value,
                     std::nullopt);
     }
   }
 }
 
-void TaskManager::EvCleanTerminateTaskQueueCb_() {
-  TaskTerminateQueueElem elem;
-  std::vector<TaskTerminateQueueElem> not_ready_elems;
-  while (m_task_terminate_queue_.try_dequeue(elem)) {
-    CRANE_TRACE("Receive TerminateRunningTask Request for #{}.{}.",
+void TaskManager::EvCleanTerminateStepQueueCb_() {
+  StepTerminateQueueElem elem;
+  std::vector<StepTerminateQueueElem> not_ready_elems;
+  while (m_step_terminate_queue_.try_dequeue(elem)) {
+    CRANE_TRACE("Receive TerminateRunningStep Request for #{}.{}.",
                 g_config.JobId, g_config.StepId);
 
     if (m_step_.IsDaemon() && !m_active_shutdown_.load()) {
       CRANE_TRACE(
-          "TerminateRunningTask request ignored for daemon step unless active "
+          "TerminateRunningStep request ignored for daemon step unless active "
           "shutdown is in progress.",
           g_config.JobId, g_config.StepId);
       continue;
@@ -2671,7 +2671,7 @@ void TaskManager::EvCleanTerminateTaskQueueCb_() {
     if (elem.mark_as_orphaned) m_step_.orphaned = true;
     if (!elem.mark_as_orphaned && !m_step_.IsRunning()) {
       not_ready_elems.emplace_back(std::move(elem));
-      CRANE_DEBUG("Task is not ready to terminate, will check next time.");
+      CRANE_DEBUG("Step is not ready to terminate, will check next time.");
       continue;
     }
 
@@ -2715,7 +2715,7 @@ void TaskManager::EvCleanTerminateTaskQueueCb_() {
       } else if (m_step_.IsInteractive()) {
         // For an Interactive task with no process running, it ends
         // immediately.
-        TaskFinish_(task_id, crane::grpc::TaskStatus::Completed,
+        TaskFinish_(task_id, crane::grpc::JobStatus::Completed,
                     ExitCode::EC_TERMINATED, std::nullopt);
       } else {
         CRANE_ASSERT_MSG(false, "Terminating a batch step without any task");
@@ -2724,24 +2724,24 @@ void TaskManager::EvCleanTerminateTaskQueueCb_() {
   }
 
   for (auto& not_ready_elem : not_ready_elems) {
-    m_task_terminate_queue_.enqueue(not_ready_elem);
+    m_step_terminate_queue_.enqueue(not_ready_elem);
   }
 }
 
-void TaskManager::EvCleanChangeTaskTimeLimitQueueCb_() {
+void TaskManager::EvCleanChangeStepTimeLimitQueueCb_() {
   absl::Time now = absl::Now();
 
-  ChangeTaskTimeLimitQueueElem elem;
-  std::vector<ChangeTaskTimeLimitQueueElem> not_ready_elems;
-  while (m_task_time_limit_change_queue_.try_dequeue(elem)) {
+  ChangeStepTimeLimitQueueElem elem;
+  std::vector<ChangeStepTimeLimitQueueElem> not_ready_elems;
+  while (m_step_time_limit_change_queue_.try_dequeue(elem)) {
     if (!m_step_.IsRunning()) {
       not_ready_elems.emplace_back(std::move(elem));
       CRANE_DEBUG(
-          "Task is not ready to change time limit, will check next time.");
+          "Step is not ready to change time limit, will check next time.");
       continue;
     }
     if (m_step_.AllTaskFinished()) {
-      CRANE_DEBUG("Change timelimit for a completing task, ignored.");
+      CRANE_DEBUG("Change timelimit for a completing step, ignored.");
       continue;
     }
     // Delete the old timer.
@@ -2753,13 +2753,13 @@ void TaskManager::EvCleanChangeTaskTimeLimitQueueCb_() {
     absl::Duration const& new_time_limit = elem.time_limit;
 
     if (now - start_time >= new_time_limit) {
-      // If the task times out, terminate it.
-      TaskTerminateQueueElem ev_task_terminate{
+      // If the step times out, terminate it.
+      StepTerminateQueueElem ev_step_terminate{
           .termination_reason = TerminatedBy::TERMINATION_BY_TIMEOUT};
-      m_task_terminate_queue_.enqueue(ev_task_terminate);
-      m_terminate_task_async_handle_->send();
+      m_step_terminate_queue_.enqueue(ev_step_terminate);
+      m_terminate_step_async_handle_->send();
     } else {
-      // If the task haven't timed out, set up a new timer.
+      // If the step hasn't timed out, set up a new timer.
       int64_t new_sec =
           ToInt64Seconds(new_time_limit - (absl::Now() - start_time));
       AddTerminationTimer_(new_sec);
@@ -2784,13 +2784,13 @@ void TaskManager::EvCleanChangeTaskTimeLimitQueueCb_() {
     elem.ok_prom.set_value(CraneErrCode::SUCCESS);
   }
   for (auto& not_ready_elem : not_ready_elems) {
-    m_task_time_limit_change_queue_.enqueue(std::move(not_ready_elem));
+    m_step_time_limit_change_queue_.enqueue(std::move(not_ready_elem));
   }
 }
 
-void TaskManager::EvGrpcExecuteTaskCb_() {
-  ExecuteTaskElem elem;
-  while (m_grpc_execute_task_queue_.try_dequeue(elem)) {
+void TaskManager::EvGrpcExecuteStepCb_() {
+  ExecuteStepElem elem;
+  while (m_grpc_execute_step_queue_.try_dequeue(elem)) {
     m_step_.GotNewStatus(StepStatus::Running);
     for (auto task_id : m_step_.task_ids) {
       std::unique_ptr<ITaskInstance> instance;
@@ -2811,7 +2811,7 @@ void TaskManager::EvGrpcExecuteTaskCb_() {
     if (!m_step_.pwd.Valid()) {
       CRANE_ERROR("Failed to look up password entry for uid {}", m_step_.uid);
       for (auto task_id : m_step_.task_ids)
-        TaskFinish_(task_id, crane::grpc::TaskStatus::Failed,
+        TaskFinish_(task_id, crane::grpc::JobStatus::Failed,
                     ExitCode::EC_PERMISSION_DENIED,
                     fmt::format("Failed to look up password entry for uid {}",
                                 m_step_.uid));
@@ -2826,7 +2826,7 @@ void TaskManager::EvGrpcExecuteTaskCb_() {
                     m_step_.step_id, static_cast<int>(err));
         for (auto task_id : m_step_.task_ids) {
           g_task_mgr->TaskFinish_(
-              task_id, crane::grpc::TaskStatus::Failed,
+              task_id, crane::grpc::JobStatus::Failed,
               ExitCode::EC_FILE_NOT_FOUND,
               fmt::format("Failed to prepare step, code: {}",
                           static_cast<int>(err)));
@@ -2877,7 +2877,7 @@ void TaskManager::EvGrpcExecuteTaskCb_() {
       CRANE_ERROR("[Step #{}.{}] Failed to allocate cgroup", m_step_.job_id,
                   m_step_.step_id);
       for (auto task_id : m_step_.task_ids) {
-        g_task_mgr->TaskFinish_(task_id, crane::grpc::TaskStatus::Failed,
+        g_task_mgr->TaskFinish_(task_id, crane::grpc::JobStatus::Failed,
                                 ExitCode::EC_CGROUP_ERR,
                                 "Failed to allocate cgroup");
       }

--- a/src/Craned/Supervisor/TaskManager.h
+++ b/src/Craned/Supervisor/TaskManager.h
@@ -59,7 +59,7 @@ class StepInstance {
   std::vector<gid_t> gids;
 
   // TODO: Move these into ProcInstance
-  std::optional<crane::grpc::InteractiveTaskType> interactive_type;
+  std::optional<crane::grpc::InteractiveJobType> interactive_type;
   bool x11{};
   bool x11_fwd{};
   bool pty{};
@@ -98,7 +98,7 @@ class StepInstance {
         uid(step.uid()),
         gids(step.gid().begin(), step.gid().end()) {
     interactive_type =
-        step.type() == crane::grpc::TaskType::Interactive
+        step.type() == crane::grpc::JobType::Interactive
             ? std::optional(step.interactive_meta().interactive_type())
             : std::nullopt;
     pty = interactive_type.has_value() && step.interactive_meta().pty();
@@ -309,15 +309,15 @@ class PodInstance : public ITaskInstance {
   static CraneErrCode ResolveUserNsMapping_(
       const PasswordEntry& pwd, cri::api::LinuxSandboxSecurityContext* sec_ctx);
 
-  void SetPodLabels_(const crane::grpc::PodTaskAdditionalMeta& pod_meta,
+  void SetPodLabels_(const crane::grpc::PodJobAdditionalMeta& pod_meta,
                      uid_t uid, job_id_t job_id, const std::string& job_name);
-  void SetPodAnnotations_(const crane::grpc::PodTaskAdditionalMeta& pod_meta,
+  void SetPodAnnotations_(const crane::grpc::PodJobAdditionalMeta& pod_meta,
                           uid_t uid, job_id_t job_id,
                           const std::string& job_name,
                           const std::string& hostname);
 
   CraneErrCode SetPodSandboxConfig_(
-      const crane::grpc::PodTaskAdditionalMeta& pod_meta);
+      const crane::grpc::PodJobAdditionalMeta& pod_meta);
   CraneErrCode PersistPodSandboxInfo_();
 
   cri::api::PodSandboxConfig m_pod_config_;
@@ -380,10 +380,10 @@ class ContainerInstance : public ITaskInstance {
                            const std::string& step_name);
 
   CraneErrCode LoadPodSandboxInfo_(
-      const crane::grpc::PodTaskAdditionalMeta* pod_meta);
+      const crane::grpc::PodJobAdditionalMeta* pod_meta);
   CraneErrCode SetContainerConfig_(
-      const crane::grpc::ContainerTaskAdditionalMeta& ca_meta,
-      const crane::grpc::PodTaskAdditionalMeta* pod_meta);
+      const crane::grpc::ContainerJobAdditionalMeta& ca_meta,
+      const crane::grpc::PodJobAdditionalMeta* pod_meta);
 
   std::string m_image_id_;
   std::string m_pod_id_;
@@ -518,7 +518,7 @@ class TaskManager {
   // Shutdown supervisor asynchronously with given status, exit code and reason.
   // Status change will be sent only if daemon step.
   void ShutdownSupervisorAsync(
-      crane::grpc::TaskStatus new_status = StepStatus::Completed,
+      crane::grpc::JobStatus new_status = StepStatus::Completed,
       uint32_t exit_code = 0, std::string reason = "");
 
   // NOLINTBEGIN(readability-identifier-naming)
@@ -527,7 +527,7 @@ class TaskManager {
     auto termination_handle = m_uvw_loop_->resource<uvw::timer_handle>();
     termination_handle->on<uvw::timer_event>(
         [this](const uvw::timer_event&, uvw::timer_handle& /* h */) {
-          EvTaskTimerCb_();
+          EvStepTimerCb_();
         });
     termination_handle->start(
         std::chrono::duration_cast<std::chrono::milliseconds>(duration),
@@ -539,7 +539,7 @@ class TaskManager {
     auto termination_handle = m_uvw_loop_->resource<uvw::timer_handle>();
     termination_handle->on<uvw::timer_event>(
         [this](const uvw::timer_event&, uvw::timer_handle& /* h */) {
-          EvTaskTimerCb_();
+          EvStepTimerCb_();
         });
     termination_handle->start(std::chrono::seconds(secs),
                               std::chrono::seconds(0));
@@ -578,7 +578,7 @@ class TaskManager {
   }
 
   // Should called in uvw thread, otherwise data race may happen.
-  void TaskFinish_(task_id_t task_id, crane::grpc::TaskStatus new_status,
+  void TaskFinish_(task_id_t task_id, crane::grpc::JobStatus new_status,
                    uint32_t exit_code, std::optional<std::string> reason);
   CraneErrCode LaunchExecution_(ITaskInstance* task);
   // NOLINTEND(readability-identifier-naming)
@@ -595,13 +595,13 @@ class TaskManager {
 
   void TaskStopAndDoStatusChange(task_id_t task_id);
 
-  std::future<CraneErrCode> ExecuteTaskAsync();
+  std::future<CraneErrCode> ExecuteStepAsync();
 
   std::future<CraneExpected<EnvMap>> QueryStepEnvAsync();
 
-  std::future<CraneErrCode> ChangeTaskTimeLimitAsync(absl::Duration time_limit);
+  std::future<CraneErrCode> ChangeStepTimeLimitAsync(absl::Duration time_limit);
 
-  void TerminateTaskAsync(bool mark_as_orphaned, TerminatedBy terminated_by);
+  void TerminateStepAsync(bool mark_as_orphaned, TerminatedBy terminated_by);
 
   void CheckStatusAsync(crane::grpc::supervisor::CheckStatusReply* response);
 
@@ -615,16 +615,16 @@ class TaskManager {
   template <class T>
   using ConcurrentQueue = moodycamel::ConcurrentQueue<T>;
 
-  struct ExecuteTaskElem {
+  struct ExecuteStepElem {
     std::promise<CraneErrCode> ok_prom;
   };
 
-  struct TaskTerminateQueueElem {
+  struct StepTerminateQueueElem {
     TerminatedBy termination_reason{TerminatedBy::NONE};
     bool mark_as_orphaned{false};
   };
 
-  struct ChangeTaskTimeLimitQueueElem {
+  struct ChangeStepTimeLimitQueueElem {
     absl::Duration time_limit;
     std::promise<CraneErrCode> ok_prom;
   };
@@ -642,19 +642,19 @@ class TaskManager {
   // Handle stopped tasks
   void EvCleanTaskStopQueueCb_();
 
-  // Handle task termination requests
-  void EvTaskTimerCb_();
-  void EvCleanTerminateTaskQueueCb_();
-  void EvCleanChangeTaskTimeLimitQueueCb_();
+  // Handle step termination requests
+  void EvStepTimerCb_();
+  void EvCleanTerminateStepQueueCb_();
+  void EvCleanChangeStepTimeLimitQueueCb_();
 
-  void EvGrpcExecuteTaskCb_();
+  void EvGrpcExecuteStepCb_();
   void EvGrpcQueryStepEnvCb_();
   void EvGrpcCheckStatusCb_();
   void EvGrpcMigrateSshProcToCgroupCb_();
 
   std::shared_ptr<uvw::loop> m_uvw_loop_;
 
-  ConcurrentQueue<std::tuple<crane::grpc::TaskStatus, uint32_t, std::string>>
+  ConcurrentQueue<std::tuple<crane::grpc::JobStatus, uint32_t, std::string>>
       m_shutdown_status_queue_;
   std::shared_ptr<uvw::async_handle> m_shutdown_supervisor_handle_;
 
@@ -672,17 +672,17 @@ class TaskManager {
   std::shared_ptr<uvw::async_handle> m_task_stopped_async_handle_;
   ConcurrentQueue<task_id_t> m_task_stopped_queue_;
 
-  // Task is requested to be terminated
-  std::shared_ptr<uvw::async_handle> m_terminate_task_async_handle_;
-  std::shared_ptr<uvw::timer_handle> m_terminate_task_timer_handle_;
-  ConcurrentQueue<TaskTerminateQueueElem> m_task_terminate_queue_;
+  // Step is requested to be terminated
+  std::shared_ptr<uvw::async_handle> m_terminate_step_async_handle_;
+  std::shared_ptr<uvw::timer_handle> m_terminate_step_timer_handle_;
+  ConcurrentQueue<StepTerminateQueueElem> m_step_terminate_queue_;
 
-  std::shared_ptr<uvw::async_handle> m_change_task_time_limit_async_handle_;
-  std::shared_ptr<uvw::timer_handle> m_change_task_time_limit_timer_handle_;
-  ConcurrentQueue<ChangeTaskTimeLimitQueueElem> m_task_time_limit_change_queue_;
+  std::shared_ptr<uvw::async_handle> m_change_step_time_limit_async_handle_;
+  std::shared_ptr<uvw::timer_handle> m_change_step_time_limit_timer_handle_;
+  ConcurrentQueue<ChangeStepTimeLimitQueueElem> m_step_time_limit_change_queue_;
 
-  std::shared_ptr<uvw::async_handle> m_grpc_execute_task_async_handle_;
-  ConcurrentQueue<ExecuteTaskElem> m_grpc_execute_task_queue_;
+  std::shared_ptr<uvw::async_handle> m_grpc_execute_step_async_handle_;
+  ConcurrentQueue<ExecuteStepElem> m_grpc_execute_step_queue_;
 
   std::shared_ptr<uvw::async_handle> m_grpc_query_step_env_async_handle_;
   ConcurrentQueue<std::promise<CraneExpected<EnvMap>>>

--- a/src/Misc/Pam/Pam.cpp
+++ b/src/Misc/Pam/Pam.cpp
@@ -23,7 +23,7 @@
 #define PAM_STR_TRUE ("T")
 #define PAM_STR_FALSE ("F")
 #define PAM_ITEM_AUTH_RESULT ("AUTH_RES")
-#define PAM_ITEM_TASK_ID ("TASK_ID")
+#define PAM_ITEM_JOB_ID ("JOB_ID")
 
 static std::once_flag g_init_flag;
 static bool g_module_initialized{false};
@@ -78,22 +78,22 @@ extern "C" {
     return PAM_AUTH_ERR;
   }
 
-  uint32_t task_id;
+  uint32_t job_id;
 
   pam_syslog(pamh, LOG_ERR, "[Crane] Try to query %s for remote port %hu",
              remote_address.c_str(), port);
 
-  ok = GrpcQueryPortFromCraned(pamh, uid, remote_address, port, &task_id);
+  ok = GrpcQueryPortFromCraned(pamh, uid, remote_address, port, &job_id);
 
   if (ok) {
     pam_syslog(pamh, LOG_ERR,
                "[Crane] Accepted ssh connection with remote port %hu ", port);
 
     char *auth_result = strdup(PAM_STR_TRUE);
-    char *task_id_str = strdup(std::to_string(task_id).c_str());
+    char *job_id_str = strdup(std::to_string(job_id).c_str());
 
     pam_set_data(pamh, PAM_ITEM_AUTH_RESULT, auth_result, clean_up_cb);
-    pam_set_data(pamh, PAM_ITEM_TASK_ID, task_id_str, clean_up_cb);
+    pam_set_data(pamh, PAM_ITEM_JOB_ID, job_id_str, clean_up_cb);
 
     return PAM_SUCCESS;
   } else {
@@ -111,9 +111,9 @@ extern "C" {
 
 [[maybe_unused]] int pam_sm_open_session(pam_handle_t *pamh, int flags,
                                          int argc, const char **argv) {
-  int task_id;
+  int job_id;
   char *auth_result;
-  char *task_id_str;
+  char *job_id_str;
 
   bool ok;
   std::string username;
@@ -141,16 +141,16 @@ extern "C" {
 
   pam_get_data(pamh, PAM_ITEM_AUTH_RESULT, (const void **)&auth_result);
   if (strcmp(auth_result, PAM_STR_TRUE) == 0) {
-    pam_get_data(pamh, PAM_ITEM_TASK_ID, (const void **)&task_id_str);
+    pam_get_data(pamh, PAM_ITEM_JOB_ID, (const void **)&job_id_str);
 
     pam_syslog(
         pamh, LOG_ERR,
-        "[Crane] open_session retrieved task_id: %s. Moving it to cgroups",
-        task_id_str);
+        "[Crane] open_session retrieved job_id: %s. Moving it to cgroups",
+        job_id_str);
 
-    task_id = std::atoi(task_id_str);
+    job_id = std::atoi(job_id_str);
 
-    ok = GrpcMigrateSshProcToCgroupAndSetEnv(pamh, getpid(), task_id);
+    ok = GrpcMigrateSshProcToCgroupAndSetEnv(pamh, getpid(), job_id);
     if (ok) {
       return PAM_SUCCESS;
     } else {
@@ -161,7 +161,7 @@ extern "C" {
     }
   } else {
     // If auth result is false, it indicates that system administrator allow a
-    // user with no task running to log in, and then we just let it pass.
+    // user with no job running to log in, and then we just let it pass.
     return PAM_SUCCESS;
   }
 }

--- a/src/Misc/Pam/PamUtil.cpp
+++ b/src/Misc/Pam/PamUtil.cpp
@@ -440,8 +440,7 @@ bool GrpcMigrateSshProcToCgroupAndSetEnv(pam_handle_t *pamh, pid_t pid,
       return false;
     }
 
-    pam_syslog(pamh, LOG_ERR,
-               "[Crane] QueryJobEnvVariablesForward succeeded.");
+    pam_syslog(pamh, LOG_ERR, "[Crane] QueryJobEnvVariablesForward succeeded.");
     for (const auto &[name, value] : reply.env_map()) {
       int ret = pam_putenv(pamh, fmt::format("{}={}", name, value).c_str());
       if (ret != PAM_SUCCESS) {

--- a/src/Misc/Pam/PamUtil.cpp
+++ b/src/Misc/Pam/PamUtil.cpp
@@ -304,7 +304,7 @@ bool PamGetRemoteAddressPort(pam_handle_t *pamh, std::string *address,
 
 bool GrpcQueryPortFromCraned(pam_handle_t *pamh, uid_t uid,
                              const std::string &remote_address,
-                             uint16_t port_to_query, uint32_t *task_id) {
+                             uint16_t port_to_query, uint32_t *job_id) {
   using grpc::Channel;
   using grpc::ClientContext;
   using grpc::Status;
@@ -347,27 +347,27 @@ bool GrpcQueryPortFromCraned(pam_handle_t *pamh, uid_t uid,
 
   status = stub->QueryStepFromPortForward(&context, request, &reply);
   if (!status.ok()) {
-    pam_syslog(pamh, LOG_ERR, "QueryTaskIdFromPort gRPC call failed: %s | %s",
+    pam_syslog(pamh, LOG_ERR, "QueryJobIdFromPort gRPC call failed: %s | %s",
                status.error_message().c_str(), status.error_details().c_str());
     return false;
   }
 
   if (reply.ok()) {
     pam_syslog(pamh, LOG_ERR,
-               "ssh client with remote port %u belongs to task #%u",
+               "ssh client with remote port %u belongs to job #%u",
                port_to_query, reply.job_id());
-    *task_id = reply.job_id();
+    *job_id = reply.job_id();
     return true;
   } else {
     pam_syslog(pamh, LOG_ERR,
-               "ssh client with remote port %u doesn't belong to any task",
+               "ssh client with remote port %u doesn't belong to any job",
                port_to_query);
     return false;
   }
 }
 
 bool GrpcMigrateSshProcToCgroupAndSetEnv(pam_handle_t *pamh, pid_t pid,
-                                         task_id_t task_id) {
+                                         job_id_t job_id) {
   using grpc::Channel;
   using grpc::ClientContext;
   using grpc::Status;
@@ -398,7 +398,7 @@ bool GrpcMigrateSshProcToCgroupAndSetEnv(pam_handle_t *pamh, pid_t pid,
     ClientContext context;
 
     request.set_pid(pid);
-    request.set_task_id(task_id);
+    request.set_job_id(job_id);
 
     status = stub->MigrateSshProcToCgroup(&context, request, &reply);
     if (!status.ok()) {
@@ -424,24 +424,24 @@ bool GrpcMigrateSshProcToCgroupAndSetEnv(pam_handle_t *pamh, pid_t pid,
     crane::grpc::QuerySshStepEnvVariablesForwardReply reply;
     ClientContext context;
 
-    request.set_task_id(task_id);
+    request.set_job_id(job_id);
 
     status = stub->QuerySshStepEnvVariablesForward(&context, request, &reply);
     if (!status.ok()) {
       pam_syslog(
           pamh, LOG_ERR,
-          "[Crane] QueryTaskEnvVariablesForward gRPC call failed: %s | %s",
+          "[Crane] QueryJobEnvVariablesForward gRPC call failed: %s | %s",
           status.error_message().c_str(), status.error_details().c_str());
       return false;
     }
 
     if (!reply.ok()) {
-      pam_syslog(pamh, LOG_ERR, "[Crane] QueryTaskEnvVariablesForward failed.");
+      pam_syslog(pamh, LOG_ERR, "[Crane] QueryJobEnvVariablesForward failed.");
       return false;
     }
 
     pam_syslog(pamh, LOG_ERR,
-               "[Crane] QueryTaskEnvVariablesForward succeeded.");
+               "[Crane] QueryJobEnvVariablesForward succeeded.");
     for (const auto &[name, value] : reply.env_map()) {
       int ret = pam_putenv(pamh, fmt::format("{}={}", name, value).c_str());
       if (ret != PAM_SUCCESS) {

--- a/src/Misc/Pam/PamUtil.h
+++ b/src/Misc/Pam/PamUtil.h
@@ -41,10 +41,10 @@ bool PamGetRemoteAddressPort(pam_handle_t *pamh, std::string *address,
 
 bool GrpcQueryPortFromCraned(pam_handle_t *pamh, uid_t uid,
                              const std::string &remote_address,
-                             uint16_t port_to_query, uint32_t *task_id);
+                             uint16_t port_to_query, uint32_t *job_id);
 
 bool GrpcMigrateSshProcToCgroupAndSetEnv(pam_handle_t *pamh, pid_t pid,
-                                         task_id_t task_id);
+                                         job_id_t job_id);
 
 struct PamConfig {
   std::string CraneConfigFilePath;

--- a/src/Utilities/Lua/Lua.cpp
+++ b/src/Utilities/Lua/Lua.cpp
@@ -161,10 +161,8 @@ void LuaEnvironment::RegisterFunctions_() {
   m_crane_table_["ERROR"] = static_cast<int>(CraneErrCode::ERR_LUA_FAILED);
   m_crane_table_["SUCCESS"] = static_cast<int>(CraneErrCode::SUCCESS);
 
-  m_crane_table_["Pending"] =
-      static_cast<int>(crane::grpc::JobStatus::Pending);
-  m_crane_table_["Running"] =
-      static_cast<int>(crane::grpc::JobStatus::Running);
+  m_crane_table_["Pending"] = static_cast<int>(crane::grpc::JobStatus::Pending);
+  m_crane_table_["Running"] = static_cast<int>(crane::grpc::JobStatus::Running);
   m_crane_table_["Completed"] =
       static_cast<int>(crane::grpc::JobStatus::Completed);
   m_crane_table_["Failed"] = static_cast<int>(crane::grpc::JobStatus::Failed);

--- a/src/Utilities/Lua/Lua.cpp
+++ b/src/Utilities/Lua/Lua.cpp
@@ -162,20 +162,20 @@ void LuaEnvironment::RegisterFunctions_() {
   m_crane_table_["SUCCESS"] = static_cast<int>(CraneErrCode::SUCCESS);
 
   m_crane_table_["Pending"] =
-      static_cast<int>(crane::grpc::TaskStatus::Pending);
+      static_cast<int>(crane::grpc::JobStatus::Pending);
   m_crane_table_["Running"] =
-      static_cast<int>(crane::grpc::TaskStatus::Running);
+      static_cast<int>(crane::grpc::JobStatus::Running);
   m_crane_table_["Completed"] =
-      static_cast<int>(crane::grpc::TaskStatus::Completed);
-  m_crane_table_["Failed"] = static_cast<int>(crane::grpc::TaskStatus::Failed);
+      static_cast<int>(crane::grpc::JobStatus::Completed);
+  m_crane_table_["Failed"] = static_cast<int>(crane::grpc::JobStatus::Failed);
   m_crane_table_["Cancelled"] =
-      static_cast<int>(crane::grpc::TaskStatus::Cancelled);
+      static_cast<int>(crane::grpc::JobStatus::Cancelled);
   m_crane_table_["OutOfMemory"] =
-      static_cast<int>(crane::grpc::TaskStatus::OutOfMemory);
+      static_cast<int>(crane::grpc::JobStatus::OutOfMemory);
 
-  m_crane_table_["Batch"] = static_cast<int>(crane::grpc::TaskType::Batch);
+  m_crane_table_["Batch"] = static_cast<int>(crane::grpc::JobType::Batch);
   m_crane_table_["Interactive"] =
-      static_cast<int>(crane::grpc::TaskType::Interactive);
+      static_cast<int>(crane::grpc::JobType::Interactive);
 
   // other used flags
 }

--- a/src/Utilities/PluginClient/PluginClient.cpp
+++ b/src/Utilities/PluginClient/PluginClient.cpp
@@ -240,12 +240,12 @@ grpc::Status PluginClient::SendUpdateLicensesHook_(
   return m_stub_->UpdateLicensesHook(context, *request, &reply);
 }
 
-void PluginClient::StartHookAsync(std::vector<crane::grpc::TaskInfo> tasks) {
+void PluginClient::StartHookAsync(std::vector<crane::grpc::JobInfo> jobs) {
   auto request = std::make_unique<crane::grpc::plugin::StartHookRequest>();
-  auto* task_list = request->mutable_task_info_list();
-  for (auto& task : tasks) {
-    auto* task_it = task_list->Add();
-    task_it->CopyFrom(task);
+  auto* job_list = request->mutable_job_info_list();
+  for (auto& job : jobs) {
+    auto* job_it = job_list->Add();
+    job_it->CopyFrom(job);
   }
 
   HookEvent e{HookType::START,
@@ -253,16 +253,16 @@ void PluginClient::StartHookAsync(std::vector<crane::grpc::TaskInfo> tasks) {
   m_event_queue_.enqueue(std::move(e));
 }
 
-void PluginClient::EndHookAsync(std::vector<crane::grpc::TaskInfo> tasks) {
+void PluginClient::EndHookAsync(std::vector<crane::grpc::JobInfo> jobs) {
   auto request = std::make_unique<crane::grpc::plugin::EndHookRequest>();
-  auto* task_list = request->mutable_task_info_list();
+  auto* job_list = request->mutable_job_info_list();
 
   auto now = absl::ToUnixSeconds(absl::Now());
-  for (auto& task : tasks) {
-    auto* task_it = task_list->Add();
-    task_it->CopyFrom(task);
-    task_it->mutable_elapsed_time()->set_seconds(now -
-                                                 task.start_time().seconds());
+  for (auto& job : jobs) {
+    auto* job_it = job_list->Add();
+    job_it->CopyFrom(job);
+    job_it->mutable_elapsed_time()->set_seconds(now -
+                                                 job.start_time().seconds());
   }
 
   HookEvent e{HookType::END,
@@ -271,11 +271,11 @@ void PluginClient::EndHookAsync(std::vector<crane::grpc::TaskInfo> tasks) {
 }
 
 void PluginClient::CreateCgroupHookAsync(
-    task_id_t task_id, const std::string& cgroup,
+    job_id_t job_id, const std::string& cgroup,
     const crane::grpc::ResourceInNode& resource) {
   auto request =
       std::make_unique<crane::grpc::plugin::CreateCgroupHookRequest>();
-  request->set_task_id(task_id);
+  request->set_job_id(job_id);
   request->set_cgroup(cgroup);
   request->mutable_resource()->CopyFrom(resource);
 
@@ -284,11 +284,11 @@ void PluginClient::CreateCgroupHookAsync(
   m_event_queue_.enqueue(std::move(e));
 }
 
-void PluginClient::DestroyCgroupHookAsync(task_id_t task_id,
+void PluginClient::DestroyCgroupHookAsync(job_id_t job_id,
                                           const std::string& cgroup) {
   auto request =
       std::make_unique<crane::grpc::plugin::DestroyCgroupHookRequest>();
-  request->set_task_id(task_id);
+  request->set_job_id(job_id);
   request->set_cgroup(cgroup);
 
   HookEvent e{HookType::DESTROY_CGROUP,

--- a/src/Utilities/PluginClient/PluginClient.cpp
+++ b/src/Utilities/PluginClient/PluginClient.cpp
@@ -262,7 +262,7 @@ void PluginClient::EndHookAsync(std::vector<crane::grpc::JobInfo> jobs) {
     auto* job_it = job_list->Add();
     job_it->CopyFrom(job);
     job_it->mutable_elapsed_time()->set_seconds(now -
-                                                 job.start_time().seconds());
+                                                job.start_time().seconds());
   }
 
   HookEvent e{HookType::END,

--- a/src/Utilities/PluginClient/include/crane/PluginClient.h
+++ b/src/Utilities/PluginClient/include/crane/PluginClient.h
@@ -69,15 +69,15 @@ class PluginClient {
 
   // These functions are used to add HookEvent into the event queue.
   // Launched by Ctld
-  void StartHookAsync(std::vector<crane::grpc::TaskInfo> tasks);
-  void EndHookAsync(std::vector<crane::grpc::TaskInfo> tasks);
+  void StartHookAsync(std::vector<crane::grpc::JobInfo> jobs);
+  void EndHookAsync(std::vector<crane::grpc::JobInfo> jobs);
   void NodeEventHookAsync(
       std::vector<crane::grpc::plugin::CranedEventInfo> events);
 
   // Launched by Craned
-  void CreateCgroupHookAsync(task_id_t task_id, const std::string& cgroup,
+  void CreateCgroupHookAsync(job_id_t job_id, const std::string& cgroup,
                              const crane::grpc::ResourceInNode& resource);
-  void DestroyCgroupHookAsync(task_id_t task_id, const std::string& cgroup);
+  void DestroyCgroupHookAsync(job_id_t job_id, const std::string& cgroup);
 
   void UpdatePowerStateHookAsync(const std::string& craned_id,
                                  crane::grpc::CranedControlState state,

--- a/src/Utilities/PublicHeader/OS.cpp
+++ b/src/Utilities/PublicHeader/OS.cpp
@@ -662,7 +662,7 @@ std::expected<std::string, RunPrologEpilogStatus> RunPrologOrEpiLog(
 
 void ApplyPrologOutputToEnvAndStdout(
     const std::string& output,
-    std::unordered_map<std::string, std::string>* env_map, int task_stdout_fd) {
+    std::unordered_map<std::string, std::string>* env_map, int job_stdout_fd) {
   static const LazyRE2 export_re = {
       R"(^export\s+([A-Za-z_][A-Za-z0-9_]*)\s*=\s*(.*)$)"};
   static const LazyRE2 unset_re = {R"(^unset\s+([A-Za-z_][A-Za-z0-9_]*)\s*$)"};
@@ -675,8 +675,8 @@ void ApplyPrologOutputToEnvAndStdout(
     } else if (RE2::FullMatch(line, *unset_re, &name)) {
       env_map->erase(name);
     } else if (RE2::FullMatch(line, *print_re, &to_print)) {
-      write(task_stdout_fd, to_print.data(), to_print.size());
-      write(task_stdout_fd, "\n", 1);
+      write(job_stdout_fd, to_print.data(), to_print.size());
+      write(job_stdout_fd, "\n", 1);
     }
   }
 }

--- a/src/Utilities/PublicHeader/String.cpp
+++ b/src/Utilities/PublicHeader/String.cpp
@@ -600,7 +600,7 @@ std::string StepToDIdString(const crane::grpc::StepToD &step_to_d) {
   return StepIdsToString(step_to_d.job_id(), step_to_d.step_id());
 }
 
-std::string StepStatusToString(const crane::grpc::TaskStatus &status) {
+std::string StepStatusToString(const crane::grpc::JobStatus &status) {
   return std::string(Internal::CraneStepStatusStrArr[static_cast<int>(status)]);
 }
 

--- a/src/Utilities/PublicHeader/include/crane/Logger.h
+++ b/src/Utilities/PublicHeader/include/crane/Logger.h
@@ -199,14 +199,14 @@ struct formatter<std::filesystem::path> {
 };
 
 template <>
-struct formatter<crane::grpc::TaskStatus> {
+struct formatter<crane::grpc::JobStatus> {
   template <typename ParseContext>
   constexpr auto parse(ParseContext& ctx) {
     return ctx.begin();
   };
 
   template <typename FormatContext>
-  auto format(const crane::grpc::TaskStatus& v, FormatContext& ctx) const {
+  auto format(const crane::grpc::JobStatus& v, FormatContext& ctx) const {
     return fmt::format_to(
         ctx.out(), "{}",
         util::Internal::CraneStepStatusStrArr[static_cast<int>(v)]);

--- a/src/Utilities/PublicHeader/include/crane/OS.h
+++ b/src/Utilities/PublicHeader/include/crane/OS.h
@@ -115,6 +115,6 @@ std::expected<std::string, RunPrologEpilogStatus> RunPrologOrEpiLog(
 
 void ApplyPrologOutputToEnvAndStdout(
     const std::string& output,
-    std::unordered_map<std::string, std::string>* env_map, int task_stdout_fd);
+    std::unordered_map<std::string, std::string>* env_map, int job_stdout_fd);
 
 }  // namespace util::os

--- a/src/Utilities/PublicHeader/include/crane/PublicHeader.h
+++ b/src/Utilities/PublicHeader/include/crane/PublicHeader.h
@@ -307,7 +307,7 @@ constexpr std::array<std::string_view, crane::grpc::ErrCode_ARRAYSIZE>
 
         "Not a valide resource string",
         "The current submitted job exceeds the QoS limit (MAX_TRES_PER_USER_BEYOND)",
-        "The current submitted job exceeds the QoS limit (MAX_TRES_PER_ACCOUNT_BEYOND)"
+        "The current submitted job exceeds the QoS limit (MAX_TRES_PER_ACCOUNT_BEYOND)",
         "The current submitted job exceeds the QoS limit (ERR_TRES_PER_JOB_BEYOND)"
     };
 // clang-format on

--- a/src/Utilities/PublicHeader/include/crane/PublicHeader.h
+++ b/src/Utilities/PublicHeader/include/crane/PublicHeader.h
@@ -33,7 +33,7 @@
 #endif
 
 using job_id_t = uint32_t;
-using task_id_t = uint32_t;
+using task_id_t = uint32_t;  // Task ID within a step (Supervisor layer)
 using step_id_t = uint32_t;
 
 using CraneErrCode = crane::grpc::ErrCode;
@@ -68,7 +68,7 @@ inline const char* const kDefaultPluginConfigPath = "/etc/crane/plugin.yaml";
 inline const char* const kUnlimitedQosName = "UNLIMITED";
 inline const char* const kHostFilePath = "/etc/hosts";
 
-inline constexpr size_t kDefaultQueryTaskNumLimit = 1000;
+inline constexpr size_t kDefaultQueryJobNumLimit = 1000;
 inline constexpr uint32_t kDefaultQosPriority = 1000;
 inline constexpr uint64_t kPriorityDefaultMaxAge = 7UL * 24 * 3600;  // 7 days
 inline constexpr double kMemoryToleranceGB = 0.01;
@@ -111,10 +111,10 @@ inline const char* const kDefaultPlugindUnixSockPath = "cplugind/cplugind.sock";
 
 inline const char* const kResourceTypeGpu = "gpu";
 
-constexpr uint64_t kTaskMinTimeLimitSec = 11;
-constexpr int64_t kTaskMaxTimeLimitSec =
+constexpr uint64_t kJobMinTimeLimitSec = 11;
+constexpr int64_t kJobMaxTimeLimitSec =
     google::protobuf::util::TimeUtil::kDurationMaxSeconds;
-constexpr int64_t kTaskMaxTimeStampSec =
+constexpr int64_t kJobMaxTimeStampSec =
     google::protobuf::util::TimeUtil::kTimestampMaxSeconds;
 
 constexpr uint64_t kCranedPingIntervalSec = 10;
@@ -223,21 +223,21 @@ constexpr std::array<std::string_view, crane::grpc::ErrCode_ARRAYSIZE>
 
         // 40 - 44
         "Generic failure",
-        "Not enough resources for the task",
+        "Not enough resources for the job",
         "Non-existent error",
-        "Not enough nodes in the partition for the task",
+        "Not enough nodes in the partition for the job",
         "Invalid node list",
 
         // 45 - 49
         "Invalid exclude node list",
         "Time limit reached the user's limit",
         "CPUs per task reached the user's limit",
-        "Not enough nodes for the task",
+        "Not enough nodes for the job",
         "System error",
 
         // 50 - 54
-        "Existing task",
-        "The number of pending tasks exceeded the maximum value",
+        "Existing job",
+        "The number of pending jobs exceeded the maximum value",
         "Invalid parameter",
         "Stop error",
         "Permission denied",
@@ -271,7 +271,7 @@ constexpr std::array<std::string_view, crane::grpc::ErrCode_ARRAYSIZE>
         "Revocation of the certificate failed, Please check the logs",
 
         // 75 - 79
-        "User information does not match, unable to submit the task.",
+        "User information does not match, unable to submit the job.",
         "You need to set --force for this operation.",
         "Invalid username",
         "Legal licenses",
@@ -280,7 +280,7 @@ constexpr std::array<std::string_view, crane::grpc::ErrCode_ARRAYSIZE>
         // 80 - 84
         "CRI runtime returns error. For other errors in Crane, use ERR_GENERIC_FAILURE.",
         "CRI support is disabled in the cluster.",
-        "Task is pending or container is not ready.",
+        "Job is pending or container is not ready.",
         "Requested CRI operation is not supported in multi-node steps.",
         "Invalid memory format",
 
@@ -302,13 +302,13 @@ constexpr std::array<std::string_view, crane::grpc::ErrCode_ARRAYSIZE>
         "ERR_INVALID_ARGUMENT",
         "ERR_RESOURCE_ALREADY_EXIST",
         "The current submitted job exceeds the QoS limit (MaxSubmitJobsPerAccount)",
-        "Cannot delete user with active tasks.",
+        "Cannot delete user with active jobs.",
         "The current submitted job exceeds the QoS limit (MaxJobsPerQos)",
 
         "Not a valide resource string",
         "The current submitted job exceeds the QoS limit (MAX_TRES_PER_USER_BEYOND)",
         "The current submitted job exceeds the QoS limit (MAX_TRES_PER_ACCOUNT_BEYOND)"
-        "The current submitted job exceeds the QoS limit (ERR_TRES_PER_TASK_BEYOND)"
+        "The current submitted job exceeds the QoS limit (ERR_TRES_PER_JOB_BEYOND)"
     };
 // clang-format on
 }  // namespace Internal

--- a/src/Utilities/PublicHeader/include/crane/String.h
+++ b/src/Utilities/PublicHeader/include/crane/String.h
@@ -219,7 +219,7 @@ std::string JobStepsWithStatusToString(const Map& m) {
 
 namespace Internal {
 // clang-format off
-constexpr std::array<std::string_view, crane::grpc::TaskStatus_ARRAYSIZE>
+constexpr std::array<std::string_view, crane::grpc::JobStatus_ARRAYSIZE>
     CraneStepStatusStrArr = {
         // 0 - 4
         "Pending",
@@ -245,7 +245,7 @@ constexpr std::array<std::string_view, crane::grpc::TaskStatus_ARRAYSIZE>
 // clang-format on
 };  // namespace Internal
 
-std::string StepStatusToString(const crane::grpc::TaskStatus& status);
+std::string StepStatusToString(const crane::grpc::JobStatus& status);
 
 int TimeStr2Mins(std::string_view input);
 void ParsePrologEpilogHookPaths(const std::string& log_hook_config,

--- a/test/CraneCtld/EmbeddedDbClientTest.cpp
+++ b/test/CraneCtld/EmbeddedDbClientTest.cpp
@@ -51,67 +51,57 @@ class EmbeddedDbClientTest : public ::testing::Test {
 TEST_F(EmbeddedDbClientTest, Simple) {
   int rc;
 
-  uint32_t next_task_id;
+  uint32_t next_job_id;
   rc = g_embedded_db_client->FetchTypeFromDb_(
-      EmbeddedDbClient::s_next_task_id_str_, &next_task_id);
+      EmbeddedDbClient::s_next_job_id_str_, &next_job_id);
   EXPECT_EQ(rc, UNQLITE_OK);
-  EXPECT_EQ(next_task_id, 0);
+  EXPECT_EQ(next_job_id, 0);
 
-  EmbeddedDbClient::db_id_t next_task_db_id;
+  EmbeddedDbClient::db_id_t next_job_db_id;
   rc = g_embedded_db_client->FetchTypeFromDb_(
-      EmbeddedDbClient::s_next_task_db_id_str_, &next_task_db_id);
+      EmbeddedDbClient::s_next_job_db_id_str_, &next_job_db_id);
   EXPECT_EQ(rc, UNQLITE_OK);
-  EXPECT_EQ(next_task_db_id, 0);
+  EXPECT_EQ(next_job_db_id, 0);
 }
 
 TEST_F(EmbeddedDbClientTest, LinkList) {
-  using crane::grpc::PersistedPartOfTaskInCtld;
-  using crane::grpc::TaskInEmbeddedDb;
-  using crane::grpc::TaskToCtld;
+  using crane::grpc::JobInEmbeddedDb;
+  using crane::grpc::JobToCtld;
 
   int rc;
   bool ok;
-  TaskToCtld task_to_ctld;
-  PersistedPartOfTaskInCtld persisted_part;
+  JobToCtld job_to_ctld;
 
-  task_to_ctld.set_name("Task0");
-  ok = g_embedded_db_client->AppendTaskToPendingAndAdvanceTaskIds(
-      task_to_ctld, &persisted_part);
-  ASSERT_TRUE(ok);
-  EXPECT_EQ(persisted_part.task_id(), 0);
-  EXPECT_EQ(persisted_part.task_db_id(), 0);
-
-  task_to_ctld.set_name("Task1");
-  ok = g_embedded_db_client->AppendTaskToPendingAndAdvanceTaskIds(
-      task_to_ctld, &persisted_part);
-  ASSERT_TRUE(ok);
-  EXPECT_EQ(persisted_part.task_id(), 1);
-  EXPECT_EQ(persisted_part.task_db_id(), 1);
-
-  task_to_ctld.set_name("Task2");
-  ok = g_embedded_db_client->AppendTaskToPendingAndAdvanceTaskIds(
-      task_to_ctld, &persisted_part);
-  ASSERT_TRUE(ok);
-  EXPECT_EQ(persisted_part.task_id(), 2);
-  EXPECT_EQ(persisted_part.task_db_id(), 2);
-
-  task_to_ctld.set_name("Task3");
-  ok = g_embedded_db_client->AppendTaskToPendingAndAdvanceTaskIds(
-      task_to_ctld, &persisted_part);
-  ASSERT_TRUE(ok);
-  EXPECT_EQ(persisted_part.task_id(), 3);
-  EXPECT_EQ(persisted_part.task_db_id(), 3);
-
-  ok = g_embedded_db_client->MoveTaskFromPendingToRunning(1);
+  job_to_ctld.set_name("Job0");
+  ok = g_embedded_db_client->AppendJobToPendingAndAdvanceJobIds(
+      job_to_ctld);
   ASSERT_TRUE(ok);
 
-  ok = g_embedded_db_client->MoveTaskFromPendingToRunning(3);
+  job_to_ctld.set_name("Job1");
+  ok = g_embedded_db_client->AppendJobToPendingAndAdvanceJobIds(
+      job_to_ctld);
+  ASSERT_TRUE(ok);
+
+  job_to_ctld.set_name("Job2");
+  ok = g_embedded_db_client->AppendJobToPendingAndAdvanceJobIds(
+      job_to_ctld);
+  ASSERT_TRUE(ok);
+
+  job_to_ctld.set_name("Job3");
+  ok = g_embedded_db_client->AppendJobToPendingAndAdvanceJobIds(
+      job_to_ctld);
+  ASSERT_TRUE(ok);
+
+  ok = g_embedded_db_client->MoveJobFromPendingToRunning(1);
+  ASSERT_TRUE(ok);
+
+  ok = g_embedded_db_client->MoveJobFromPendingToRunning(3);
   ASSERT_TRUE(ok);
 
   int i;
 
   i = 0;
-  std::list<TaskInEmbeddedDb> pending_list;
+  std::list<JobInEmbeddedDb> pending_list;
   ok = g_embedded_db_client->GetPendingQueueCopy(&pending_list);
   ASSERT_TRUE(ok);
   ASSERT_EQ(pending_list.size(), 2);
@@ -120,13 +110,13 @@ TEST_F(EmbeddedDbClientTest, LinkList) {
                 [&i](decltype(g_embedded_db_client
                                   ->m_pending_queue_)::value_type const& kv) {
                   // Pending Queue: head -> 2 -> 0 -> tail
-                  constexpr std::array<Ctld::task_db_id_t, 2> arr{2, 0};
+                  constexpr std::array<Ctld::job_db_id_t, 2> arr{2, 0};
                   EXPECT_EQ(kv.second.db_id, arr[i++]);
                 });
   ASSERT_EQ(i, 2);
 
   i = 0;
-  std::list<TaskInEmbeddedDb> running_list;
+  std::list<JobInEmbeddedDb> running_list;
   ok = g_embedded_db_client->GetRunningQueueCopy(&running_list);
   ASSERT_TRUE(ok);
   ASSERT_EQ(running_list.size(), 2);
@@ -135,7 +125,7 @@ TEST_F(EmbeddedDbClientTest, LinkList) {
                 [&i](decltype(g_embedded_db_client
                                   ->m_running_queue_)::value_type const& kv) {
                   // Running Queue: head -> 1 -> 3 -> tail
-                  constexpr std::array<Ctld::task_db_id_t, 2> arr{3, 1};
+                  constexpr std::array<Ctld::job_db_id_t, 2> arr{3, 1};
                   EXPECT_EQ(kv.second.db_id, arr[i++]);
                 });
   ASSERT_EQ(i, 2);
@@ -146,7 +136,7 @@ TEST_F(EmbeddedDbClientTest, LinkList) {
       g_embedded_db_client->s_pending_queue_tail_,
       [&i](EmbeddedDbClient::DbQueueNode const& node) {
         // Pending Queue: head -> 2 -> 0 -> tail
-        constexpr std::array<Ctld::task_db_id_t, 2> arr{2, 0};
+        constexpr std::array<Ctld::job_db_id_t, 2> arr{2, 0};
         EXPECT_EQ(node.db_id, arr[i++]);
       });
   ASSERT_EQ(rc, UNQLITE_OK);
@@ -158,45 +148,45 @@ TEST_F(EmbeddedDbClientTest, LinkList) {
       g_embedded_db_client->s_running_queue_tail_,
       [&i](EmbeddedDbClient::DbQueueNode const& node) {
         // Running Queue: head -> 3 -> 1 -> tail
-        constexpr std::array<Ctld::task_db_id_t, 2> arr{3, 1};
+        constexpr std::array<Ctld::job_db_id_t, 2> arr{3, 1};
         EXPECT_EQ(node.db_id, arr[i++]);
       });
   ASSERT_EQ(rc, UNQLITE_OK);
   ASSERT_EQ(i, 2);
 
-  TaskInEmbeddedDb task_in_embedded_db;
-  rc = g_embedded_db_client->FetchTaskDataInDbAtomic_(3, &task_in_embedded_db);
+  JobInEmbeddedDb job_in_embedded_db;
+  rc = g_embedded_db_client->FetchJobDataInDbAtomic_(3, &job_in_embedded_db);
   ASSERT_EQ(rc, UNQLITE_OK);
-  ASSERT_EQ(task_in_embedded_db.persisted_part().task_id(), 3);
-  ASSERT_EQ(task_in_embedded_db.persisted_part().task_db_id(), 3);
-  ASSERT_EQ(task_in_embedded_db.task_to_ctld().name(), "Task3");
+  ASSERT_EQ(job_in_embedded_db.persisted_part().job_id(), 3);
+  ASSERT_EQ(job_in_embedded_db.persisted_part().job_db_id(), 3);
+  ASSERT_EQ(job_in_embedded_db.job_to_ctld().name(), "Job3");
 
-  task_in_embedded_db.Clear();
-  ok = g_embedded_db_client->MovePendingOrRunningTaskToEnded(3);
+  job_in_embedded_db.Clear();
+  ok = g_embedded_db_client->MovePendingOrRunningJobToEnded(3);
   ASSERT_TRUE(ok);
-  rc = g_embedded_db_client->FetchTaskDataInDbAtomic_(3, &task_in_embedded_db);
+  rc = g_embedded_db_client->FetchJobDataInDbAtomic_(3, &job_in_embedded_db);
   ASSERT_EQ(rc, UNQLITE_OK);
-  ASSERT_EQ(task_in_embedded_db.persisted_part().task_id(), 3);
-  ASSERT_EQ(task_in_embedded_db.persisted_part().task_db_id(), 3);
-  ASSERT_EQ(task_in_embedded_db.task_to_ctld().name(), "Task3");
+  ASSERT_EQ(job_in_embedded_db.persisted_part().job_id(), 3);
+  ASSERT_EQ(job_in_embedded_db.persisted_part().job_db_id(), 3);
+  ASSERT_EQ(job_in_embedded_db.job_to_ctld().name(), "Job3");
 
-  task_in_embedded_db.Clear();
-  ok = g_embedded_db_client->MovePendingOrRunningTaskToEnded(1);
+  job_in_embedded_db.Clear();
+  ok = g_embedded_db_client->MovePendingOrRunningJobToEnded(1);
   ASSERT_TRUE(ok);
-  ok = g_embedded_db_client->FetchTaskDataInDb(1, &task_in_embedded_db);
+  ok = g_embedded_db_client->FetchJobDataInDb(1, &job_in_embedded_db);
   ASSERT_TRUE(ok);
-  ASSERT_EQ(task_in_embedded_db.persisted_part().task_id(), 1);
-  ASSERT_EQ(task_in_embedded_db.persisted_part().task_db_id(), 1);
-  ASSERT_EQ(task_in_embedded_db.task_to_ctld().name(), "Task1");
+  ASSERT_EQ(job_in_embedded_db.persisted_part().job_id(), 1);
+  ASSERT_EQ(job_in_embedded_db.persisted_part().job_db_id(), 1);
+  ASSERT_EQ(job_in_embedded_db.job_to_ctld().name(), "Job1");
 
-  task_in_embedded_db.Clear();
-  ok = g_embedded_db_client->MovePendingOrRunningTaskToEnded(2);
+  job_in_embedded_db.Clear();
+  ok = g_embedded_db_client->MovePendingOrRunningJobToEnded(2);
   ASSERT_TRUE(ok);
-  ok = g_embedded_db_client->FetchTaskDataInDb(2, &task_in_embedded_db);
+  ok = g_embedded_db_client->FetchJobDataInDb(2, &job_in_embedded_db);
   ASSERT_TRUE(ok);
-  ASSERT_EQ(task_in_embedded_db.persisted_part().task_id(), 2);
-  ASSERT_EQ(task_in_embedded_db.persisted_part().task_db_id(), 2);
-  ASSERT_EQ(task_in_embedded_db.task_to_ctld().name(), "Task2");
+  ASSERT_EQ(job_in_embedded_db.persisted_part().job_id(), 2);
+  ASSERT_EQ(job_in_embedded_db.persisted_part().job_db_id(), 2);
+  ASSERT_EQ(job_in_embedded_db.job_to_ctld().name(), "Job2");
 
   rc = g_embedded_db_client->ForEachInDbQueueNoLock_(
       g_embedded_db_client->s_running_queue_head_,
@@ -207,7 +197,7 @@ TEST_F(EmbeddedDbClientTest, LinkList) {
       });
   ASSERT_EQ(rc, UNQLITE_OK);
 
-  std::list<TaskInEmbeddedDb> ended_list;
+  std::list<JobInEmbeddedDb> ended_list;
 
   i = 0;
   rc = g_embedded_db_client->ForEachInDbQueueNoLock_(
@@ -215,13 +205,13 @@ TEST_F(EmbeddedDbClientTest, LinkList) {
       g_embedded_db_client->s_ended_queue_tail_,
       [&i](EmbeddedDbClient::DbQueueNode const& node) {
         // Ended Queue: head -> 2 -> 1 -> 3 -> tail
-        constexpr std::array<Ctld::task_db_id_t, 3> arr{2, 1, 3};
+        constexpr std::array<Ctld::job_db_id_t, 3> arr{2, 1, 3};
         EXPECT_EQ(node.db_id, arr[i++]);
       });
   ASSERT_EQ(rc, UNQLITE_OK);
   ASSERT_EQ(i, 3);
 
-  ok = g_embedded_db_client->PurgeEndedTasks(1);
+  ok = g_embedded_db_client->PurgeEndedJobs(1);
   ASSERT_TRUE(ok);
 
   i = 0;
@@ -230,7 +220,7 @@ TEST_F(EmbeddedDbClientTest, LinkList) {
       g_embedded_db_client->s_ended_queue_tail_,
       [&i](EmbeddedDbClient::DbQueueNode const& node) {
         // Ended Queue: head -> 2 -> 3 -> tail
-        constexpr std::array<Ctld::task_db_id_t, 2> arr{2, 3};
+        constexpr std::array<Ctld::job_db_id_t, 2> arr{2, 3};
         EXPECT_EQ(node.db_id, arr[i++]);
       });
   ASSERT_EQ(rc, UNQLITE_OK);
@@ -245,12 +235,12 @@ TEST_F(EmbeddedDbClientTest, LinkList) {
                 [&i](decltype(g_embedded_db_client
                                   ->m_ended_queue_)::value_type const& kv) {
                   // Ended Queue: head -> 2 -> 3 -> tail
-                  constexpr std::array<Ctld::task_db_id_t, 2> arr{2, 3};
+                  constexpr std::array<Ctld::job_db_id_t, 2> arr{2, 3};
                   EXPECT_EQ(kv.second.db_id, arr[i++]);
                 });
   ASSERT_EQ(i, 2);
 
-  task_in_embedded_db.Clear();
-  ok = g_embedded_db_client->FetchTaskDataInDb(1, &task_in_embedded_db);
+  job_in_embedded_db.Clear();
+  ok = g_embedded_db_client->FetchJobDataInDb(1, &job_in_embedded_db);
   ASSERT_FALSE(ok);
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Breaking Changes**
  * System-wide rename from “task” to “job”: APIs, RPCs, request/response types, enums, CLI flags, and UI/CLI messages now use job-centric names.
  * Status/type enums and status fields moved to JobStatus/JobType; streaming, hooks, plugins, and monitoring reflect job/step semantics.
  * Storage and tooling updated: database collection/table names, migration and wipe commands, and plugin hook payloads now target jobs instead of tasks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->