### PR TITLE
refactor: Add completing status

### DIFF
--- a/protos/Crane.proto
+++ b/protos/Crane.proto
@@ -33,6 +33,7 @@ message StepStatusChangeRequest {
   uint32 exit_code = 5;
   string reason = 6;
   google.protobuf.Timestamp timestamp = 7;
+  optional JobStatus final_status = 8;
 }
 
 message StepStatusChangeReply {
@@ -171,15 +172,6 @@ message ResumeJobsRequest {
 }
 
 message ResumeJobsReply {
-  bool ok = 1;
-  string reason = 2;
-}
-
-message TerminateOrphanedStepRequest {
-  map<uint32, JobStepIds> job_step_ids_map = 1;
-}
-
-message TerminateOrphanedStepReply {
   bool ok = 1;
   string reason = 2;
 }
@@ -1446,7 +1438,6 @@ service Craned {
   rpc TerminateSteps(TerminateStepsRequest) returns (TerminateStepsReply);
   rpc SuspendJobs(SuspendJobsRequest) returns (SuspendJobsReply);
   rpc ResumeJobs(ResumeJobsRequest) returns (ResumeJobsReply);
-  rpc TerminateOrphanedStep(TerminateOrphanedStepRequest) returns (TerminateOrphanedStepReply);
   rpc ChangeJobTimeConstraint(ChangeJobTimeConstraintRequest) returns (ChangeJobTimeConstraintReply);
 
   /*

--- a/protos/PublicDefs.proto
+++ b/protos/PublicDefs.proto
@@ -345,6 +345,7 @@ message RuntimeAttrOfStep {
   repeated string execution_nodes = 16;
   repeated string configuring_nodes = 17;
   repeated string running_nodes = 18;
+  repeated string completing_nodes = 19;
 
   google.protobuf.Timestamp submit_time = 25;
   google.protobuf.Timestamp start_time = 26;

--- a/protos/Supervisor.proto
+++ b/protos/Supervisor.proto
@@ -159,7 +159,7 @@ message ChangeStepTimeConstraintReply {
 }
 
 message TerminateStepRequest {
-  bool mark_orphaned = 1;
+  reserved 1;  // was mark_orphaned
   crane.grpc.TerminateSource terminate_source = 2;
 }
 

--- a/src/CraneCtld/CtldPublicDefs.cpp
+++ b/src/CraneCtld/CtldPublicDefs.cpp
@@ -246,6 +246,18 @@ void StepInCtld::StepOnNodeFinish(const CranedId& node) {
       m_running_nodes_.begin(), m_running_nodes_.end());
 }
 
+void StepInCtld::StepOnNodeCompleting(const CranedId& node) {
+  this->m_completing_nodes_.insert(node);
+  this->m_runtime_attr_.mutable_completing_nodes()->Assign(
+      m_completing_nodes_.begin(), m_completing_nodes_.end());
+}
+
+bool StepInCtld::AllNodesCompleting() const {
+  return !m_completing_nodes_.empty() &&
+         m_completing_nodes_.size() == m_execute_nodes_.size() &&
+         m_completing_nodes_ == m_execute_nodes_;
+}
+
 void StepInCtld::SetSubmitTime(absl::Time submit_time) {
   m_submit_time_ = submit_time;
   this->m_runtime_attr_.mutable_submit_time()->set_seconds(
@@ -370,6 +382,8 @@ void StepInCtld::RecoverFromDb(
                        runtime_attr.configuring_nodes().end()});
   SetRunningNodes({runtime_attr.running_nodes().begin(),
                    runtime_attr.running_nodes().end()});
+  m_completing_nodes_ = {runtime_attr.completing_nodes().begin(),
+                         runtime_attr.completing_nodes().end()};
 
   SetSubmitTime(absl::FromUnixSeconds(runtime_attr.submit_time().seconds()));
   SetStartTime(absl::FromUnixSeconds(runtime_attr.start_time().seconds()));
@@ -703,21 +717,18 @@ DaemonStepInCtld::StepStatusChange(crane::grpc::JobStatus new_status,
 
   case crane::grpc::JobStatus::Running:
   case crane::grpc::JobStatus::Completing:
-    // Completing -> Completed / Failed
-    switch (new_status) {
-    case crane::grpc::JobStatus::Failed:
+    if (new_status == crane::grpc::JobStatus::Completing) {
+      // First report: processes dead, supervisor exiting.
+      // Track in completing_nodes_. FreeJobs is triggered by primary step.
+      this->StepOnNodeCompleting(craned_id);
+      break;
+    }
+
+    // Terminal report: cleanup done on this node.
+    if (new_status != crane::grpc::JobStatus::Completed) {
+      if (Is)
       this->SetErrorStatus(new_status);
       this->SetErrorExitCode(exit_code);
-      break;
-
-    case crane::grpc::JobStatus::Completed:
-      break;
-
-    [[unlikely]] default:
-      CRANE_ERROR("Invalid daemon step status transition, current: {}, new: {}",
-                  util::StepStatusToString(this->Status()),
-                  util::StepStatusToString(new_status));
-      return std::nullopt;
     }
 
     this->StepOnNodeFinish(craned_id);
@@ -755,8 +766,9 @@ DaemonStepInCtld::StepStatusChange(crane::grpc::JobStatus new_status,
       // FreeJobs() and TerminateOrphanedStep() could be called concurrently for
       // the same daemon step, both trying to free the supervisor, double-freed.
 
-      // FreeJobs() is enough to free the daemon step's supervisor.
-      context->craned_jobs_to_free[craned_id].emplace_back(job->JobId());
+      for (const auto& node_id : job->CranedIds()) {
+        context->craned_jobs_to_free[node_id].emplace_back(job->JobId());
+      }
       if (job->IsInteractive()) {
         auto& meta = std::get<InteractiveMeta>(job->meta);
         if (!meta.has_been_cancelled_on_front_end) {
@@ -1199,8 +1211,7 @@ CommonStepInCtld::StepStatusChange(crane::grpc::JobStatus new_status,
   auto step_id = this->StepId();
 
   bool step_finished{false};
-  // Step failed to configure, terminate step
-  bool step_configure_failed{false};
+  bool step_all_completing{false};
 
   CRANE_TRACE("[Step #{}.{}] current status {}, got new status {} from {}",
               job_id, step_id, this->Status(), new_status, craned_id);
@@ -1215,8 +1226,19 @@ CommonStepInCtld::StepStatusChange(crane::grpc::JobStatus new_status,
     }
     if (this->AllNodesConfigured()) {
       if (this->PrevErrorStatus().has_value()) {
-        // Configuring -> Failed
-        step_configure_failed = true;
+        // Configure failed: enter completing flow.
+        // Failed node counts as completing. Cancel other nodes and wait
+        // for them to also complete.
+        CRANE_INFO("[Step #{}.{}] CONFIGURE_FAILED, entering completing flow.",
+                   job_id, step_id);
+        this->SetStatus(crane::grpc::JobStatus::Completing);
+        this->StepOnNodeCompleting(craned_id);
+        // Cancel other nodes — their supervisors will send Completing
+        for (const auto& node : this->ExecutionNodes()) {
+          if (node != craned_id)
+            context->craned_cancel_steps[node][job->JobId()].insert(step_id);
+        }
+        step_all_completing = this->AllNodesCompleting();
       } else {
         // Configuring -> Running
         // All supervisor ready without failure, start execution.
@@ -1244,19 +1266,27 @@ CommonStepInCtld::StepStatusChange(crane::grpc::JobStatus new_status,
     break;
   case crane::grpc::JobStatus::Running:
   case crane::grpc::JobStatus::Completing:
-    // Running/Completing -> Completed / Failed / Cancelled,
-    // Primary: the job is completed.
-
-    this->StepOnNodeFinish(craned_id);
-    if (new_status != crane::grpc::JobStatus::Completed) {
-      this->SetErrorStatus(new_status);
-      this->SetErrorExitCode(exit_code);
-    }
-    step_finished = this->AllNodesFinished();
-    if (!step_finished) {
-      CRANE_DEBUG(
-          "[Step #{}.{}] got a finish status, waiting for {} status change.",
-          job_id, step_id, this->RunningNodes().size());
+    if (new_status == crane::grpc::JobStatus::Completing) {
+      this->StepOnNodeCompleting(craned_id);
+      step_all_completing = this->AllNodesCompleting();
+      if (!step_all_completing) {
+        CRANE_DEBUG("[Step #{}.{}] got Completing, waiting for {} more nodes.",
+                    job_id, step_id,
+                    this->ExecutionNodes().size() - m_completing_nodes_.size());
+      }
+    } else {
+      // Terminal report: cleanup done on this node.
+      if (new_status != crane::grpc::JobStatus::Completed) {
+        this->SetErrorStatus(new_status);
+        this->SetErrorExitCode(exit_code);
+      }
+      CRANE_ASSERT(IsTerminalStatus(new_status));
+      this->StepOnNodeFinish(craned_id);
+      step_finished = this->AllNodesFinished();
+      if (!step_finished) {
+        CRANE_DEBUG("[Step #{}.{}] got terminal, waiting for {} more nodes.",
+                    job_id, step_id, this->RunningNodes().size());
+      }
     }
     break;
   default:
@@ -1267,14 +1297,22 @@ CommonStepInCtld::StepStatusChange(crane::grpc::JobStatus new_status,
                            StepStatusToString(new_status)));
   }
 
-  // Step finish: configure failed or execution status change
-  if (step_finished || step_configure_failed) {
+  // AllNodesCompleting: trigger FreeSteps for step-level cleanup.
+  // User proc stopped but step is NOT released — terminal will arrive after
+  // cleanup.
+  if (step_all_completing) {
+    CRANE_INFO("[Step #{}.{}] Status :{},last status:{}, triggering cleanup.",
+               job_id, step_id, crane::grpc::JobStatus::Completing,
+               this->Status());
+    this->SetStatus(crane::grpc::JobStatus::Completing);
+
+    // Notify frontend (interactive steps)
     if (this->ia_meta.has_value()) {
       auto& meta = this->ia_meta.value();
       if (!meta.has_been_cancelled_on_front_end) {
         meta.has_been_cancelled_on_front_end = true;
         meta.cb_step_cancel({.job_id = job_id, .step_id = step_id});
-        // Completion ack will send in grpc server triggered by job complete
+        // Completion ack will send in grpc server triggered by step complete
         // req
         meta.cb_step_completed({.job_id = job_id,
                                 .step_id = step_id,
@@ -1288,118 +1326,91 @@ CommonStepInCtld::StepStatusChange(crane::grpc::JobStatus new_status,
                                 .cfored_name = meta.cfored_name});
       }
     }
-    this->SetEndTime(absl::FromUnixSeconds(timestamp.seconds()) +
-                     absl::Nanoseconds(timestamp.nanos()));
-    if (this->Status() == crane::grpc::JobStatus::Configuring) {
-      CRANE_INFO("[Step #{}.{}] CONFIGURE_FAILED.", job_id, step_id);
-      // CONFIGURE_FAILED
-      this->SetStatus(this->PrevErrorStatus().value());
-      this->SetExitCode(this->PrevErrorExitCode());
-      // Step failed to configure, terminate this step
-      for (const auto& node : this->ExecutionNodes()) {
-        if (node != craned_id)
-          context->craned_orphaned_steps[node][job->JobId()].emplace(step_id);
-      }
 
-      if (this->IsPrimaryStep()) {
-        job->DaemonStep()->SetStatus(crane::grpc::Completing);
-        context->rn_step_raw_ptrs.emplace(job->DaemonStep());
-        // Primary step CONFIGURE_FAILED, free daemon step, will send status
-        // change.
-        for (const auto& node : job->DaemonStep()->CranedIds()) {
-          context->craned_jobs_to_free[node].emplace_back(job->JobId());
-        }
-      } else {
-        for (const auto& node : this->CranedIds()) {
-          context->craned_step_free_map[node][job_id].insert(step_id);
-        }
-      }
-    } else {
-      // Step COMPLETED
-      if (this->IsPrimaryStep()) {
-        job->DaemonStep()->SetStatus(crane::grpc::Completing);
-        context->rn_step_raw_ptrs.emplace(job->DaemonStep());
-        // Primary step finish, free daemon step, will send status change.
-        for (const auto& node : job->DaemonStep()->CranedIds()) {
-          context->craned_jobs_to_free[node].emplace_back(job->JobId());
-        }
-
-        std::unordered_set<step_id_t> pd_steps;
-        CRANE_DEBUG("[Job #{}] primary step exited, terminating other steps.",
-                    job_id);
-
-        // Cancel all other step with CANCELED status
-        const absl::Time& cancel_time = this->EndTime();
-        for (const auto& comm_step : job->Steps() | std::views::values) {
-          // All pending steps are crun steps, just set status to cancelled
-          if (comm_step->Status() == crane::grpc::JobStatus::Pending) {
-            comm_step->SetStatus(crane::grpc::Cancelled);
-            comm_step->SetStartTime(cancel_time);
-            comm_step->SetEndTime(cancel_time);
-
-            // Crun needs this, ccon do not.
-            if (comm_step->ia_meta.has_value()) {
-              auto& meta = comm_step->ia_meta.value();
-              if (!meta.has_been_cancelled_on_front_end) {
-                meta.has_been_cancelled_on_front_end = true;
-                meta.cb_step_cancel({.job_id = comm_step->job_id,
-                                     .step_id = comm_step->StepId()});
-              }
-
-              // Send Completion Ack to frontend now.
-              meta.cb_step_completed({.job_id = comm_step->job_id,
-                                      .step_id = comm_step->StepId(),
-                                      .send_completion_ack = true,
-                                      .cfored_name = meta.cfored_name});
-            }
-
-            pd_steps.insert(comm_step->StepId());
-            CRANE_TRACE(
-                "[Step #{}.{}] Cancelled pending step due to primary step "
-                "exit.",
-                comm_step->job_id, comm_step->StepId());
-          } else {
-            CRANE_TRACE(
-                "[Step #{}.{}] Sending cancel due to primary step exit.",
-                comm_step->job_id, comm_step->StepId());
-            for (const auto& node : comm_step->ExecutionNodes()) {
-              context->craned_cancel_steps[node][comm_step->job_id].emplace(
-                  comm_step->StepId());
-            }
-          }
-        }
-        for (const auto& pd_step_id : pd_steps) {
-          auto pd_step = job->EraseStep(pd_step_id);
-          context->step_raw_ptrs.insert(pd_step.get());
-          context->step_ptrs.insert(std::move(pd_step));
-        }
-      } else {
-        for (const auto& node : this->ExecutionNodes()) {
-          context->craned_step_free_map[node][job_id].insert(step_id);
-        }
-      }
-      if (this->PrevErrorStatus().has_value()) {
-        this->SetStatus(this->PrevErrorStatus().value());
-        this->SetExitCode(this->PrevErrorExitCode());
-      } else {
-        this->SetStatus(crane::grpc::JobStatus::Completed);
-        this->SetExitCode(exit_code);
-      }
-
-      CRANE_INFO("[Step #{}.{}] FINISHED with status {}.", job_id, step_id,
-                 this->Status());
+    // FreeSteps for ALL execution nodes (step-level cleanup)
+    for (const auto& node : this->ExecutionNodes()) {
+      context->craned_step_free_map[node][job_id].insert(step_id);
     }
 
+    // Primary step: also cancel other running common steps
+    if (this->IsPrimaryStep()) {
+      std::unordered_set<step_id_t> pd_steps;
+      CRANE_DEBUG("[Job #{}] primary step completing, terminating other steps.",
+                  job_id);
+      const absl::Time cancel_time =
+          absl::FromUnixSeconds(timestamp.seconds()) +
+          absl::Nanoseconds(timestamp.nanos());
+      for (const auto& comm_step : job->Steps() | std::views::values) {
+        if (comm_step->Status() == crane::grpc::JobStatus::Pending) {
+          comm_step->SetStatus(crane::grpc::Cancelled);
+          comm_step->SetStartTime(cancel_time);
+          comm_step->SetEndTime(cancel_time);
+          if (comm_step->ia_meta.has_value()) {
+            auto& meta = comm_step->ia_meta.value();
+            if (!meta.has_been_cancelled_on_front_end) {
+              meta.has_been_cancelled_on_front_end = true;
+              meta.cb_step_cancel({.job_id = comm_step->job_id,
+                                   .step_id = comm_step->StepId()});
+            }
+            meta.cb_step_completed({.job_id = comm_step->job_id,
+                                    .step_id = comm_step->StepId(),
+                                    .send_completion_ack = true,
+                                    .cfored_name = meta.cfored_name});
+          }
+          pd_steps.insert(comm_step->StepId());
+        } else {
+          for (const auto& node : comm_step->ExecutionNodes()) {
+            context->craned_cancel_steps[node][comm_step->job_id].emplace(
+                comm_step->StepId());
+          }
+        }
+      }
+      for (const auto& pd_step_id : pd_steps) {
+        auto pd_step = job->EraseStep(pd_step_id);
+        context->step_raw_ptrs.insert(pd_step.get());
+        context->step_ptrs.insert(std::move(pd_step));
+      }
+    }
+    context->rn_step_raw_ptrs.insert(this);
+  }
+
+  // AllNodesFinished (terminal from all nodes = step-level cleanup done).
+  // Release step. Primary additionally triggers FreeJobs for job-level cleanup.
+  if (step_finished) {
+    this->SetEndTime(absl::FromUnixSeconds(timestamp.seconds()) +
+                     absl::Nanoseconds(timestamp.nanos()));
+    if (this->PrevErrorStatus().has_value()) {
+      this->SetStatus(this->PrevErrorStatus().value());
+      this->SetExitCode(this->PrevErrorExitCode());
+    } else {
+      this->SetStatus(crane::grpc::JobStatus::Completed);
+      this->SetExitCode(exit_code);
+    }
+    CRANE_INFO("[Step #{}.{}] FINISHED with status {}.", job_id, step_id,
+               this->Status());
+
+    // Primary step: trigger FreeJobs for daemon step (job-level cleanup).
+    // Don't manually set daemon step to Completing — FreeJobs sends
+    // ShutdownSupervisor to daemon supervisor, which will send Completing
+    // on its own via the normal two-phase flow.
+    if (this->IsPrimaryStep()) {
+      for (const auto& node : job->DaemonStep()->CranedIds()) {
+        context->craned_jobs_to_free[node].emplace_back(job->JobId());
+      }
+    }
+
+    // Release step
     context->step_raw_ptrs.insert(this);
     if (this->IsPrimaryStep()) {
       job->SetPrimaryStepStatus(this->Status());
-      job->SetPrimaryStepExitCode(exit_code);
+      job->SetPrimaryStepExitCode(this->ExitCode());
       context->rn_job_raw_ptrs.insert(job);
       context->step_ptrs.emplace(job->ReleasePrimaryStep());
     } else {
       context->step_ptrs.insert(job->EraseStep(step_id));
     }
   }
+
   if (job->AllStepsFinished())
     return std::make_pair(job->PrimaryStepStatus(), job->PrimaryStepExitCode());
   else

--- a/src/CraneCtld/CtldPublicDefs.cpp
+++ b/src/CraneCtld/CtldPublicDefs.cpp
@@ -724,9 +724,11 @@ DaemonStepInCtld::StepStatusChange(crane::grpc::JobStatus new_status,
       break;
     }
 
+    if (!IsFinishedStepStatus(new_status))
+      CRANE_WARN("Node {} reported step status {} which is not a valid status.",
+                 craned_id, util::StepStatusToString(new_status));
     // Terminal report: cleanup done on this node.
     if (new_status != crane::grpc::JobStatus::Completed) {
-      if (Is)
       this->SetErrorStatus(new_status);
       this->SetErrorExitCode(exit_code);
     }
@@ -1275,12 +1277,16 @@ CommonStepInCtld::StepStatusChange(crane::grpc::JobStatus new_status,
                     this->ExecutionNodes().size() - m_completing_nodes_.size());
       }
     } else {
+      if (!IsFinishedStepStatus(new_status)) {
+        CRANE_WARN(
+            "Node {} reported step status {} which is not a valid status.",
+            craned_id, util::StepStatusToString(new_status));
+      }
       // Terminal report: cleanup done on this node.
       if (new_status != crane::grpc::JobStatus::Completed) {
         this->SetErrorStatus(new_status);
         this->SetErrorExitCode(exit_code);
       }
-      CRANE_ASSERT(IsTerminalStatus(new_status));
       this->StepOnNodeFinish(craned_id);
       step_finished = this->AllNodesFinished();
       if (!step_finished) {

--- a/src/CraneCtld/CtldPublicDefs.cpp
+++ b/src/CraneCtld/CtldPublicDefs.cpp
@@ -1365,8 +1365,7 @@ CommonStepInCtld::StepStatusChange(crane::grpc::JobStatus new_status,
           }
           pd_steps.insert(comm_step->StepId());
         } else if (IsFinishedStepStatus(comm_step->Status()) ||
-                   comm_step->Status() ==
-                       crane::grpc::JobStatus::Completing) {
+                   comm_step->Status() == crane::grpc::JobStatus::Completing) {
           continue;
         } else {
           for (const auto& node : comm_step->ExecutionNodes()) {

--- a/src/CraneCtld/CtldPublicDefs.cpp
+++ b/src/CraneCtld/CtldPublicDefs.cpp
@@ -246,6 +246,18 @@ void StepInCtld::StepOnNodeFinish(const CranedId& node) {
       m_running_nodes_.begin(), m_running_nodes_.end());
 }
 
+void StepInCtld::StepOnNodeCompleting(const CranedId& node) {
+  this->m_completing_nodes_.insert(node);
+  this->m_runtime_attr_.mutable_completing_nodes()->Assign(
+      m_completing_nodes_.begin(), m_completing_nodes_.end());
+}
+
+bool StepInCtld::AllNodesCompleting() const {
+  return !m_completing_nodes_.empty() &&
+         m_completing_nodes_.size() == m_execute_nodes_.size() &&
+         m_completing_nodes_ == m_execute_nodes_;
+}
+
 void StepInCtld::SetSubmitTime(absl::Time submit_time) {
   m_submit_time_ = submit_time;
   this->m_runtime_attr_.mutable_submit_time()->set_seconds(
@@ -370,6 +382,8 @@ void StepInCtld::RecoverFromDb(
                        runtime_attr.configuring_nodes().end()});
   SetRunningNodes({runtime_attr.running_nodes().begin(),
                    runtime_attr.running_nodes().end()});
+  m_completing_nodes_ = {runtime_attr.completing_nodes().begin(),
+                         runtime_attr.completing_nodes().end()};
 
   SetSubmitTime(absl::FromUnixSeconds(runtime_attr.submit_time().seconds()));
   SetStartTime(absl::FromUnixSeconds(runtime_attr.start_time().seconds()));
@@ -703,21 +717,18 @@ DaemonStepInCtld::StepStatusChange(crane::grpc::JobStatus new_status,
 
   case crane::grpc::JobStatus::Running:
   case crane::grpc::JobStatus::Completing:
-    // Completing -> Completed / Failed
-    switch (new_status) {
-    case crane::grpc::JobStatus::Failed:
+    if (new_status == crane::grpc::JobStatus::Completing) {
+      // First report: processes dead, supervisor exiting.
+      // Track in completing_nodes_. FreeJobs is triggered by primary step.
+      this->StepOnNodeCompleting(craned_id);
+      break;
+    }
+
+    // Terminal report: cleanup done on this node.
+    if (new_status != crane::grpc::JobStatus::Completed) {
+      if (Is)
       this->SetErrorStatus(new_status);
       this->SetErrorExitCode(exit_code);
-      break;
-
-    case crane::grpc::JobStatus::Completed:
-      break;
-
-    [[unlikely]] default:
-      CRANE_ERROR("Invalid daemon step status transition, current: {}, new: {}",
-                  util::StepStatusToString(this->Status()),
-                  util::StepStatusToString(new_status));
-      return std::nullopt;
     }
 
     this->StepOnNodeFinish(craned_id);
@@ -755,12 +766,8 @@ DaemonStepInCtld::StepStatusChange(crane::grpc::JobStatus new_status,
       // FreeJobs() and TerminateOrphanedStep() could be called concurrently for
       // the same daemon step, both trying to free the supervisor, double-freed.
 
-      // FreeJobs() is enough to free the daemon step's supervisor. It must be
-      // sent to every node allocated to this daemon step; otherwise nodes that
-      // did not trigger the final Configuring status change would never receive
-      // ShutdownSupervisor.
-      for (const auto& node : this->CranedIds()) {
-        context->craned_jobs_to_free[node].emplace_back(job->JobId());
+      for (const auto& node_id : job->CranedIds()) {
+        context->craned_jobs_to_free[node_id].emplace_back(job->JobId());
       }
       if (job->IsInteractive()) {
         auto& meta = std::get<InteractiveMeta>(job->meta);
@@ -1204,8 +1211,7 @@ CommonStepInCtld::StepStatusChange(crane::grpc::JobStatus new_status,
   auto step_id = this->StepId();
 
   bool step_finished{false};
-  // Step failed to configure, terminate step
-  bool step_configure_failed{false};
+  bool step_all_completing{false};
 
   CRANE_TRACE("[Step #{}.{}] current status {}, got new status {} from {}",
               job_id, step_id, this->Status(), new_status, craned_id);
@@ -1220,8 +1226,19 @@ CommonStepInCtld::StepStatusChange(crane::grpc::JobStatus new_status,
     }
     if (this->AllNodesConfigured()) {
       if (this->PrevErrorStatus().has_value()) {
-        // Configuring -> Failed
-        step_configure_failed = true;
+        // Configure failed: enter completing flow.
+        // Failed node counts as completing. Cancel other nodes and wait
+        // for them to also complete.
+        CRANE_INFO("[Step #{}.{}] CONFIGURE_FAILED, entering completing flow.",
+                   job_id, step_id);
+        this->SetStatus(crane::grpc::JobStatus::Completing);
+        this->StepOnNodeCompleting(craned_id);
+        // Cancel other nodes — their supervisors will send Completing
+        for (const auto& node : this->ExecutionNodes()) {
+          if (node != craned_id)
+            context->craned_cancel_steps[node][job->JobId()].insert(step_id);
+        }
+        step_all_completing = this->AllNodesCompleting();
       } else {
         // Configuring -> Running
         // All supervisor ready without failure, start execution.
@@ -1249,19 +1266,27 @@ CommonStepInCtld::StepStatusChange(crane::grpc::JobStatus new_status,
     break;
   case crane::grpc::JobStatus::Running:
   case crane::grpc::JobStatus::Completing:
-    // Running/Completing -> Completed / Failed / Cancelled,
-    // Primary: the job is completed.
-
-    this->StepOnNodeFinish(craned_id);
-    if (new_status != crane::grpc::JobStatus::Completed) {
-      this->SetErrorStatus(new_status);
-      this->SetErrorExitCode(exit_code);
-    }
-    step_finished = this->AllNodesFinished();
-    if (!step_finished) {
-      CRANE_DEBUG(
-          "[Step #{}.{}] got a finish status, waiting for {} status change.",
-          job_id, step_id, this->RunningNodes().size());
+    if (new_status == crane::grpc::JobStatus::Completing) {
+      this->StepOnNodeCompleting(craned_id);
+      step_all_completing = this->AllNodesCompleting();
+      if (!step_all_completing) {
+        CRANE_DEBUG("[Step #{}.{}] got Completing, waiting for {} more nodes.",
+                    job_id, step_id,
+                    this->ExecutionNodes().size() - m_completing_nodes_.size());
+      }
+    } else {
+      // Terminal report: cleanup done on this node.
+      if (new_status != crane::grpc::JobStatus::Completed) {
+        this->SetErrorStatus(new_status);
+        this->SetErrorExitCode(exit_code);
+      }
+      CRANE_ASSERT(IsTerminalStatus(new_status));
+      this->StepOnNodeFinish(craned_id);
+      step_finished = this->AllNodesFinished();
+      if (!step_finished) {
+        CRANE_DEBUG("[Step #{}.{}] got terminal, waiting for {} more nodes.",
+                    job_id, step_id, this->RunningNodes().size());
+      }
     }
     break;
   default:
@@ -1272,14 +1297,22 @@ CommonStepInCtld::StepStatusChange(crane::grpc::JobStatus new_status,
                            StepStatusToString(new_status)));
   }
 
-  // Step finish: configure failed or execution status change
-  if (step_finished || step_configure_failed) {
+  // AllNodesCompleting: trigger FreeSteps for step-level cleanup.
+  // User proc stopped but step is NOT released — terminal will arrive after
+  // cleanup.
+  if (step_all_completing) {
+    CRANE_INFO("[Step #{}.{}] Status :{},last status:{}, triggering cleanup.",
+               job_id, step_id, crane::grpc::JobStatus::Completing,
+               this->Status());
+    this->SetStatus(crane::grpc::JobStatus::Completing);
+
+    // Notify frontend (interactive steps)
     if (this->ia_meta.has_value()) {
       auto& meta = this->ia_meta.value();
       if (!meta.has_been_cancelled_on_front_end) {
         meta.has_been_cancelled_on_front_end = true;
         meta.cb_step_cancel({.job_id = job_id, .step_id = step_id});
-        // Completion ack will send in grpc server triggered by job complete
+        // Completion ack will send in grpc server triggered by step complete
         // req
         meta.cb_step_completed({.job_id = job_id,
                                 .step_id = step_id,
@@ -1293,118 +1326,91 @@ CommonStepInCtld::StepStatusChange(crane::grpc::JobStatus new_status,
                                 .cfored_name = meta.cfored_name});
       }
     }
-    this->SetEndTime(absl::FromUnixSeconds(timestamp.seconds()) +
-                     absl::Nanoseconds(timestamp.nanos()));
-    if (this->Status() == crane::grpc::JobStatus::Configuring) {
-      CRANE_INFO("[Step #{}.{}] CONFIGURE_FAILED.", job_id, step_id);
-      // CONFIGURE_FAILED
-      this->SetStatus(this->PrevErrorStatus().value());
-      this->SetExitCode(this->PrevErrorExitCode());
-      // Step failed to configure, terminate this step
-      for (const auto& node : this->ExecutionNodes()) {
-        if (node != craned_id)
-          context->craned_orphaned_steps[node][job->JobId()].emplace(step_id);
-      }
 
-      if (this->IsPrimaryStep()) {
-        job->DaemonStep()->SetStatus(crane::grpc::Completing);
-        context->rn_step_raw_ptrs.emplace(job->DaemonStep());
-        // Primary step CONFIGURE_FAILED, free daemon step, will send status
-        // change.
-        for (const auto& node : job->DaemonStep()->CranedIds()) {
-          context->craned_jobs_to_free[node].emplace_back(job->JobId());
-        }
-      } else {
-        for (const auto& node : this->CranedIds()) {
-          context->craned_step_free_map[node][job_id].insert(step_id);
-        }
-      }
-    } else {
-      // Step COMPLETED
-      if (this->IsPrimaryStep()) {
-        job->DaemonStep()->SetStatus(crane::grpc::Completing);
-        context->rn_step_raw_ptrs.emplace(job->DaemonStep());
-        // Primary step finish, free daemon step, will send status change.
-        for (const auto& node : job->DaemonStep()->CranedIds()) {
-          context->craned_jobs_to_free[node].emplace_back(job->JobId());
-        }
-
-        std::unordered_set<step_id_t> pd_steps;
-        CRANE_DEBUG("[Job #{}] primary step exited, terminating other steps.",
-                    job_id);
-
-        // Cancel all other step with CANCELED status
-        const absl::Time& cancel_time = this->EndTime();
-        for (const auto& comm_step : job->Steps() | std::views::values) {
-          // All pending steps are crun steps, just set status to cancelled
-          if (comm_step->Status() == crane::grpc::JobStatus::Pending) {
-            comm_step->SetStatus(crane::grpc::Cancelled);
-            comm_step->SetStartTime(cancel_time);
-            comm_step->SetEndTime(cancel_time);
-
-            // Crun needs this, ccon do not.
-            if (comm_step->ia_meta.has_value()) {
-              auto& meta = comm_step->ia_meta.value();
-              if (!meta.has_been_cancelled_on_front_end) {
-                meta.has_been_cancelled_on_front_end = true;
-                meta.cb_step_cancel({.job_id = comm_step->job_id,
-                                     .step_id = comm_step->StepId()});
-              }
-
-              // Send Completion Ack to frontend now.
-              meta.cb_step_completed({.job_id = comm_step->job_id,
-                                      .step_id = comm_step->StepId(),
-                                      .send_completion_ack = true,
-                                      .cfored_name = meta.cfored_name});
-            }
-
-            pd_steps.insert(comm_step->StepId());
-            CRANE_TRACE(
-                "[Step #{}.{}] Cancelled pending step due to primary step "
-                "exit.",
-                comm_step->job_id, comm_step->StepId());
-          } else {
-            CRANE_TRACE(
-                "[Step #{}.{}] Sending cancel due to primary step exit.",
-                comm_step->job_id, comm_step->StepId());
-            for (const auto& node : comm_step->ExecutionNodes()) {
-              context->craned_cancel_steps[node][comm_step->job_id].emplace(
-                  comm_step->StepId());
-            }
-          }
-        }
-        for (const auto& pd_step_id : pd_steps) {
-          auto pd_step = job->EraseStep(pd_step_id);
-          context->step_raw_ptrs.insert(pd_step.get());
-          context->step_ptrs.insert(std::move(pd_step));
-        }
-      } else {
-        for (const auto& node : this->ExecutionNodes()) {
-          context->craned_step_free_map[node][job_id].insert(step_id);
-        }
-      }
-      if (this->PrevErrorStatus().has_value()) {
-        this->SetStatus(this->PrevErrorStatus().value());
-        this->SetExitCode(this->PrevErrorExitCode());
-      } else {
-        this->SetStatus(crane::grpc::JobStatus::Completed);
-        this->SetExitCode(exit_code);
-      }
-
-      CRANE_INFO("[Step #{}.{}] FINISHED with status {}.", job_id, step_id,
-                 this->Status());
+    // FreeSteps for ALL execution nodes (step-level cleanup)
+    for (const auto& node : this->ExecutionNodes()) {
+      context->craned_step_free_map[node][job_id].insert(step_id);
     }
 
+    // Primary step: also cancel other running common steps
+    if (this->IsPrimaryStep()) {
+      std::unordered_set<step_id_t> pd_steps;
+      CRANE_DEBUG("[Job #{}] primary step completing, terminating other steps.",
+                  job_id);
+      const absl::Time cancel_time =
+          absl::FromUnixSeconds(timestamp.seconds()) +
+          absl::Nanoseconds(timestamp.nanos());
+      for (const auto& comm_step : job->Steps() | std::views::values) {
+        if (comm_step->Status() == crane::grpc::JobStatus::Pending) {
+          comm_step->SetStatus(crane::grpc::Cancelled);
+          comm_step->SetStartTime(cancel_time);
+          comm_step->SetEndTime(cancel_time);
+          if (comm_step->ia_meta.has_value()) {
+            auto& meta = comm_step->ia_meta.value();
+            if (!meta.has_been_cancelled_on_front_end) {
+              meta.has_been_cancelled_on_front_end = true;
+              meta.cb_step_cancel({.job_id = comm_step->job_id,
+                                   .step_id = comm_step->StepId()});
+            }
+            meta.cb_step_completed({.job_id = comm_step->job_id,
+                                    .step_id = comm_step->StepId(),
+                                    .send_completion_ack = true,
+                                    .cfored_name = meta.cfored_name});
+          }
+          pd_steps.insert(comm_step->StepId());
+        } else {
+          for (const auto& node : comm_step->ExecutionNodes()) {
+            context->craned_cancel_steps[node][comm_step->job_id].emplace(
+                comm_step->StepId());
+          }
+        }
+      }
+      for (const auto& pd_step_id : pd_steps) {
+        auto pd_step = job->EraseStep(pd_step_id);
+        context->step_raw_ptrs.insert(pd_step.get());
+        context->step_ptrs.insert(std::move(pd_step));
+      }
+    }
+    context->rn_step_raw_ptrs.insert(this);
+  }
+
+  // AllNodesFinished (terminal from all nodes = step-level cleanup done).
+  // Release step. Primary additionally triggers FreeJobs for job-level cleanup.
+  if (step_finished) {
+    this->SetEndTime(absl::FromUnixSeconds(timestamp.seconds()) +
+                     absl::Nanoseconds(timestamp.nanos()));
+    if (this->PrevErrorStatus().has_value()) {
+      this->SetStatus(this->PrevErrorStatus().value());
+      this->SetExitCode(this->PrevErrorExitCode());
+    } else {
+      this->SetStatus(crane::grpc::JobStatus::Completed);
+      this->SetExitCode(exit_code);
+    }
+    CRANE_INFO("[Step #{}.{}] FINISHED with status {}.", job_id, step_id,
+               this->Status());
+
+    // Primary step: trigger FreeJobs for daemon step (job-level cleanup).
+    // Don't manually set daemon step to Completing — FreeJobs sends
+    // ShutdownSupervisor to daemon supervisor, which will send Completing
+    // on its own via the normal two-phase flow.
+    if (this->IsPrimaryStep()) {
+      for (const auto& node : job->DaemonStep()->CranedIds()) {
+        context->craned_jobs_to_free[node].emplace_back(job->JobId());
+      }
+    }
+
+    // Release step
     context->step_raw_ptrs.insert(this);
     if (this->IsPrimaryStep()) {
       job->SetPrimaryStepStatus(this->Status());
-      job->SetPrimaryStepExitCode(exit_code);
+      job->SetPrimaryStepExitCode(this->ExitCode());
       context->rn_job_raw_ptrs.insert(job);
       context->step_ptrs.emplace(job->ReleasePrimaryStep());
     } else {
       context->step_ptrs.insert(job->EraseStep(step_id));
     }
   }
+
   if (job->AllStepsFinished())
     return std::make_pair(job->PrimaryStepStatus(), job->PrimaryStepExitCode());
   else

--- a/src/CraneCtld/CtldPublicDefs.cpp
+++ b/src/CraneCtld/CtldPublicDefs.cpp
@@ -1364,6 +1364,10 @@ CommonStepInCtld::StepStatusChange(crane::grpc::JobStatus new_status,
                                     .cfored_name = meta.cfored_name});
           }
           pd_steps.insert(comm_step->StepId());
+        } else if (IsFinishedStepStatus(comm_step->Status()) ||
+                   comm_step->Status() ==
+                       crane::grpc::JobStatus::Completing) {
+          continue;
         } else {
           for (const auto& node : comm_step->ExecutionNodes()) {
             context->craned_cancel_steps[node][comm_step->job_id].emplace(

--- a/src/CraneCtld/CtldPublicDefs.h
+++ b/src/CraneCtld/CtldPublicDefs.h
@@ -532,10 +532,6 @@ struct StepStatusChangeContext {
   std::unordered_map<CranedId,
                      std::unordered_map<job_id_t, std::set<step_id_t>>>
       craned_step_exec_map;
-  // Error steps to terminate with orphaned status
-  std::unordered_map<CranedId,
-                     std::unordered_map<job_id_t, std::set<step_id_t>>>
-      craned_orphaned_steps{};
   // Common step to cancel, caused by a finished primary step
   std::unordered_map<CranedId,
                      std::unordered_map<job_id_t, std::set<step_id_t>>>
@@ -620,6 +616,7 @@ struct StepInCtld {
 
   std::unordered_set<CranedId> m_configuring_nodes_;
   std::unordered_set<CranedId> m_running_nodes_;
+  std::unordered_set<CranedId> m_completing_nodes_;
 
   // If this job is PENDING, start_time is either not set (default constructed)
   // or an estimated start time.
@@ -695,6 +692,9 @@ struct StepInCtld {
   }
   void StepOnNodeFinish(const CranedId& node);
   bool AllNodesFinished() const { return m_running_nodes_.empty(); }
+
+  void StepOnNodeCompleting(const CranedId& node);
+  bool AllNodesCompleting() const;
 
   void SetSubmitTime(absl::Time submit_time);
   absl::Time SubmitTime() const { return m_submit_time_; }

--- a/src/CraneCtld/Database/DbClient.cpp
+++ b/src/CraneCtld/Database/DbClient.cpp
@@ -771,19 +771,21 @@ bool MongodbClient::FetchJobRecords(
             job_info.mutable_req_total_res_view();
         mutable_req_total_res_view->set_cpu_count(static_cast<double>(
             cpu_t::from_raw_value(view["cpus_req"].get_int64().value)));
+        auto mem_req = ViewGetArithmeticValue_<uint64_t>(view["mem_req"]);
         mutable_req_total_res_view->set_memory_bytes(
-            view["mem_req"].get_int64().value);
+            mem_req);
         mutable_req_total_res_view->set_memory_sw_bytes(
-            view["mem_req"].get_int64().value);
+            mem_req);
 
         auto* mutable_allocated_res_view =
             job_info.mutable_allocated_res_view();
         mutable_allocated_res_view->set_cpu_count(static_cast<double>(
             cpu_t::from_raw_value(view["cpus_alloc"].get_int64().value)));
+        auto mem_alloc = ViewGetArithmeticValue_<uint64_t>(view["mem_alloc"]);
         mutable_allocated_res_view->set_memory_bytes(
-            view["mem_alloc"].get_int64().value);
+            mem_alloc);
         mutable_allocated_res_view->set_memory_sw_bytes(
-            view["mem_alloc"].get_int64().value);
+            mem_alloc);
         auto* gres_map_ptr = mutable_allocated_res_view->mutable_gres_map();
         *gres_map_ptr = ToGrpcGresMap(
             BsonToGresMap(view["device_map"].get_document().value));
@@ -5184,6 +5186,8 @@ bool MongodbClient::MigrateV0ToV1_() {
         kvp("exclude_nodes",
             make_document(
                 kvp("$ifNull", make_array("$exclude_nodes", make_array())))),
+        kvp("submit_hostname",
+            make_document(kvp("$ifNull", make_array("$submit_hostname", "")))),
         kvp("execution_nodes",
             make_document(kvp("$ifNull",
                               make_array("$execution_nodes", make_array()))))));

--- a/src/CraneCtld/Database/DbClient.cpp
+++ b/src/CraneCtld/Database/DbClient.cpp
@@ -772,20 +772,16 @@ bool MongodbClient::FetchJobRecords(
         mutable_req_total_res_view->set_cpu_count(static_cast<double>(
             cpu_t::from_raw_value(view["cpus_req"].get_int64().value)));
         auto mem_req = ViewGetArithmeticValue_<uint64_t>(view["mem_req"]);
-        mutable_req_total_res_view->set_memory_bytes(
-            mem_req);
-        mutable_req_total_res_view->set_memory_sw_bytes(
-            mem_req);
+        mutable_req_total_res_view->set_memory_bytes(mem_req);
+        mutable_req_total_res_view->set_memory_sw_bytes(mem_req);
 
         auto* mutable_allocated_res_view =
             job_info.mutable_allocated_res_view();
         mutable_allocated_res_view->set_cpu_count(static_cast<double>(
             cpu_t::from_raw_value(view["cpus_alloc"].get_int64().value)));
         auto mem_alloc = ViewGetArithmeticValue_<uint64_t>(view["mem_alloc"]);
-        mutable_allocated_res_view->set_memory_bytes(
-            mem_alloc);
-        mutable_allocated_res_view->set_memory_sw_bytes(
-            mem_alloc);
+        mutable_allocated_res_view->set_memory_bytes(mem_alloc);
+        mutable_allocated_res_view->set_memory_sw_bytes(mem_alloc);
         auto* gres_map_ptr = mutable_allocated_res_view->mutable_gres_map();
         *gres_map_ptr = ToGrpcGresMap(
             BsonToGresMap(view["device_map"].get_document().value));

--- a/src/CraneCtld/Database/DbClient.cpp
+++ b/src/CraneCtld/Database/DbClient.cpp
@@ -1196,12 +1196,16 @@ bool MongodbClient::InsertSteps(const std::unordered_set<StepInCtld*>& steps) {
       filter.append(kvp("job_id", static_cast<int32_t>(job_id)));
 
       // Combine $push and $setOnInsert
-      // $push: append steps to existing document
+      // $push: append steps to existing document, sorted by step_id
       // $setOnInsert: create minimal document if it doesn't exist
       document update_doc;
       update_doc.append(kvp("$push", [&steps_array](sub_document push_doc) {
         push_doc.append(kvp("steps", [&steps_array](sub_document each_doc) {
           each_doc.append(kvp("$each", steps_array));
+          each_doc.append(
+              kvp("$sort", [](sub_document sort_doc) {
+                sort_doc.append(kvp("step_id", 1));
+              }));
         }));
       }));
       update_doc.append(

--- a/src/CraneCtld/Database/DbClient.cpp
+++ b/src/CraneCtld/Database/DbClient.cpp
@@ -1202,10 +1202,9 @@ bool MongodbClient::InsertSteps(const std::unordered_set<StepInCtld*>& steps) {
       update_doc.append(kvp("$push", [&steps_array](sub_document push_doc) {
         push_doc.append(kvp("steps", [&steps_array](sub_document each_doc) {
           each_doc.append(kvp("$each", steps_array));
-          each_doc.append(
-              kvp("$sort", [](sub_document sort_doc) {
-                sort_doc.append(kvp("step_id", 1));
-              }));
+          each_doc.append(kvp("$sort", [](sub_document sort_doc) {
+            sort_doc.append(kvp("step_id", 1));
+          }));
         }));
       }));
       update_doc.append(

--- a/src/CraneCtld/DbClient.cpp
+++ b/src/CraneCtld/DbClient.cpp
@@ -771,19 +771,21 @@ bool MongodbClient::FetchJobRecords(
             job_info.mutable_req_total_res_view();
         mutable_req_total_res_view->set_cpu_count(static_cast<double>(
             cpu_t::from_raw_value(view["cpus_req"].get_int64().value)));
+        auto mem_req = ViewGetArithmeticValue_<uint64_t>(view["mem_req"]);
         mutable_req_total_res_view->set_memory_bytes(
-            view["mem_req"].get_int64().value);
+            mem_req);
         mutable_req_total_res_view->set_memory_sw_bytes(
-            view["mem_req"].get_int64().value);
+            mem_req);
 
         auto* mutable_allocated_res_view =
             job_info.mutable_allocated_res_view();
         mutable_allocated_res_view->set_cpu_count(static_cast<double>(
             cpu_t::from_raw_value(view["cpus_alloc"].get_int64().value)));
+        auto mem_alloc = ViewGetArithmeticValue_<uint64_t>(view["mem_alloc"]);
         mutable_allocated_res_view->set_memory_bytes(
-            view["mem_alloc"].get_int64().value);
+            mem_alloc);
         mutable_allocated_res_view->set_memory_sw_bytes(
-            view["mem_alloc"].get_int64().value);
+            mem_alloc);
         auto* gres_map_ptr = mutable_allocated_res_view->mutable_gres_map();
         *gres_map_ptr = ToGrpcGresMap(
             BsonToGresMap(view["device_map"].get_document().value));
@@ -5184,6 +5186,8 @@ bool MongodbClient::MigrateV0ToV1_() {
         kvp("exclude_nodes",
             make_document(
                 kvp("$ifNull", make_array("$exclude_nodes", make_array())))),
+        kvp("submit_hostname",
+            make_document(kvp("$ifNull", make_array("$submit_hostname", "")))),
         kvp("execution_nodes",
             make_document(kvp("$ifNull",
                               make_array("$execution_nodes", make_array()))))));

--- a/src/CraneCtld/DbClient.cpp
+++ b/src/CraneCtld/DbClient.cpp
@@ -772,20 +772,16 @@ bool MongodbClient::FetchJobRecords(
         mutable_req_total_res_view->set_cpu_count(static_cast<double>(
             cpu_t::from_raw_value(view["cpus_req"].get_int64().value)));
         auto mem_req = ViewGetArithmeticValue_<uint64_t>(view["mem_req"]);
-        mutable_req_total_res_view->set_memory_bytes(
-            mem_req);
-        mutable_req_total_res_view->set_memory_sw_bytes(
-            mem_req);
+        mutable_req_total_res_view->set_memory_bytes(mem_req);
+        mutable_req_total_res_view->set_memory_sw_bytes(mem_req);
 
         auto* mutable_allocated_res_view =
             job_info.mutable_allocated_res_view();
         mutable_allocated_res_view->set_cpu_count(static_cast<double>(
             cpu_t::from_raw_value(view["cpus_alloc"].get_int64().value)));
         auto mem_alloc = ViewGetArithmeticValue_<uint64_t>(view["mem_alloc"]);
-        mutable_allocated_res_view->set_memory_bytes(
-            mem_alloc);
-        mutable_allocated_res_view->set_memory_sw_bytes(
-            mem_alloc);
+        mutable_allocated_res_view->set_memory_bytes(mem_alloc);
+        mutable_allocated_res_view->set_memory_sw_bytes(mem_alloc);
         auto* gres_map_ptr = mutable_allocated_res_view->mutable_gres_map();
         *gres_map_ptr = ToGrpcGresMap(
             BsonToGresMap(view["device_map"].get_document().value));

--- a/src/CraneCtld/JobScheduler.cpp
+++ b/src/CraneCtld/JobScheduler.cpp
@@ -175,7 +175,10 @@ bool JobScheduler::Init() {
       auto result = AcquireJobAttributes(job.get());
       if (!result || job->type == crane::grpc::Interactive) {
         job->SetStatus(crane::grpc::Failed);
-        job->SetEndTime(absl::Now());
+        auto now = absl::Now();
+        auto max_end_time = job->StartTime() + job->time_limit;
+        auto end_time = std::min(now, max_end_time);
+        job->SetEndTime(end_time);
         ok = g_embedded_db_client->UpdateRuntimeAttrOfJob(0, job_db_id,
                                                           job->RuntimeAttr());
         if (!ok) {
@@ -4634,28 +4637,6 @@ void JobScheduler::CleanJobStatusChangeQueueCb_() {
     });
   }
 
-  std::latch orphaned_step_latch{
-      static_cast<std::ptrdiff_t>(context.craned_orphaned_steps.size())};
-  for (const auto& craned_id :
-       context.craned_orphaned_steps | std::views::keys) {
-    m_rpc_worker_pool_->detach_task(
-        [&orphaned_step_latch, craned_id, &context]() {
-          auto stub = g_craned_keeper->GetCranedStub(craned_id);
-
-          // If the craned is down, just ignore it.
-          if (stub && !stub->Invalid()) {
-            const auto& steps = context.craned_orphaned_steps.at(craned_id);
-            auto err = stub->TerminateOrphanedSteps(steps);
-            if (err != CraneErrCode::SUCCESS) {
-              CRANE_ERROR(
-                  "Failed to TerminateOrphanedSteps for [{}] jobs on Node {}",
-                  util::JobStepsToString(steps), craned_id);
-            }
-          }
-          orphaned_step_latch.count_down();
-        });
-  }
-
   std::latch cancel_step_latch{
       static_cast<std::ptrdiff_t>(context.craned_cancel_steps.size())};
   for (const auto& craned_id : context.craned_cancel_steps | std::views::keys) {
@@ -4709,7 +4690,6 @@ void JobScheduler::CleanJobStatusChangeQueueCb_() {
   alloc_step_latch.wait();
   free_step_latch.wait();
   exec_step_latch.wait();
-  orphaned_step_latch.wait();
   cancel_step_latch.wait();
   free_job_latch.wait();
 
@@ -5067,13 +5047,12 @@ void JobScheduler::QueryRnJobOnCtldForNodeConfig(
   }
 }
 
-void JobScheduler::TerminateOrphanedSteps(
+void JobScheduler::TerminateStepsOnOtherNodes(
     const std::unordered_map<job_id_t, std::set<step_id_t>>& steps,
     const CranedId& excluded_node) {
-  CRANE_INFO("Terminate orphaned steps: [{}] synced by {}.",
+  CRANE_INFO("Terminate steps on other nodes: [{}] excluding {}.",
              util::JobStepsToString(steps), excluded_node);
 
-  // Now we just terminate all jobs.
   std::unordered_map<CranedId,
                      std::unordered_map<job_id_t, std::set<step_id_t>>>
       craned_steps_map;
@@ -5119,9 +5098,9 @@ void JobScheduler::TerminateOrphanedSteps(
         [craned_id, node_job_steps = std::move(craned_steps)] {
           auto stub = g_craned_keeper->GetCranedStub(craned_id);
           if (stub && !stub->Invalid()) {
-            if (auto err = stub->TerminateOrphanedSteps(node_job_steps);
+            if (auto err = stub->TerminateSteps(node_job_steps);
                 err != CraneErrCode::SUCCESS) {
-              CRANE_ERROR("Failed to terminate orphaned steps [{}] on node {}.",
+              CRANE_ERROR("Failed to terminate steps [{}] on node {}.",
                           util::JobStepsToString(node_job_steps), craned_id);
             }
           }

--- a/src/CraneCtld/JobScheduler.cpp
+++ b/src/CraneCtld/JobScheduler.cpp
@@ -175,7 +175,10 @@ bool JobScheduler::Init() {
       auto result = AcquireJobAttributes(job.get());
       if (!result || job->type == crane::grpc::Interactive) {
         job->SetStatus(crane::grpc::Failed);
-        job->SetEndTime(absl::Now());
+        auto now = absl::Now();
+        auto max_end_time = job->StartTime() + job->time_limit;
+        auto end_time = std::min(now, max_end_time);
+        job->SetEndTime(end_time);
         ok = g_embedded_db_client->UpdateRuntimeAttrOfJob(0, job_db_id,
                                                           job->RuntimeAttr());
         if (!ok) {
@@ -4633,28 +4636,6 @@ void JobScheduler::CleanJobStatusChangeQueueCb_() {
     });
   }
 
-  std::latch orphaned_step_latch{
-      static_cast<std::ptrdiff_t>(context.craned_orphaned_steps.size())};
-  for (const auto& craned_id :
-       context.craned_orphaned_steps | std::views::keys) {
-    m_rpc_worker_pool_->detach_task(
-        [&orphaned_step_latch, craned_id, &context]() {
-          auto stub = g_craned_keeper->GetCranedStub(craned_id);
-
-          // If the craned is down, just ignore it.
-          if (stub && !stub->Invalid()) {
-            const auto& steps = context.craned_orphaned_steps.at(craned_id);
-            auto err = stub->TerminateOrphanedSteps(steps);
-            if (err != CraneErrCode::SUCCESS) {
-              CRANE_ERROR(
-                  "Failed to TerminateOrphanedSteps for [{}] jobs on Node {}",
-                  util::JobStepsToString(steps), craned_id);
-            }
-          }
-          orphaned_step_latch.count_down();
-        });
-  }
-
   std::latch cancel_step_latch{
       static_cast<std::ptrdiff_t>(context.craned_cancel_steps.size())};
   for (const auto& craned_id : context.craned_cancel_steps | std::views::keys) {
@@ -4708,7 +4689,6 @@ void JobScheduler::CleanJobStatusChangeQueueCb_() {
   alloc_step_latch.wait();
   free_step_latch.wait();
   exec_step_latch.wait();
-  orphaned_step_latch.wait();
   cancel_step_latch.wait();
   free_job_latch.wait();
 
@@ -5066,13 +5046,12 @@ void JobScheduler::QueryRnJobOnCtldForNodeConfig(
   }
 }
 
-void JobScheduler::TerminateOrphanedSteps(
+void JobScheduler::TerminateStepsOnOtherNodes(
     const std::unordered_map<job_id_t, std::set<step_id_t>>& steps,
     const CranedId& excluded_node) {
-  CRANE_INFO("Terminate orphaned steps: [{}] synced by {}.",
+  CRANE_INFO("Terminate steps on other nodes: [{}] excluding {}.",
              util::JobStepsToString(steps), excluded_node);
 
-  // Now we just terminate all jobs.
   std::unordered_map<CranedId,
                      std::unordered_map<job_id_t, std::set<step_id_t>>>
       craned_steps_map;
@@ -5118,9 +5097,9 @@ void JobScheduler::TerminateOrphanedSteps(
         [craned_id, node_job_steps = std::move(craned_steps)] {
           auto stub = g_craned_keeper->GetCranedStub(craned_id);
           if (stub && !stub->Invalid()) {
-            if (auto err = stub->TerminateOrphanedSteps(node_job_steps);
+            if (auto err = stub->TerminateSteps(node_job_steps);
                 err != CraneErrCode::SUCCESS) {
-              CRANE_ERROR("Failed to terminate orphaned steps [{}] on node {}.",
+              CRANE_ERROR("Failed to terminate steps [{}] on node {}.",
                           util::JobStepsToString(node_job_steps), craned_id);
             }
           }

--- a/src/CraneCtld/JobScheduler.h
+++ b/src/CraneCtld/JobScheduler.h
@@ -837,7 +837,7 @@ class JobScheduler {
   void QueryRnJobOnCtldForNodeConfig(const CranedId& craned_id,
                                      crane::grpc::ConfigureCranedRequest* req);
 
-  void TerminateOrphanedSteps(
+  void TerminateStepsOnOtherNodes(
       const std::unordered_map<job_id_t, std::set<step_id_t>>& steps,
       const CranedId& excluded_node);
 
@@ -878,6 +878,7 @@ class JobScheduler {
     CommonStepInCtld* step;
     auto& job = rn_it->second;
     step = job->GetStep(step_id);
+    auto terminati_source = crane::grpc::TERMINATE_SOURCE_USER_CANCEL;
     if (step) {
       if (step->type == crane::grpc::Interactive) {
         auto& meta = step->ia_meta.value();
@@ -890,7 +891,7 @@ class JobScheduler {
           m_cancel_job_async_handle_->send();
           return CraneErrCode::SUCCESS;
         }
-        auto terminate_source =
+        terminate_source =
             cancelled_on_front_end
                 ? crane::grpc::TERMINATE_SOURCE_USER_CANCEL
                 : crane::grpc::TERMINATE_SOURCE_NORMAL_COMPLETION;
@@ -901,6 +902,10 @@ class JobScheduler {
     } else {
       return CraneErrCode::ERR_NON_EXISTENT;
     }
+    if (step->Status() == crane::grpc::JobStatus::Running)
+      return TerminateRunningStepNoLock_(step,terminati_source);
+    else
+      return CraneErrCode::ERR_INVALID_PARAM;
   }
 
   CraneErrCode TerminateRunningStep(

--- a/src/CraneCtld/JobScheduler.h
+++ b/src/CraneCtld/JobScheduler.h
@@ -878,7 +878,7 @@ class JobScheduler {
     CommonStepInCtld* step;
     auto& job = rn_it->second;
     step = job->GetStep(step_id);
-    auto terminati_source = crane::grpc::TERMINATE_SOURCE_USER_CANCEL;
+    auto terminate_source = crane::grpc::TERMINATE_SOURCE_USER_CANCEL;
     if (step) {
       if (step->type == crane::grpc::Interactive) {
         auto& meta = step->ia_meta.value();
@@ -895,17 +895,17 @@ class JobScheduler {
             cancelled_on_front_end
                 ? crane::grpc::TERMINATE_SOURCE_USER_CANCEL
                 : crane::grpc::TERMINATE_SOURCE_NORMAL_COMPLETION;
-        return TerminateRunningStepNoLock_(step, terminate_source);
+
+        if (step->Status() == crane::grpc::JobStatus::Running)
+          return TerminateRunningStepNoLock_(step, terminate_source);
+        else
+          return CraneErrCode::ERR_INVALID_PARAM;
       } else {
         return CraneErrCode::ERR_INVALID_PARAM;
       }
     } else {
       return CraneErrCode::ERR_NON_EXISTENT;
     }
-    if (step->Status() == crane::grpc::JobStatus::Running)
-      return TerminateRunningStepNoLock_(step,terminati_source);
-    else
-      return CraneErrCode::ERR_INVALID_PARAM;
   }
 
   CraneErrCode TerminateRunningStep(

--- a/src/CraneCtld/JobScheduler.h
+++ b/src/CraneCtld/JobScheduler.h
@@ -879,7 +879,7 @@ class JobScheduler {
     CommonStepInCtld* step;
     auto& job = rn_it->second;
     step = job->GetStep(step_id);
-    auto terminati_source = crane::grpc::TERMINATE_SOURCE_USER_CANCEL;
+    auto terminate_source = crane::grpc::TERMINATE_SOURCE_USER_CANCEL;
     if (step) {
       if (step->type == crane::grpc::Interactive) {
         auto& meta = step->ia_meta.value();
@@ -896,17 +896,17 @@ class JobScheduler {
             cancelled_on_front_end
                 ? crane::grpc::TERMINATE_SOURCE_USER_CANCEL
                 : crane::grpc::TERMINATE_SOURCE_NORMAL_COMPLETION;
-        return TerminateRunningStepNoLock_(step, terminate_source);
+
+        if (step->Status() == crane::grpc::JobStatus::Running)
+          return TerminateRunningStepNoLock_(step, terminate_source);
+        else
+          return CraneErrCode::ERR_INVALID_PARAM;
       } else {
         return CraneErrCode::ERR_INVALID_PARAM;
       }
     } else {
       return CraneErrCode::ERR_NON_EXISTENT;
     }
-    if (step->Status() == crane::grpc::JobStatus::Running)
-      return TerminateRunningStepNoLock_(step,terminati_source);
-    else
-      return CraneErrCode::ERR_INVALID_PARAM;
   }
 
   CraneErrCode TerminateRunningStep(

--- a/src/CraneCtld/JobScheduler.h
+++ b/src/CraneCtld/JobScheduler.h
@@ -838,7 +838,7 @@ class JobScheduler {
   void QueryRnJobOnCtldForNodeConfig(const CranedId& craned_id,
                                      crane::grpc::ConfigureCranedRequest* req);
 
-  void TerminateOrphanedSteps(
+  void TerminateStepsOnOtherNodes(
       const std::unordered_map<job_id_t, std::set<step_id_t>>& steps,
       const CranedId& excluded_node);
 
@@ -879,6 +879,7 @@ class JobScheduler {
     CommonStepInCtld* step;
     auto& job = rn_it->second;
     step = job->GetStep(step_id);
+    auto terminati_source = crane::grpc::TERMINATE_SOURCE_USER_CANCEL;
     if (step) {
       if (step->type == crane::grpc::Interactive) {
         auto& meta = step->ia_meta.value();
@@ -891,7 +892,7 @@ class JobScheduler {
           m_cancel_job_async_handle_->send();
           return CraneErrCode::SUCCESS;
         }
-        auto terminate_source =
+        terminate_source =
             cancelled_on_front_end
                 ? crane::grpc::TERMINATE_SOURCE_USER_CANCEL
                 : crane::grpc::TERMINATE_SOURCE_NORMAL_COMPLETION;
@@ -902,6 +903,10 @@ class JobScheduler {
     } else {
       return CraneErrCode::ERR_NON_EXISTENT;
     }
+    if (step->Status() == crane::grpc::JobStatus::Running)
+      return TerminateRunningStepNoLock_(step,terminati_source);
+    else
+      return CraneErrCode::ERR_INVALID_PARAM;
   }
 
   CraneErrCode TerminateRunningStep(

--- a/src/CraneCtld/RpcService/CranedKeeper.cpp
+++ b/src/CraneCtld/RpcService/CranedKeeper.cpp
@@ -100,40 +100,6 @@ CraneErrCode CranedStub::TerminateSteps(
   return CraneErrCode::SUCCESS;
 }
 
-CraneErrCode CranedStub::TerminateOrphanedSteps(
-    const std::unordered_map<job_id_t, std::set<step_id_t>> &steps) {
-  using crane::grpc::TerminateOrphanedStepReply;
-  using crane::grpc::TerminateOrphanedStepRequest;
-
-  ClientContext context;
-  Status status;
-  TerminateOrphanedStepRequest request;
-  TerminateOrphanedStepReply reply;
-  context.set_deadline(std::chrono::system_clock::now() +
-                       std::chrono::seconds(kCtldRpcTimeoutSeconds));
-
-  auto &job_step_map = *request.mutable_job_step_ids_map();
-
-  for (const auto &[job_id, step_ids] : steps) {
-    job_step_map[job_id].mutable_steps()->Assign(step_ids.begin(),
-                                                 step_ids.end());
-  }
-  status = m_stub_->TerminateOrphanedStep(&context, request, &reply);
-  if (!status.ok()) {
-    CRANE_DEBUG(
-        "TerminateOrphanedJobs RPC for Node {} returned status not ok: {}",
-        m_craned_id_, status.error_message());
-    HandleGrpcErrorCode_(status.error_code());
-    return CraneErrCode::ERR_RPC_FAILURE;
-  }
-  UpdateLastActiveTime();
-
-  if (reply.ok())
-    return CraneErrCode::SUCCESS;
-  else
-    return CraneErrCode::ERR_GENERIC_FAILURE;
-}
-
 CraneErrCode CranedStub::AllocJobs(
     const std::vector<crane::grpc::JobToD> &jobs) {
   using crane::grpc::AllocJobsReply;

--- a/src/CraneCtld/RpcService/CranedKeeper.h
+++ b/src/CraneCtld/RpcService/CranedKeeper.h
@@ -88,9 +88,6 @@ class CranedStub {
       crane::grpc::TerminateSource terminate_source =
           crane::grpc::TERMINATE_SOURCE_USER_CANCEL);
 
-  CraneErrCode TerminateOrphanedSteps(
-      const std::unordered_map<job_id_t, std::set<step_id_t>> &steps);
-
   CraneErrCode ChangeJobTimeConstraint(
       uint32_t job_id, std::optional<int64_t> time_limit_seconds,
       std::optional<int64_t> deadline_time);

--- a/src/CraneCtld/RpcService/CtldGrpcServer.cpp
+++ b/src/CraneCtld/RpcService/CtldGrpcServer.cpp
@@ -143,16 +143,24 @@ grpc::Status CtldForInternalServiceImpl::CranedRegister(
              util::JobStepsToString(orphaned_steps));
   if (!orphaned_steps.empty()) {
     auto now = google::protobuf::util::TimeUtil::GetCurrentTime();
-    g_job_scheduler->TerminateOrphanedSteps(orphaned_steps,
-                                            request->craned_id());
+    // Terminate steps on other alive nodes (normal cancel flow)
+    g_job_scheduler->TerminateStepsOnOtherNodes(orphaned_steps,
+                                                request->craned_id());
+    // For the crashed node: send synthetic Completing + Terminal
+    // (two independent events, not "terminal implies completing")
     for (const auto& [job_id, steps] : orphaned_steps) {
-      // Reverse order: we should process larger step_id first to avoid warnings
-      // abort daemon/primary steps
-      for (const auto step_id : steps | std::views::reverse)
+      for (const auto step_id : steps | std::views::reverse) {
+        // Synthetic Completing → drives AllNodesCompleting → FreeSteps
+        g_job_scheduler->StepStatusChangeWithReasonAsync(
+            job_id, step_id, request->craned_id(),
+            crane::grpc::JobStatus::Completing, ExitCode::EC_CRANED_DOWN,
+            "Craned re-registered but step lost.", now);
+        // Synthetic Terminal → drives AllNodesFinished → release/FreeJobs
         g_job_scheduler->StepStatusChangeWithReasonAsync(
             job_id, step_id, request->craned_id(),
             crane::grpc::JobStatus::Failed, ExitCode::EC_CRANED_DOWN,
             "Craned re-registered but step lost.", now);
+      }
     }
   }
 

--- a/src/Craned/Common/CgroupManager.cpp
+++ b/src/Craned/Common/CgroupManager.cpp
@@ -548,7 +548,7 @@ CgroupManager::AllocateAndGetCgroup(
       return cg_unique_ptr;
     }
     auto *cg_v2_ptr = dynamic_cast<CgroupV2 *>(cg_unique_ptr.get());
-    cg_v2_ptr->RecoverFromResInNode(resource);
+    cg_v2_ptr->RecoverFromCgSpec(resource);
 #endif
 
     return cg_unique_ptr;

--- a/src/Craned/Core/CranedPublicDefs.h
+++ b/src/Craned/Core/CranedPublicDefs.h
@@ -58,6 +58,7 @@ struct StepStatusChangeQueueElem {
   crane::grpc::JobStatus new_status{};
   uint32_t exit_code{};
   std::optional<std::string> reason;
+  std::optional<crane::grpc::JobStatus> final_status;
   google::protobuf::Timestamp timestamp;
 };
 

--- a/src/Craned/Core/CranedServer.cpp
+++ b/src/Craned/Core/CranedServer.cpp
@@ -86,30 +86,7 @@ grpc::Status CranedServiceImpl::TerminateSteps(
   return Status::OK;
 }
 
-grpc::Status CranedServiceImpl::TerminateOrphanedStep(
-    grpc::ServerContext *context,
-    const crane::grpc::TerminateOrphanedStepRequest *request,
-    crane::grpc::TerminateOrphanedStepReply *response) {
-  if (!g_server->ReadyFor(RequestSource::CTLD)) {
-    CRANE_ERROR("CranedServer is not ready.");
-    response->set_reason("CranedServer is not ready");
-    return Status{grpc::StatusCode::UNAVAILABLE, "CranedServer is not ready"};
-  }
-  std::unordered_map<job_id_t, std::unordered_set<step_id_t>> job_steps_map;
-  for (const auto &[job_id, steps] : request->job_step_ids_map()) {
-    job_steps_map[job_id].insert(steps.steps().begin(), steps.steps().end());
-  }
-  CRANE_TRACE("Receive TerminateOrphanedStep for steps [{}]",
-              util::JobStepsToString(job_steps_map));
-
-  for (const auto [job_id, steps] : job_steps_map)
-    for (const auto step_id : steps)
-      g_job_mgr->MarkStepAsOrphanedAndTerminateAsync(job_id, step_id);
-
-  response->set_ok(true);
-
-  return Status::OK;
-}
+// TerminateOrphanedStep removed: all cleanup goes through FreeJobs.
 
 grpc::Status CranedServiceImpl::QueryStepFromPort(
     grpc::ServerContext *context,
@@ -572,9 +549,12 @@ grpc::Status CranedServiceImpl::StepStatusChange(
     response->set_ok(false);
     return Status{grpc::StatusCode::UNAVAILABLE, "CranedServer is not ready"};
   }
+  std::optional<crane::grpc::JobStatus> final_status;
+  if (request->has_final_status()) final_status = request->final_status();
   g_job_mgr->StepStatusChangeAsync(request->job_id(), request->step_id(),
                                    request->new_status(), request->exit_code(),
-                                   request->reason(), request->timestamp());
+                                   request->reason(), final_status,
+                                   request->timestamp());
   response->set_ok(true);
   return Status::OK;
 }

--- a/src/Craned/Core/CranedServer.h
+++ b/src/Craned/Core/CranedServer.h
@@ -63,11 +63,6 @@ class CranedServiceImpl : public Craned::Service {
       const crane::grpc::TerminateStepsRequest *request,
       crane::grpc::TerminateStepsReply *response) override;
 
-  grpc::Status TerminateOrphanedStep(
-      grpc::ServerContext *context,
-      const crane::grpc::TerminateOrphanedStepRequest *request,
-      crane::grpc::TerminateOrphanedStepReply *response) override;
-
   grpc::Status QueryStepFromPort(
       grpc::ServerContext *context,
       const crane::grpc::QueryStepFromPortRequest *request,

--- a/src/Craned/Core/CtldClient.cpp
+++ b/src/Craned/Core/CtldClient.cpp
@@ -707,10 +707,18 @@ void CtldClient::Init() {
         if (!invalid_steps.empty()) {
           CRANE_INFO("Terminating invalid steps (not tracked by Ctld): [{}].",
                      util::JobStepsToString(invalid_steps));
-          for (auto [job_id, steps] : invalid_steps) {
-            for (auto step_id : steps)
-              g_job_mgr->MarkStepAsOrphanedAndTerminateAsync(job_id, step_id);
+          // Mark as silent cleanup (no status forwarded to CraneCtld),
+          // then FreeSteps triggers CleanUpJobAndStepsAsync which
+          // terminates supervisors and waits for exit via timer.
+          std::unordered_map<job_id_t, std::unordered_set<step_id_t>>
+              steps_to_free;
+          for (auto& [job_id, steps] : invalid_steps) {
+            for (auto step_id : steps) {
+              g_job_mgr->MarkStepSilentCleanup(job_id, step_id);
+              steps_to_free[job_id].insert(step_id);
+            }
           }
+          g_job_mgr->FreeSteps(std::move(steps_to_free));
         }
         if (!invalid_jobs.empty()) {
           CRANE_INFO("Freeing invalid jobs: [{}].",
@@ -1016,6 +1024,8 @@ bool CtldClient::SendStatusChanges_(
     *request.mutable_timestamp() = status_change.timestamp;
     if (status_change.reason.has_value())
       request.set_reason(status_change.reason.value());
+    if (status_change.final_status.has_value())
+      request.set_final_status(status_change.final_status.value());
 
     status = m_stub_->StepStatusChange(&context, request, &reply);
     if (!status.ok()) {

--- a/src/Craned/Core/JobManager.cpp
+++ b/src/Craned/Core/JobManager.cpp
@@ -453,13 +453,10 @@ bool JobManager::FreeJobs(std::set<job_id_t>&& job_ids) {
           "daemon step",
           job_id);
       // Free job implicitly free its daemon step and got a status change from
-      // daemon step, send a status change to ctld if not found.
-      g_ctld_client->StepStatusChangeAsync(StepStatusChangeQueueElem{
-          .job_id = job_id,
-          .step_id = kDaemonStepId,
-          .new_status = StepStatus::Cancelled,
-          .reason = "Job not found on craned during free request",
-          .timestamp = google::protobuf::util::TimeUtil::GetCurrentTime()});
+      // daemon step, send Completing + Terminal if not found.
+      SendCompletingAndTerminal_(job_id, kDaemonStepId, StepStatus::Cancelled,
+                                 ExitCode::EC_TERMINATED,
+                                 "Job not found on craned during free request");
       continue;
     }
 
@@ -536,8 +533,12 @@ void JobManager::FreeSteps(
     for (step_id_t step_id : step_ids) {
       absl::MutexLock lk(job->step_map_mtx.get());
       if (!job->step_map.contains(step_id)) {
-        CRANE_WARN("[Step #{}.{}] Try to free nonexistent step, ignoring it.",
-                   job_id, step_id);
+        CRANE_WARN(
+            "[Step #{}.{}] Try to free nonexistent step, sending terminal.",
+            job_id, step_id);
+        SendCompletingAndTerminal_(
+            job_id, step_id, StepStatus::Failed, ExitCode::EC_TERMINATED,
+            "Step not found on craned during free request");
         continue;
       }
       auto& step = job->step_map.at(step_id);
@@ -726,21 +727,27 @@ bool JobManager::EvCheckSupervisorRunning_() {
 
       if (exists) {
         retry_count++;
+        if (retry_count >= kMaxSupervisorCheckRetryCount) {
+          CRANE_WARN(
+              "[Step #{}.{}] Supervisor is still running after {} checks, "
+              "sending SIGKILL.",
+              job_id, step_id, kMaxSupervisorCheckRetryCount);
+          kill(step->supv_pid, SIGKILL);
+          SendCompletingAndTerminal_(
+              job_id, step_id, StepStatus::Failed, ExitCode::EC_RPC_ERR,
+              "Supervisor not responding during step completion");
+        }
+        continue;
       }
-      if (retry_count >= kMaxSupervisorCheckRetryCount) {
-        CRANE_WARN(
-            "[Step #{}.{}] Supervisor is still running after {} checks, will "
-            "clean up now!",
-            job_id, step_id, kMaxSupervisorCheckRetryCount);
-        g_ctld_client->StepStatusChangeAsync(StepStatusChangeQueueElem{
-            .job_id = job_id,
-            .step_id = step_id,
-            .new_status = StepStatus::Failed,
-            .exit_code = ExitCode::EC_RPC_ERR,
-            .reason = "Supervisor not responding during step completion",
-            .timestamp = google::protobuf::util::TimeUtil::GetCurrentTime()});
-      } else {
-        if (exists) continue;
+      // Supervisor exited. Wait for pending_terminal_status to be set
+      // (Completing message may still be in the status change queue).
+      if (!step->pending_terminal_status.has_value() && !step->silent_cleanup) {
+        retry_count--;
+        CRANE_TRACE(
+            "[Step #{}.{}] Supervisor exited but pending_terminal_status "
+            "not set, waiting for next tick.",
+            job_id, step_id);
+        continue;
       }
       exit_steps.push_back(step);
     }
@@ -899,10 +906,9 @@ CraneExpected<void> JobManager::ChangeStepTimeConstraint(
     CRANE_ERROR(
         "[Step #{}.{}] Supervisor stub is null when changing time constraint",
         job_id, step_id);
-    StepStatusChangeAsync(
+    SendCompletingAndTerminal_(
         job_id, step_id, StepStatus::Failed, ExitCode::EC_RPC_ERR,
-        "Supervisor stub is null when changing time constraint",
-        google::protobuf::util::TimeUtil::GetCurrentTime());
+        "Supervisor stub is null when changing time constraint");
     return std::unexpected{CraneErrCode::ERR_RPC_FAILURE};
   }
   auto err = stub->ChangeStepTimeConstraint(time_limit_seconds, deadline_time);
@@ -972,10 +978,9 @@ CraneExpected<EnvMap> JobManager::QuerySshStepEnvVariables(job_id_t job_id,
   if (!stub) {
     CRANE_ERROR("[Step #{}.{}] Supervisor stub is null when query env", job_id,
                 step_id);
-    StepStatusChangeAsync(job_id, step_id, StepStatus::Failed,
-                          ExitCode::EC_RPC_ERR,
-                          "Supervisor stub is null when query env",
-                          google::protobuf::util::TimeUtil::GetCurrentTime());
+    SendCompletingAndTerminal_(job_id, step_id, StepStatus::Failed,
+                               ExitCode::EC_RPC_ERR,
+                               "Supervisor stub is null when query env");
     return std::unexpected{CraneErrCode::ERR_RPC_FAILURE};
   }
   return stub->QueryStepEnv();
@@ -1043,7 +1048,6 @@ bool JobManager::FreeJobAllocation_(std::vector<JobInD>&& jobs) {
                             }) | std::views::common,
                             ","));
   std::unordered_map<job_id_t, CgroupInterface*> job_cg_map;
-  std::vector<uid_t> uid_vec;
 
   for (auto& job : jobs) {
     CgroupManager::ReleaseJobCpuPool(job.job_id, job.job_to_d.res());
@@ -1086,10 +1090,30 @@ bool JobManager::FreeJobAllocation_(std::vector<JobInD>&& jobs) {
 void JobManager::FreeStepAllocation_(
     std::vector<std::unique_ptr<StepInstance>>&& steps) {
   for (auto& step : steps) {
+    job_id_t job_id = step->job_id;
+    step_id_t step_id = step->step_id;
     step->CleanUp();
+    std::optional<StepInstance::PendingTerminalStatus> terminal_status =
+        std::nullopt;
+    if (step->pending_terminal_status.has_value() && !step->silent_cleanup) {
+      terminal_status = step->pending_terminal_status.value();
+    }
     step.reset();
+    // Send terminal status after step cleanup is done (skip for silent
+    // cleanup).
+    if (terminal_status.has_value()) {
+      auto& pt = terminal_status.value();
+      CRANE_TRACE("[Step #{}.{}] Sending terminal status {} after cleanup.",
+                  job_id, step_id, pt.final_status);
+      g_ctld_client->StepStatusChangeAsync(
+          StepStatusChangeQueueElem{.job_id = job_id,
+                                    .step_id = step_id,
+                                    .new_status = pt.final_status,
+                                    .exit_code = pt.exit_code,
+                                    .reason = pt.reason,
+                                    .timestamp = pt.timestamp});
+    }
   }
-  // TODO: delete cgroup
 }
 
 bool JobManager::RunPrologWhenAllocSteps_(job_id_t job_id, step_id_t step_id,
@@ -1139,7 +1163,7 @@ bool JobManager::RunPrologWhenAllocSteps_(job_id_t job_id, step_id_t step_id,
       ActivateStepStatusChangeAsync_(
           job_id, step_id, crane::grpc::JobStatus::Failed,
           ExitCode::EC_PROLOG_ERR,
-          fmt::format("Failed to run prolog for job#{} ", job_id),
+          fmt::format("Failed to run prolog for job#{} ", job_id), std::nullopt,
           google::protobuf::util::TimeUtil::GetCurrentTime());
       return false;
     }
@@ -1162,7 +1186,7 @@ void JobManager::LaunchStepMt_(std::unique_ptr<StepInstance> step) {
         job_id, step_id, crane::grpc::JobStatus::Failed,
         ExitCode::EC_CGROUP_ERR,
         fmt::format("Failed to get the allocation for job#{} ", job_id),
-        google::protobuf::util::TimeUtil::GetCurrentTime());
+        std::nullopt, google::protobuf::util::TimeUtil::GetCurrentTime());
     return;
   }
   auto* job = job_ptr.get();
@@ -1176,7 +1200,7 @@ void JobManager::LaunchStepMt_(std::unique_ptr<StepInstance> step) {
     ActivateStepStatusChangeAsync_(
         job_id, step_id, crane::grpc::JobStatus::Failed,
         ExitCode::EC_SPAWN_FAILED, "Container is not enabled in this craned.",
-        google::protobuf::util::TimeUtil::GetCurrentTime());
+        std::nullopt, google::protobuf::util::TimeUtil::GetCurrentTime());
     return;
   }
 
@@ -1195,7 +1219,7 @@ void JobManager::LaunchStepMt_(std::unique_ptr<StepInstance> step) {
       ActivateStepStatusChangeAsync_(
           job_id, step_id, crane::grpc::JobStatus::Failed,
           ExitCode::EC_CGROUP_ERR,
-          fmt::format("Failed to get cgroup for job#{} ", job_id),
+          fmt::format("Failed to get cgroup for job#{} ", job_id), std::nullopt,
           google::protobuf::util::TimeUtil::GetCurrentTime());
       return;
     }
@@ -1220,7 +1244,7 @@ void JobManager::LaunchStepMt_(std::unique_ptr<StepInstance> step) {
         ExitCode::EC_CGROUP_ERR,
         fmt::format("Cannot create cgroup for the instance of step {}.{}",
                     job_id, step_id),
-        google::protobuf::util::TimeUtil::GetCurrentTime());
+        std::nullopt, google::protobuf::util::TimeUtil::GetCurrentTime());
     return;
   }
   err = step_ptr->SpawnSupervisor(job->GetJobEnvMap());
@@ -1231,7 +1255,7 @@ void JobManager::LaunchStepMt_(std::unique_ptr<StepInstance> step) {
         ExitCode::EC_SPAWN_FAILED,
         fmt::format("Cannot spawn a new process inside the instance of job #{}",
                     job_id),
-        google::protobuf::util::TimeUtil::GetCurrentTime());
+        std::nullopt, google::protobuf::util::TimeUtil::GetCurrentTime());
   } else {
     // kOk means that SpawnSupervisor_ has successfully forked a child
     // process.
@@ -1243,15 +1267,56 @@ void JobManager::LaunchStepMt_(std::unique_ptr<StepInstance> step) {
 void JobManager::EvCleanStepStatusChangeQueueCb_() {
   StepStatusChangeQueueElem status_change;
   while (m_step_status_change_queue_.try_dequeue(status_change)) {
-    {
+    bool should_forward = true;
+
+    // Lambda to update step fields once we have the pointer.
+    auto update_step = [&](StepInstance* step) {
+      step->GotNewStatus(status_change.new_status);
+      should_forward = !step->silent_cleanup;
+      if (status_change.new_status == StepStatus::Completing &&
+          status_change.final_status.has_value()) {
+        step->pending_terminal_status = StepInstance::PendingTerminalStatus{
+            .final_status = status_change.final_status.value(),
+            .exit_code = status_change.exit_code,
+            .reason = status_change.reason.value_or(""),
+            .timestamp = status_change.timestamp};
+      }
+    };
+
+    if (status_change.new_status == StepStatus::Completing) {
+      // Completing may arrive after FreeJobs/FreeSteps moved the step
+      // from m_job_map_ to m_completing_job_. Check both.
+      bool found = false;
+      {
+        absl::MutexLock lk(&m_free_job_step_mtx_);
+        if (auto it = m_completing_job_.find(status_change.job_id);
+            it != m_completing_job_.end()) {
+          absl::MutexLock lk2(it->second.step_map_mtx.get());
+          if (auto sit = it->second.step_map.find(status_change.step_id);
+              sit != it->second.step_map.end()) {
+            update_step(sit->second.get());
+            found = true;
+          }
+        }
+      }
+      if (!found) {
+        auto job_ptr = m_job_map_.GetValueExclusivePtr(status_change.job_id);
+        if (job_ptr) {
+          absl::MutexLock lk(job_ptr->step_map_mtx.get());
+          if (auto it = job_ptr->step_map.find(status_change.step_id);
+              it != job_ptr->step_map.end()) {
+            update_step(it->second.get());
+          }
+        }
+      }
+    } else {
+      // Non-Completing status: step is in m_job_map_.
       auto job_ptr = m_job_map_.GetValueExclusivePtr(status_change.job_id);
       if (job_ptr) {
         absl::MutexLock lk(job_ptr->step_map_mtx.get());
-        if (auto step_it = job_ptr->step_map.find(status_change.step_id);
-            step_it != job_ptr->step_map.end()) {
-          step_it->second->GotNewStatus(status_change.new_status);
-          step_it->second->exit_code = status_change.exit_code;
-          step_it->second->end_time = status_change.timestamp;
+        if (auto it = job_ptr->step_map.find(status_change.step_id);
+            it != job_ptr->step_map.end()) {
+          update_step(it->second.get());
         }
       }
     }
@@ -1259,23 +1324,45 @@ void JobManager::EvCleanStepStatusChangeQueueCb_() {
     CRANE_TRACE("[Step #{}.{}] StepStatusChange status: {}.",
                 status_change.job_id, status_change.step_id,
                 status_change.new_status);
-    g_ctld_client->StepStatusChangeAsync(std::move(status_change));
+
+    if (should_forward) {
+      status_change.final_status = std::nullopt;
+      g_ctld_client->StepStatusChangeAsync(std::move(status_change));
+    } else {
+      CRANE_DEBUG(
+          "[Step #{}.{}] silent_cleanup set, not forwarding to CraneCtld.",
+          status_change.job_id, status_change.step_id);
+    }
   }
 }
 
 void JobManager::ActivateStepStatusChangeAsync_(
     job_id_t job_id, step_id_t step_id, crane::grpc::JobStatus new_status,
     uint32_t exit_code, std::optional<std::string> reason,
+    std::optional<crane::grpc::JobStatus> final_status,
     const google::protobuf::Timestamp& timestamp) {
   StepStatusChangeQueueElem status_change{.job_id = job_id,
                                           .step_id = step_id,
                                           .new_status = new_status,
                                           .exit_code = exit_code,
+                                          .final_status = final_status,
                                           .timestamp = std::move(timestamp)};
   if (reason.has_value()) status_change.reason = std::move(reason);
 
   m_step_status_change_queue_.enqueue(std::move(status_change));
   m_step_status_change_async_handle_->send();
+}
+
+void JobManager::SendCompletingAndTerminal_(
+    job_id_t job_id, step_id_t step_id, crane::grpc::JobStatus terminal_status,
+    uint32_t exit_code, std::string reason) {
+  auto now = google::protobuf::util::TimeUtil::GetCurrentTime();
+  // Completing (drives AllNodesCompleting → FreeSteps)
+  ActivateStepStatusChangeAsync_(job_id, step_id, StepStatus::Completing,
+                                 exit_code, reason, terminal_status, now);
+  // Terminal (drives AllNodesFinished → release/FreeJobs)
+  ActivateStepStatusChangeAsync_(job_id, step_id, terminal_status, exit_code,
+                                 std::move(reason), std::nullopt, now);
 }
 
 /**
@@ -1449,8 +1536,15 @@ uint32_t JobManager::GetStepExitCode(job_id_t job_id, step_id_t step_id) {
                step_id);
     return 0;
   }
-
-  return step_it->second->exit_code;
+  if (step_it->second->pending_terminal_status.has_value())
+    return step_it->second->pending_terminal_status->exit_code;
+  else {
+    CRANE_WARN(
+        "[Step #{}.{}] Pending terminal status not found when getting exit "
+        "code, returning 0",
+        job_id, step_id);
+    return 0;
+  }
 }
 
 google::protobuf::Timestamp JobManager::GetStepEndTime(job_id_t job_id,
@@ -1470,7 +1564,14 @@ google::protobuf::Timestamp JobManager::GetStepEndTime(job_id_t job_id,
     return {};
   }
 
-  return step_it->second->end_time;
+  if (step_it->second->pending_terminal_status.has_value())
+    return step_it->second->pending_terminal_status->timestamp;
+  else {
+    CRANE_WARN(
+        "[Step #{}.{}] Pending terminal status not found when getting end time",
+        job_id, step_id);
+    return {};
+  }
 }
 
 std::optional<JobInfoOfUid> JobManager::QueryJobInfoOfUid(uid_t uid) {
@@ -1506,10 +1607,8 @@ void JobManager::EvCleanTerminateStepQueueCb_() {
     std::vector<StepInstance*> steps_to_clean;
     std::vector<JobInD> job_to_clean;
     {
-      CRANE_INFO(
-          "[Step #{}.{}] Terminating step, orphaned:{} terminate_source:{}.",
-          elem.job_id, elem.step_id, elem.mark_as_orphaned,
-          static_cast<int>(elem.terminate_source));
+      CRANE_INFO("[Step #{}.{}] Terminating step, terminate_source:{}.",
+                 elem.job_id, elem.step_id, static_cast<int>(elem.terminate_source));
       bool terminate_job = elem.step_id == kDaemonStepId;
       auto map_ptr = m_job_map_.GetMapExclusivePtr();
       if (!map_ptr->contains(elem.job_id)) {
@@ -1517,13 +1616,9 @@ void JobManager::EvCleanTerminateStepQueueCb_() {
             "[Step #{}.{}] Terminating a non-existent job, sending a status "
             "change",
             elem.job_id, elem.step_id);
-        g_ctld_client->StepStatusChangeAsync(
-            {.job_id = elem.job_id,
-             .step_id = elem.step_id,
-             .new_status = crane::grpc::JobStatus::Cancelled,
-             .exit_code = ExitCode::EC_TERMINATED,
-             .reason = "Terminated non-existent job.",
-             .timestamp = google::protobuf::util::TimeUtil::GetCurrentTime()});
+        SendCompletingAndTerminal_(
+            elem.job_id, elem.step_id, crane::grpc::JobStatus::Cancelled,
+            ExitCode::EC_TERMINATED, "Terminated non-existent job.");
         continue;
       }
       auto job_instance = map_ptr->at(elem.job_id).RawPtr();
@@ -1535,13 +1630,9 @@ void JobManager::EvCleanTerminateStepQueueCb_() {
             "change",
             elem.job_id, elem.step_id);
 
-        g_ctld_client->StepStatusChangeAsync(
-            {.job_id = elem.job_id,
-             .step_id = elem.step_id,
-             .new_status = crane::grpc::JobStatus::Cancelled,
-             .exit_code = ExitCode::EC_TERMINATED,
-             .reason = "Terminated non-existent step.",
-             .timestamp = google::protobuf::util::TimeUtil::GetCurrentTime()});
+        SendCompletingAndTerminal_(
+            elem.job_id, elem.step_id, crane::grpc::JobStatus::Cancelled,
+            ExitCode::EC_TERMINATED, "Terminated non-existent step.");
         continue;
       }
       auto& step = job_instance->step_map.at(elem.step_id);
@@ -1579,58 +1670,23 @@ void JobManager::EvCleanTerminateStepQueueCb_() {
         if (!stub) {
           CRANE_ERROR("[Step #{}.{}] Supervisor stub is null when terminating",
                       elem.job_id, step_id);
-          StepStatusChangeAsync(
+          SendCompletingAndTerminal_(
               elem.job_id, step_id, StepStatus::Failed, ExitCode::EC_RPC_ERR,
-              "Supervisor stub is null when terminating",
-              google::protobuf::util::TimeUtil::GetCurrentTime());
+              "Supervisor stub is null when terminating");
           continue;
         }
-        auto err =
-            stub->TerminateStep(elem.mark_as_orphaned, elem.terminate_source);
+        auto err = stub->TerminateStep(elem.terminate_source);
         if (err != CraneErrCode::SUCCESS) {
           // Supervisor dead for some reason.
           CRANE_ERROR("[Step #{}.{}] Failed to terminate.", elem.job_id,
                       step_id);
-          if (!elem.mark_as_orphaned)
-            g_ctld_client->StepStatusChangeAsync(
-                {.job_id = elem.job_id,
-                 .step_id = step_id,
-                 .new_status = crane::grpc::JobStatus::Cancelled,
-                 .exit_code = ExitCode::EC_TERMINATED,
-                 .reason = "Terminated failed."});
+          SendCompletingAndTerminal_(
+              elem.job_id, step_id, crane::grpc::JobStatus::Cancelled,
+              ExitCode::EC_TERMINATED, "Terminated failed.");
         }
         CRANE_TRACE("[Step #{}.{}] Terminated.", elem.job_id, step_id);
       }
-
-      if (elem.mark_as_orphaned) {
-        if (terminate_job) {
-          auto uid_map_ptr = m_uid_to_job_ids_map_.GetMapExclusivePtr();
-          auto job_opt = FreeJobInfoNoLock_(elem.job_id, map_ptr, uid_map_ptr);
-          if (job_opt.has_value()) {
-            job_to_clean.emplace_back(std::move(job_opt.value()));
-            for (auto& [step_id, step] : job_instance->step_map) {
-              CRANE_DEBUG("[Step #{}.{}] Removed orphaned step.", elem.job_id,
-                          step_id);
-              auto* step_ptr = step.get();
-              steps_to_clean.push_back(step_ptr);
-            }
-          } else {
-            CRANE_DEBUG("Trying to terminate a not existed job #{}.",
-                        elem.job_id);
-          }
-        } else {
-          for (auto step_id : terminate_step_ids) {
-            CRANE_DEBUG("[Step #{}.{}] Removed orphaned step.", elem.job_id,
-                        step_id);
-            auto it = job_instance->step_map.find(step_id);
-            auto* step = it->second.release();
-            steps_to_clean.push_back(step);
-            job_instance->step_map.erase(it);
-          }
-        }
-      }
     }
-    CleanUpJobAndStepsAsync(std::move(job_to_clean), std::move(steps_to_clean));
   }
   m_step_terminate_queue_.enqueue_bulk(
       std::make_move_iterator(not_ready_elems.begin()), not_ready_elems.size());
@@ -1647,60 +1703,56 @@ void JobManager::TerminateStepAsync(
   m_terminate_step_async_handle_->send();
 }
 
-void JobManager::MarkStepAsOrphanedAndTerminateAsync(job_id_t job_id,
-                                                     step_id_t step_id) {
-  StepTerminateQueueElem elem{
-      .job_id = job_id,
-      .step_id = step_id,
-      .terminate_source = crane::grpc::TERMINATE_SOURCE_NORMAL_COMPLETION,
-      .mark_as_orphaned = true};
-  m_step_terminate_queue_.enqueue(std::move(elem));
-  m_terminate_step_async_handle_->send();
+void JobManager::MarkStepSilentCleanup(job_id_t job_id, step_id_t step_id) {
+  auto job_ptr = m_job_map_.GetValueExclusivePtr(job_id);
+  if (!job_ptr) return;
+  absl::MutexLock lk(job_ptr->step_map_mtx.get());
+  if (auto it = job_ptr->step_map.find(step_id);
+      it != job_ptr->step_map.end()) {
+    it->second->silent_cleanup = true;
+  }
 }
 
 void JobManager::CleanUpJobAndStepsAsync(std::vector<JobInD>&& jobs,
                                          std::vector<StepInstance*>&& steps) {
+  // Phase 1: Terminate all supervisors (daemon + non-daemon).
   std::latch shutdown_step_latch(steps.size());
   for (auto* step : steps) {
-    // Only daemon step needs manual shutdown, others will shut down itself when
-    // all jobs finished.
-    if (!step->IsDaemonStep() || step->err_before_supv_start) {
+    if (step->err_before_supv_start) {
       shutdown_step_latch.count_down();
       continue;
     }
-    step->GotNewStatus(StepStatus::Completed);
 
     g_thread_pool->detach_task([&shutdown_step_latch, step] {
-      auto stub = step->supervisor_stub;
-      if (!stub) {
-        CRANE_ERROR(
-            "[Step #{}.{}] Supervisor stub is null when shutdown supervisor",
-            step->job_id, step->step_id);
-        g_ctld_client->StepStatusChangeAsync(StepStatusChangeQueueElem{
-            .job_id = step->job_id,
-            .step_id = step->step_id,
-            .new_status = StepStatus::Failed,
-            .exit_code = ExitCode::EC_RPC_ERR,
-            .reason = "Supervisor stub is null when changing timelimit",
-            .timestamp = google::protobuf::util::TimeUtil::GetCurrentTime()});
+      // Normal none daemon step, will exit when cleanup done,no need to
+      // terminate
+      if (!step->silent_cleanup && !step->IsDaemonStep()) {
         shutdown_step_latch.count_down();
         return;
       }
-      CRANE_TRACE("[Step #{}.{}] Shutting down daemon supervisor.",
-                  step->job_id, step->step_id);
-      auto err = stub->ShutdownSupervisor();
-      if (err != CraneErrCode::SUCCESS) {
-        CRANE_ERROR(
-            "[Step #{}.{}] Failed to shutdown supervisor sending a status "
-            "change with FAILED status.",
+      // Daemon or silent cleanup
+      auto stub = step->supervisor_stub;
+      if (!stub) {
+        CRANE_ERROR("[Step #{}.{}] Supervisor stub is null when terminating",
+                    step->job_id, step->step_id);
+        shutdown_step_latch.count_down();
+        return;
+      }
+      CraneErrCode err;
+      if (step->IsDaemonStep()) {
+        CRANE_TRACE("[Step #{}.{}] Shutting down daemon supervisor.",
+                    step->job_id, step->step_id);
+        err = stub->ShutdownSupervisor();
+      } else {
+        CRANE_TRACE(
+            "[Step #{}.{}] Terminating non-daemon supervisor for silent "
+            "cleanup.",
             step->job_id, step->step_id);
-        g_ctld_client->StepStatusChangeAsync(StepStatusChangeQueueElem{
-            .job_id = step->job_id,
-            .step_id = step->step_id,
-            .new_status = StepStatus::Failed,
-            .exit_code = ExitCode::EC_RPC_ERR,
-            .reason = "Supervisor not responding during step completion",
-            .timestamp = google::protobuf::util::TimeUtil::GetCurrentTime()});
+        err = stub->TerminateStep(/*terminated_by_user=*/false);
+      }
+      if (err != CraneErrCode::SUCCESS) {
+        CRANE_ERROR("[Step #{}.{}] Failed to terminate supervisor.",
+                    step->job_id, step->step_id);
       }
 
       shutdown_step_latch.count_down();
@@ -1708,10 +1760,13 @@ void JobManager::CleanUpJobAndStepsAsync(std::vector<JobInD>&& jobs,
   }
   shutdown_step_latch.wait();
 
+  // Phase 2: Add to completing maps. EvCheckSupervisorRunning_ timer will
+  // poll supervisor pid exit, then FreeStepAllocation_ sends Terminal
+  // and FreeJobAllocation_ handles job cgroup + epilog.
   absl::MutexLock lk(&m_free_job_step_mtx_);
   for (auto* step : steps) {
     if (m_completing_step_retry_map_.contains(step)) {
-      CRANE_DEBUG("[Step #{}.{}] is already completing, ignore clean up.",
+      CRANE_DEBUG("[Step #{}.{}] is already cleaning, ignore clean up.",
                   step->job_id, step->step_id);
       continue;
     }
@@ -1721,7 +1776,7 @@ void JobManager::CleanUpJobAndStepsAsync(std::vector<JobInD>&& jobs,
   for (auto&& job : jobs) {
     job_id_t job_id = job.job_id;
     if (m_completing_job_.contains(job_id)) {
-      CRANE_DEBUG("[Job #{}] is already completing, ignore clean up.", job_id);
+      CRANE_DEBUG("[Job #{}] is already cleaning, ignore clean up.", job_id);
       continue;
     }
 
@@ -1777,11 +1832,13 @@ void JobManager::CleanUpJobAndStepsAsync(std::vector<JobInD>&& jobs,
 void JobManager::StepStatusChangeAsync(
     job_id_t job_id, step_id_t step_id, crane::grpc::JobStatus new_status,
     uint32_t exit_code, std::optional<std::string> reason,
+    std::optional<crane::grpc::JobStatus> final_status,
     const google::protobuf::Timestamp& timestamp) {
   CRANE_INFO("[Step #{}.{}] is doing StepStatusChange, new status: {}", job_id,
              step_id, new_status);
   ActivateStepStatusChangeAsync_(job_id, step_id, new_status, exit_code,
-                                 std::move(reason), std::move(timestamp));
+                                 std::move(reason), std::move(final_status),
+                                 std::move(timestamp));
 }
 
 }  // namespace Craned

--- a/src/Craned/Core/JobManager.cpp
+++ b/src/Craned/Core/JobManager.cpp
@@ -686,10 +686,9 @@ void JobManager::HandleUnexpectedSupervisorExits_() {
         "[Step #{}.{}] Supervisor exited without reporting a final step "
         "status. Marking step Failed.",
         failure.job_id, failure.step_id);
-    ActivateStepStatusChangeAsync_(
-        failure.job_id, failure.step_id, StepStatus::Failed, failure.exit_code,
-        std::move(failure.reason),
-        google::protobuf::util::TimeUtil::GetCurrentTime());
+    SendCompletingAndTerminal_(failure.job_id, failure.step_id,
+                               StepStatus::Failed, failure.exit_code,
+                               std::move(failure.reason));
   }
 }
 
@@ -1608,7 +1607,8 @@ void JobManager::EvCleanTerminateStepQueueCb_() {
     std::vector<JobInD> job_to_clean;
     {
       CRANE_INFO("[Step #{}.{}] Terminating step, terminate_source:{}.",
-                 elem.job_id, elem.step_id, static_cast<int>(elem.terminate_source));
+                 elem.job_id, elem.step_id,
+                 static_cast<int>(elem.terminate_source));
       bool terminate_job = elem.step_id == kDaemonStepId;
       auto map_ptr = m_job_map_.GetMapExclusivePtr();
       if (!map_ptr->contains(elem.job_id)) {
@@ -1748,7 +1748,8 @@ void JobManager::CleanUpJobAndStepsAsync(std::vector<JobInD>&& jobs,
             "[Step #{}.{}] Terminating non-daemon supervisor for silent "
             "cleanup.",
             step->job_id, step->step_id);
-        err = stub->TerminateStep(/*terminated_by_user=*/false);
+        err = stub->TerminateStep(
+            crane::grpc::TerminateSource::TERMINATE_SOURCE_NORMAL_COMPLETION);
       }
       if (err != CraneErrCode::SUCCESS) {
         CRANE_ERROR("[Step #{}.{}] Failed to terminate supervisor.",

--- a/src/Craned/Core/JobManager.cpp
+++ b/src/Craned/Core/JobManager.cpp
@@ -701,7 +701,7 @@ bool JobManager::EvCheckSupervisorRunning_() {
 
     std::vector<StepInstance*> exit_steps;
     absl::MutexLock lk(&m_free_job_step_mtx_);
-    for (auto& [step, retry_count] : m_completing_step_retry_map_) {
+    for (auto& [step, state] : m_completing_step_retry_map_) {
       if (step->err_before_supv_start) {
         exit_steps.push_back(step);
         continue;
@@ -711,8 +711,9 @@ bool JobManager::EvCheckSupervisorRunning_() {
       auto exists = kill(step->supv_pid, 0) == 0;
 
       if (exists) {
-        retry_count++;
-        if (retry_count >= kMaxSupervisorCheckRetryCount) {
+        state.alive_check_count++;
+        if (!state.sigkill_sent &&
+            state.alive_check_count >= kMaxSupervisorCheckRetryCount) {
           CRANE_WARN(
               "[Step #{}.{}] Supervisor is still running after {} checks, "
               "sending SIGKILL.",
@@ -721,18 +722,34 @@ bool JobManager::EvCheckSupervisorRunning_() {
           SendCompletingAndTerminal_(
               job_id, step_id, StepStatus::Failed, ExitCode::EC_RPC_ERR,
               "Supervisor not responding during step completion");
+          state.sigkill_sent = true;
         }
         continue;
       }
       // Supervisor exited. Wait for pending_terminal_status to be set
       // (Completing message may still be in the status change queue).
       if (!step->pending_terminal_status.has_value() && !step->silent_cleanup) {
-        retry_count--;
-        CRANE_TRACE(
-            "[Step #{}.{}] Supervisor exited but pending_terminal_status "
-            "not set, waiting for next tick.",
-            job_id, step_id);
-        continue;
+        state.status_wait_count++;
+        if (state.status_wait_count >= kMaxSupervisorCheckRetryCount) {
+          CRANE_ERROR(
+              "[Step #{}.{}] Timed out waiting for pending_terminal_status "
+              "after supervisor exit. Forcing Failed.",
+              job_id, step_id);
+          step->pending_terminal_status =
+              StepInstance::PendingTerminalStatus{
+                  .final_status = StepStatus::Failed,
+                  .exit_code = ExitCode::EC_RPC_ERR,
+                  .reason = "Timed out waiting for terminal status "
+                            "after supervisor exit",
+                  .timestamp = google::protobuf::util::TimeUtil::
+                      GetCurrentTime()};
+        } else {
+          CRANE_TRACE(
+              "[Step #{}.{}] Supervisor exited but pending_terminal_status "
+              "not set, waiting for next tick.",
+              job_id, step_id);
+          continue;
+        }
       }
       exit_steps.push_back(step);
     }
@@ -1319,6 +1336,19 @@ void JobManager::EvCleanStepStatusChangeQueueCb_() {
           if (auto it = job_ptr->step_map.find(status_change.step_id);
               it != job_ptr->step_map.end()) {
             update_step(it->second.get());
+            found = true;
+          }
+        }
+      }
+      // FreeSteps path: step was release()'d from step_map and only
+      // exists in m_completing_step_retry_map_.
+      if (!found) {
+        absl::MutexLock lk(&m_free_job_step_mtx_);
+        for (auto& [step_ptr, _] : m_completing_step_retry_map_) {
+          if (step_ptr->job_id == status_change.job_id &&
+              step_ptr->step_id == status_change.step_id) {
+            update_step(step_ptr);
+            break;
           }
         }
       }
@@ -1785,7 +1815,7 @@ void JobManager::CleanUpJobAndStepsAsync(std::vector<JobInD>&& jobs,
                   step->job_id, step->step_id);
       continue;
     }
-    m_completing_step_retry_map_[step] = 0;
+    m_completing_step_retry_map_[step] = CompletingStepState{};
   }
 
   for (auto&& job : jobs) {

--- a/src/Craned/Core/JobManager.cpp
+++ b/src/Craned/Core/JobManager.cpp
@@ -735,14 +735,13 @@ bool JobManager::EvCheckSupervisorRunning_() {
               "[Step #{}.{}] Timed out waiting for pending_terminal_status "
               "after supervisor exit. Forcing Failed.",
               job_id, step_id);
-          step->pending_terminal_status =
-              StepInstance::PendingTerminalStatus{
-                  .final_status = StepStatus::Failed,
-                  .exit_code = ExitCode::EC_RPC_ERR,
-                  .reason = "Timed out waiting for terminal status "
-                            "after supervisor exit",
-                  .timestamp = google::protobuf::util::TimeUtil::
-                      GetCurrentTime()};
+          step->pending_terminal_status = StepInstance::PendingTerminalStatus{
+              .final_status = StepStatus::Failed,
+              .exit_code = ExitCode::EC_RPC_ERR,
+              .reason =
+                  "Timed out waiting for terminal status "
+                  "after supervisor exit",
+              .timestamp = google::protobuf::util::TimeUtil::GetCurrentTime()};
         } else {
           CRANE_TRACE(
               "[Step #{}.{}] Supervisor exited but pending_terminal_status "

--- a/src/Craned/Core/JobManager.cpp
+++ b/src/Craned/Core/JobManager.cpp
@@ -439,13 +439,10 @@ bool JobManager::FreeJobs(std::set<job_id_t>&& job_ids) {
           "daemon step",
           job_id);
       // Free job implicitly free its daemon step and got a status change from
-      // daemon step, send a status change to ctld if not found.
-      g_ctld_client->StepStatusChangeAsync(StepStatusChangeQueueElem{
-          .job_id = job_id,
-          .step_id = kDaemonStepId,
-          .new_status = StepStatus::Cancelled,
-          .reason = "Job not found on craned during free request",
-          .timestamp = google::protobuf::util::TimeUtil::GetCurrentTime()});
+      // daemon step, send Completing + Terminal if not found.
+      SendCompletingAndTerminal_(job_id, kDaemonStepId, StepStatus::Cancelled,
+                                 ExitCode::EC_TERMINATED,
+                                 "Job not found on craned during free request");
       continue;
     }
 
@@ -522,8 +519,12 @@ void JobManager::FreeSteps(
     for (step_id_t step_id : step_ids) {
       absl::MutexLock lk(job->step_map_mtx.get());
       if (!job->step_map.contains(step_id)) {
-        CRANE_WARN("[Step #{}.{}] Try to free nonexistent step, ignoring it.",
-                   job_id, step_id);
+        CRANE_WARN(
+            "[Step #{}.{}] Try to free nonexistent step, sending terminal.",
+            job_id, step_id);
+        SendCompletingAndTerminal_(
+            job_id, step_id, StepStatus::Failed, ExitCode::EC_TERMINATED,
+            "Step not found on craned during free request");
         continue;
       }
       auto& step = job->step_map.at(step_id);
@@ -712,21 +713,27 @@ bool JobManager::EvCheckSupervisorRunning_() {
 
       if (exists) {
         retry_count++;
+        if (retry_count >= kMaxSupervisorCheckRetryCount) {
+          CRANE_WARN(
+              "[Step #{}.{}] Supervisor is still running after {} checks, "
+              "sending SIGKILL.",
+              job_id, step_id, kMaxSupervisorCheckRetryCount);
+          kill(step->supv_pid, SIGKILL);
+          SendCompletingAndTerminal_(
+              job_id, step_id, StepStatus::Failed, ExitCode::EC_RPC_ERR,
+              "Supervisor not responding during step completion");
+        }
+        continue;
       }
-      if (retry_count >= kMaxSupervisorCheckRetryCount) {
-        CRANE_WARN(
-            "[Step #{}.{}] Supervisor is still running after {} checks, will "
-            "clean up now!",
-            job_id, step_id, kMaxSupervisorCheckRetryCount);
-        g_ctld_client->StepStatusChangeAsync(StepStatusChangeQueueElem{
-            .job_id = job_id,
-            .step_id = step_id,
-            .new_status = StepStatus::Failed,
-            .exit_code = ExitCode::EC_RPC_ERR,
-            .reason = "Supervisor not responding during step completion",
-            .timestamp = google::protobuf::util::TimeUtil::GetCurrentTime()});
-      } else {
-        if (exists) continue;
+      // Supervisor exited. Wait for pending_terminal_status to be set
+      // (Completing message may still be in the status change queue).
+      if (!step->pending_terminal_status.has_value() && !step->silent_cleanup) {
+        retry_count--;
+        CRANE_TRACE(
+            "[Step #{}.{}] Supervisor exited but pending_terminal_status "
+            "not set, waiting for next tick.",
+            job_id, step_id);
+        continue;
       }
       exit_steps.push_back(step);
     }
@@ -910,10 +917,9 @@ CraneExpected<void> JobManager::ChangeStepTimeConstraint(
     CRANE_ERROR(
         "[Step #{}.{}] Supervisor stub is null when changing time constraint",
         job_id, step_id);
-    StepStatusChangeAsync(
+    SendCompletingAndTerminal_(
         job_id, step_id, StepStatus::Failed, ExitCode::EC_RPC_ERR,
-        "Supervisor stub is null when changing time constraint",
-        google::protobuf::util::TimeUtil::GetCurrentTime());
+        "Supervisor stub is null when changing time constraint");
     return std::unexpected{CraneErrCode::ERR_RPC_FAILURE};
   }
 
@@ -986,10 +992,9 @@ CraneExpected<EnvMap> JobManager::QuerySshStepEnvVariables(job_id_t job_id,
   if (!stub) {
     CRANE_ERROR("[Step #{}.{}] Supervisor stub is null when query env", job_id,
                 step_id);
-    StepStatusChangeAsync(job_id, step_id, StepStatus::Failed,
-                          ExitCode::EC_RPC_ERR,
-                          "Supervisor stub is null when query env",
-                          google::protobuf::util::TimeUtil::GetCurrentTime());
+    SendCompletingAndTerminal_(job_id, step_id, StepStatus::Failed,
+                               ExitCode::EC_RPC_ERR,
+                               "Supervisor stub is null when query env");
     return std::unexpected{CraneErrCode::ERR_RPC_FAILURE};
   }
   return stub->QueryStepEnv();
@@ -1057,7 +1062,6 @@ bool JobManager::FreeJobAllocation_(std::vector<JobInD>&& jobs) {
                             }) | std::views::common,
                             ","));
   std::unordered_map<job_id_t, CgroupInterface*> job_cg_map;
-  std::vector<uid_t> uid_vec;
 
   for (auto& job : jobs) {
     CgroupManager::ReleaseJobCpuPool(job.job_id, job.job_to_d.res());
@@ -1100,10 +1104,30 @@ bool JobManager::FreeJobAllocation_(std::vector<JobInD>&& jobs) {
 void JobManager::FreeStepAllocation_(
     std::vector<std::unique_ptr<StepInstance>>&& steps) {
   for (auto& step : steps) {
+    job_id_t job_id = step->job_id;
+    step_id_t step_id = step->step_id;
     step->CleanUp();
+    std::optional<StepInstance::PendingTerminalStatus> terminal_status =
+        std::nullopt;
+    if (step->pending_terminal_status.has_value() && !step->silent_cleanup) {
+      terminal_status = step->pending_terminal_status.value();
+    }
     step.reset();
+    // Send terminal status after step cleanup is done (skip for silent
+    // cleanup).
+    if (terminal_status.has_value()) {
+      auto& pt = terminal_status.value();
+      CRANE_TRACE("[Step #{}.{}] Sending terminal status {} after cleanup.",
+                  job_id, step_id, pt.final_status);
+      g_ctld_client->StepStatusChangeAsync(
+          StepStatusChangeQueueElem{.job_id = job_id,
+                                    .step_id = step_id,
+                                    .new_status = pt.final_status,
+                                    .exit_code = pt.exit_code,
+                                    .reason = pt.reason,
+                                    .timestamp = pt.timestamp});
+    }
   }
-  // TODO: delete cgroup
 }
 
 bool JobManager::RunPrologWhenAllocSteps_(job_id_t job_id, step_id_t step_id,
@@ -1153,7 +1177,7 @@ bool JobManager::RunPrologWhenAllocSteps_(job_id_t job_id, step_id_t step_id,
       ActivateStepStatusChangeAsync_(
           job_id, step_id, crane::grpc::JobStatus::Failed,
           ExitCode::EC_PROLOG_ERR,
-          fmt::format("Failed to run prolog for job#{} ", job_id),
+          fmt::format("Failed to run prolog for job#{} ", job_id), std::nullopt,
           google::protobuf::util::TimeUtil::GetCurrentTime());
       return false;
     }
@@ -1176,7 +1200,7 @@ void JobManager::LaunchStepMt_(std::unique_ptr<StepInstance> step) {
         job_id, step_id, crane::grpc::JobStatus::Failed,
         ExitCode::EC_CGROUP_ERR,
         fmt::format("Failed to get the allocation for job#{} ", job_id),
-        google::protobuf::util::TimeUtil::GetCurrentTime());
+        std::nullopt, google::protobuf::util::TimeUtil::GetCurrentTime());
     return;
   }
   auto* job = job_ptr.get();
@@ -1190,7 +1214,7 @@ void JobManager::LaunchStepMt_(std::unique_ptr<StepInstance> step) {
     ActivateStepStatusChangeAsync_(
         job_id, step_id, crane::grpc::JobStatus::Failed,
         ExitCode::EC_SPAWN_FAILED, "Container is not enabled in this craned.",
-        google::protobuf::util::TimeUtil::GetCurrentTime());
+        std::nullopt, google::protobuf::util::TimeUtil::GetCurrentTime());
     return;
   }
 
@@ -1209,7 +1233,7 @@ void JobManager::LaunchStepMt_(std::unique_ptr<StepInstance> step) {
       ActivateStepStatusChangeAsync_(
           job_id, step_id, crane::grpc::JobStatus::Failed,
           ExitCode::EC_CGROUP_ERR,
-          fmt::format("Failed to get cgroup for job#{} ", job_id),
+          fmt::format("Failed to get cgroup for job#{} ", job_id), std::nullopt,
           google::protobuf::util::TimeUtil::GetCurrentTime());
       return;
     }
@@ -1234,7 +1258,7 @@ void JobManager::LaunchStepMt_(std::unique_ptr<StepInstance> step) {
         ExitCode::EC_CGROUP_ERR,
         fmt::format("Cannot create cgroup for the instance of step {}.{}",
                     job_id, step_id),
-        google::protobuf::util::TimeUtil::GetCurrentTime());
+        std::nullopt, google::protobuf::util::TimeUtil::GetCurrentTime());
     return;
   }
   err = step_ptr->SpawnSupervisor(job->GetJobEnvMap());
@@ -1245,7 +1269,7 @@ void JobManager::LaunchStepMt_(std::unique_ptr<StepInstance> step) {
         ExitCode::EC_SPAWN_FAILED,
         fmt::format("Cannot spawn a new process inside the instance of job #{}",
                     job_id),
-        google::protobuf::util::TimeUtil::GetCurrentTime());
+        std::nullopt, google::protobuf::util::TimeUtil::GetCurrentTime());
   } else {
     // kOk means that SpawnSupervisor_ has successfully forked a child
     // process.
@@ -1257,15 +1281,56 @@ void JobManager::LaunchStepMt_(std::unique_ptr<StepInstance> step) {
 void JobManager::EvCleanStepStatusChangeQueueCb_() {
   StepStatusChangeQueueElem status_change;
   while (m_step_status_change_queue_.try_dequeue(status_change)) {
-    {
+    bool should_forward = true;
+
+    // Lambda to update step fields once we have the pointer.
+    auto update_step = [&](StepInstance* step) {
+      step->GotNewStatus(status_change.new_status);
+      should_forward = !step->silent_cleanup;
+      if (status_change.new_status == StepStatus::Completing &&
+          status_change.final_status.has_value()) {
+        step->pending_terminal_status = StepInstance::PendingTerminalStatus{
+            .final_status = status_change.final_status.value(),
+            .exit_code = status_change.exit_code,
+            .reason = status_change.reason.value_or(""),
+            .timestamp = status_change.timestamp};
+      }
+    };
+
+    if (status_change.new_status == StepStatus::Completing) {
+      // Completing may arrive after FreeJobs/FreeSteps moved the step
+      // from m_job_map_ to m_completing_job_. Check both.
+      bool found = false;
+      {
+        absl::MutexLock lk(&m_free_job_step_mtx_);
+        if (auto it = m_completing_job_.find(status_change.job_id);
+            it != m_completing_job_.end()) {
+          absl::MutexLock lk2(it->second.step_map_mtx.get());
+          if (auto sit = it->second.step_map.find(status_change.step_id);
+              sit != it->second.step_map.end()) {
+            update_step(sit->second.get());
+            found = true;
+          }
+        }
+      }
+      if (!found) {
+        auto job_ptr = m_job_map_.GetValueExclusivePtr(status_change.job_id);
+        if (job_ptr) {
+          absl::MutexLock lk(job_ptr->step_map_mtx.get());
+          if (auto it = job_ptr->step_map.find(status_change.step_id);
+              it != job_ptr->step_map.end()) {
+            update_step(it->second.get());
+          }
+        }
+      }
+    } else {
+      // Non-Completing status: step is in m_job_map_.
       auto job_ptr = m_job_map_.GetValueExclusivePtr(status_change.job_id);
       if (job_ptr) {
         absl::MutexLock lk(job_ptr->step_map_mtx.get());
-        if (auto step_it = job_ptr->step_map.find(status_change.step_id);
-            step_it != job_ptr->step_map.end()) {
-          step_it->second->GotNewStatus(status_change.new_status);
-          step_it->second->exit_code = status_change.exit_code;
-          step_it->second->end_time = status_change.timestamp;
+        if (auto it = job_ptr->step_map.find(status_change.step_id);
+            it != job_ptr->step_map.end()) {
+          update_step(it->second.get());
         }
       }
     }
@@ -1273,23 +1338,45 @@ void JobManager::EvCleanStepStatusChangeQueueCb_() {
     CRANE_TRACE("[Step #{}.{}] StepStatusChange status: {}.",
                 status_change.job_id, status_change.step_id,
                 status_change.new_status);
-    g_ctld_client->StepStatusChangeAsync(std::move(status_change));
+
+    if (should_forward) {
+      status_change.final_status = std::nullopt;
+      g_ctld_client->StepStatusChangeAsync(std::move(status_change));
+    } else {
+      CRANE_DEBUG(
+          "[Step #{}.{}] silent_cleanup set, not forwarding to CraneCtld.",
+          status_change.job_id, status_change.step_id);
+    }
   }
 }
 
 void JobManager::ActivateStepStatusChangeAsync_(
     job_id_t job_id, step_id_t step_id, crane::grpc::JobStatus new_status,
     uint32_t exit_code, std::optional<std::string> reason,
+    std::optional<crane::grpc::JobStatus> final_status,
     const google::protobuf::Timestamp& timestamp) {
   StepStatusChangeQueueElem status_change{.job_id = job_id,
                                           .step_id = step_id,
                                           .new_status = new_status,
                                           .exit_code = exit_code,
+                                          .final_status = final_status,
                                           .timestamp = std::move(timestamp)};
   if (reason.has_value()) status_change.reason = std::move(reason);
 
   m_step_status_change_queue_.enqueue(std::move(status_change));
   m_step_status_change_async_handle_->send();
+}
+
+void JobManager::SendCompletingAndTerminal_(
+    job_id_t job_id, step_id_t step_id, crane::grpc::JobStatus terminal_status,
+    uint32_t exit_code, std::string reason) {
+  auto now = google::protobuf::util::TimeUtil::GetCurrentTime();
+  // Completing (drives AllNodesCompleting → FreeSteps)
+  ActivateStepStatusChangeAsync_(job_id, step_id, StepStatus::Completing,
+                                 exit_code, reason, terminal_status, now);
+  // Terminal (drives AllNodesFinished → release/FreeJobs)
+  ActivateStepStatusChangeAsync_(job_id, step_id, terminal_status, exit_code,
+                                 std::move(reason), std::nullopt, now);
 }
 
 /**
@@ -1463,8 +1550,15 @@ uint32_t JobManager::GetStepExitCode(job_id_t job_id, step_id_t step_id) {
                step_id);
     return 0;
   }
-
-  return step_it->second->exit_code;
+  if (step_it->second->pending_terminal_status.has_value())
+    return step_it->second->pending_terminal_status->exit_code;
+  else {
+    CRANE_WARN(
+        "[Step #{}.{}] Pending terminal status not found when getting exit "
+        "code, returning 0",
+        job_id, step_id);
+    return 0;
+  }
 }
 
 google::protobuf::Timestamp JobManager::GetStepEndTime(job_id_t job_id,
@@ -1484,7 +1578,14 @@ google::protobuf::Timestamp JobManager::GetStepEndTime(job_id_t job_id,
     return {};
   }
 
-  return step_it->second->end_time;
+  if (step_it->second->pending_terminal_status.has_value())
+    return step_it->second->pending_terminal_status->timestamp;
+  else {
+    CRANE_WARN(
+        "[Step #{}.{}] Pending terminal status not found when getting end time",
+        job_id, step_id);
+    return {};
+  }
 }
 
 std::optional<JobInfoOfUid> JobManager::QueryJobInfoOfUid(uid_t uid) {
@@ -1520,10 +1621,8 @@ void JobManager::EvCleanTerminateStepQueueCb_() {
     std::vector<StepInstance*> steps_to_clean;
     std::vector<JobInD> job_to_clean;
     {
-      CRANE_INFO(
-          "[Step #{}.{}] Terminating step, orphaned:{} terminate_source:{}.",
-          elem.job_id, elem.step_id, elem.mark_as_orphaned,
-          static_cast<int>(elem.terminate_source));
+      CRANE_INFO("[Step #{}.{}] Terminating step, terminate_source:{}.",
+                 elem.job_id, elem.step_id, static_cast<int>(elem.terminate_source));
       bool terminate_job = elem.step_id == kDaemonStepId;
       auto map_ptr = m_job_map_.GetMapExclusivePtr();
       if (!map_ptr->contains(elem.job_id)) {
@@ -1531,13 +1630,9 @@ void JobManager::EvCleanTerminateStepQueueCb_() {
             "[Step #{}.{}] Terminating a non-existent job, sending a status "
             "change",
             elem.job_id, elem.step_id);
-        g_ctld_client->StepStatusChangeAsync(
-            {.job_id = elem.job_id,
-             .step_id = elem.step_id,
-             .new_status = crane::grpc::JobStatus::Cancelled,
-             .exit_code = ExitCode::EC_TERMINATED,
-             .reason = "Terminated non-existent job.",
-             .timestamp = google::protobuf::util::TimeUtil::GetCurrentTime()});
+        SendCompletingAndTerminal_(
+            elem.job_id, elem.step_id, crane::grpc::JobStatus::Cancelled,
+            ExitCode::EC_TERMINATED, "Terminated non-existent job.");
         continue;
       }
       auto job_instance = map_ptr->at(elem.job_id).RawPtr();
@@ -1549,13 +1644,9 @@ void JobManager::EvCleanTerminateStepQueueCb_() {
             "change",
             elem.job_id, elem.step_id);
 
-        g_ctld_client->StepStatusChangeAsync(
-            {.job_id = elem.job_id,
-             .step_id = elem.step_id,
-             .new_status = crane::grpc::JobStatus::Cancelled,
-             .exit_code = ExitCode::EC_TERMINATED,
-             .reason = "Terminated non-existent step.",
-             .timestamp = google::protobuf::util::TimeUtil::GetCurrentTime()});
+        SendCompletingAndTerminal_(
+            elem.job_id, elem.step_id, crane::grpc::JobStatus::Cancelled,
+            ExitCode::EC_TERMINATED, "Terminated non-existent step.");
         continue;
       }
       auto& step = job_instance->step_map.at(elem.step_id);
@@ -1593,58 +1684,23 @@ void JobManager::EvCleanTerminateStepQueueCb_() {
         if (!stub) {
           CRANE_ERROR("[Step #{}.{}] Supervisor stub is null when terminating",
                       elem.job_id, step_id);
-          StepStatusChangeAsync(
+          SendCompletingAndTerminal_(
               elem.job_id, step_id, StepStatus::Failed, ExitCode::EC_RPC_ERR,
-              "Supervisor stub is null when terminating",
-              google::protobuf::util::TimeUtil::GetCurrentTime());
+              "Supervisor stub is null when terminating");
           continue;
         }
-        auto err =
-            stub->TerminateStep(elem.mark_as_orphaned, elem.terminate_source);
+        auto err = stub->TerminateStep(elem.terminate_source);
         if (err != CraneErrCode::SUCCESS) {
           // Supervisor dead for some reason.
           CRANE_ERROR("[Step #{}.{}] Failed to terminate.", elem.job_id,
                       step_id);
-          if (!elem.mark_as_orphaned)
-            g_ctld_client->StepStatusChangeAsync(
-                {.job_id = elem.job_id,
-                 .step_id = step_id,
-                 .new_status = crane::grpc::JobStatus::Cancelled,
-                 .exit_code = ExitCode::EC_TERMINATED,
-                 .reason = "Terminated failed."});
+          SendCompletingAndTerminal_(
+              elem.job_id, step_id, crane::grpc::JobStatus::Cancelled,
+              ExitCode::EC_TERMINATED, "Terminated failed.");
         }
         CRANE_TRACE("[Step #{}.{}] Terminated.", elem.job_id, step_id);
       }
-
-      if (elem.mark_as_orphaned) {
-        if (terminate_job) {
-          auto uid_map_ptr = m_uid_to_job_ids_map_.GetMapExclusivePtr();
-          auto job_opt = FreeJobInfoNoLock_(elem.job_id, map_ptr, uid_map_ptr);
-          if (job_opt.has_value()) {
-            job_to_clean.emplace_back(std::move(job_opt.value()));
-            for (auto& [step_id, step] : job_instance->step_map) {
-              CRANE_DEBUG("[Step #{}.{}] Removed orphaned step.", elem.job_id,
-                          step_id);
-              auto* step_ptr = step.get();
-              steps_to_clean.push_back(step_ptr);
-            }
-          } else {
-            CRANE_DEBUG("Trying to terminate a not existed job #{}.",
-                        elem.job_id);
-          }
-        } else {
-          for (auto step_id : terminate_step_ids) {
-            CRANE_DEBUG("[Step #{}.{}] Removed orphaned step.", elem.job_id,
-                        step_id);
-            auto it = job_instance->step_map.find(step_id);
-            auto* step = it->second.release();
-            steps_to_clean.push_back(step);
-            job_instance->step_map.erase(it);
-          }
-        }
-      }
     }
-    CleanUpJobAndStepsAsync(std::move(job_to_clean), std::move(steps_to_clean));
   }
   m_step_terminate_queue_.enqueue_bulk(
       std::make_move_iterator(not_ready_elems.begin()), not_ready_elems.size());
@@ -1661,60 +1717,56 @@ void JobManager::TerminateStepAsync(
   m_terminate_step_async_handle_->send();
 }
 
-void JobManager::MarkStepAsOrphanedAndTerminateAsync(job_id_t job_id,
-                                                     step_id_t step_id) {
-  StepTerminateQueueElem elem{
-      .job_id = job_id,
-      .step_id = step_id,
-      .terminate_source = crane::grpc::TERMINATE_SOURCE_NORMAL_COMPLETION,
-      .mark_as_orphaned = true};
-  m_step_terminate_queue_.enqueue(std::move(elem));
-  m_terminate_step_async_handle_->send();
+void JobManager::MarkStepSilentCleanup(job_id_t job_id, step_id_t step_id) {
+  auto job_ptr = m_job_map_.GetValueExclusivePtr(job_id);
+  if (!job_ptr) return;
+  absl::MutexLock lk(job_ptr->step_map_mtx.get());
+  if (auto it = job_ptr->step_map.find(step_id);
+      it != job_ptr->step_map.end()) {
+    it->second->silent_cleanup = true;
+  }
 }
 
 void JobManager::CleanUpJobAndStepsAsync(std::vector<JobInD>&& jobs,
                                          std::vector<StepInstance*>&& steps) {
+  // Phase 1: Terminate all supervisors (daemon + non-daemon).
   std::latch shutdown_step_latch(steps.size());
   for (auto* step : steps) {
-    // Only daemon step needs manual shutdown, others will shut down itself when
-    // all jobs finished.
-    if (!step->IsDaemonStep() || step->err_before_supv_start) {
+    if (step->err_before_supv_start) {
       shutdown_step_latch.count_down();
       continue;
     }
-    step->GotNewStatus(StepStatus::Completed);
 
     g_thread_pool->detach_task([&shutdown_step_latch, step] {
-      auto stub = step->supervisor_stub;
-      if (!stub) {
-        CRANE_ERROR(
-            "[Step #{}.{}] Supervisor stub is null when shutdown supervisor",
-            step->job_id, step->step_id);
-        g_ctld_client->StepStatusChangeAsync(StepStatusChangeQueueElem{
-            .job_id = step->job_id,
-            .step_id = step->step_id,
-            .new_status = StepStatus::Failed,
-            .exit_code = ExitCode::EC_RPC_ERR,
-            .reason = "Supervisor stub is null when changing timelimit",
-            .timestamp = google::protobuf::util::TimeUtil::GetCurrentTime()});
+      // Normal none daemon step, will exit when cleanup done,no need to
+      // terminate
+      if (!step->silent_cleanup && !step->IsDaemonStep()) {
         shutdown_step_latch.count_down();
         return;
       }
-      CRANE_TRACE("[Step #{}.{}] Shutting down daemon supervisor.",
-                  step->job_id, step->step_id);
-      auto err = stub->ShutdownSupervisor();
-      if (err != CraneErrCode::SUCCESS) {
-        CRANE_ERROR(
-            "[Step #{}.{}] Failed to shutdown supervisor sending a status "
-            "change with FAILED status.",
+      // Daemon or silent cleanup
+      auto stub = step->supervisor_stub;
+      if (!stub) {
+        CRANE_ERROR("[Step #{}.{}] Supervisor stub is null when terminating",
+                    step->job_id, step->step_id);
+        shutdown_step_latch.count_down();
+        return;
+      }
+      CraneErrCode err;
+      if (step->IsDaemonStep()) {
+        CRANE_TRACE("[Step #{}.{}] Shutting down daemon supervisor.",
+                    step->job_id, step->step_id);
+        err = stub->ShutdownSupervisor();
+      } else {
+        CRANE_TRACE(
+            "[Step #{}.{}] Terminating non-daemon supervisor for silent "
+            "cleanup.",
             step->job_id, step->step_id);
-        g_ctld_client->StepStatusChangeAsync(StepStatusChangeQueueElem{
-            .job_id = step->job_id,
-            .step_id = step->step_id,
-            .new_status = StepStatus::Failed,
-            .exit_code = ExitCode::EC_RPC_ERR,
-            .reason = "Supervisor not responding during step completion",
-            .timestamp = google::protobuf::util::TimeUtil::GetCurrentTime()});
+        err = stub->TerminateStep(/*terminated_by_user=*/false);
+      }
+      if (err != CraneErrCode::SUCCESS) {
+        CRANE_ERROR("[Step #{}.{}] Failed to terminate supervisor.",
+                    step->job_id, step->step_id);
       }
 
       shutdown_step_latch.count_down();
@@ -1722,10 +1774,13 @@ void JobManager::CleanUpJobAndStepsAsync(std::vector<JobInD>&& jobs,
   }
   shutdown_step_latch.wait();
 
+  // Phase 2: Add to completing maps. EvCheckSupervisorRunning_ timer will
+  // poll supervisor pid exit, then FreeStepAllocation_ sends Terminal
+  // and FreeJobAllocation_ handles job cgroup + epilog.
   absl::MutexLock lk(&m_free_job_step_mtx_);
   for (auto* step : steps) {
     if (m_completing_step_retry_map_.contains(step)) {
-      CRANE_DEBUG("[Step #{}.{}] is already completing, ignore clean up.",
+      CRANE_DEBUG("[Step #{}.{}] is already cleaning, ignore clean up.",
                   step->job_id, step->step_id);
       continue;
     }
@@ -1735,7 +1790,7 @@ void JobManager::CleanUpJobAndStepsAsync(std::vector<JobInD>&& jobs,
   for (auto&& job : jobs) {
     job_id_t job_id = job.job_id;
     if (m_completing_job_.contains(job_id)) {
-      CRANE_DEBUG("[Job #{}] is already completing, ignore clean up.", job_id);
+      CRANE_DEBUG("[Job #{}] is already cleaning, ignore clean up.", job_id);
       continue;
     }
 
@@ -1791,11 +1846,13 @@ void JobManager::CleanUpJobAndStepsAsync(std::vector<JobInD>&& jobs,
 void JobManager::StepStatusChangeAsync(
     job_id_t job_id, step_id_t step_id, crane::grpc::JobStatus new_status,
     uint32_t exit_code, std::optional<std::string> reason,
+    std::optional<crane::grpc::JobStatus> final_status,
     const google::protobuf::Timestamp& timestamp) {
   CRANE_INFO("[Step #{}.{}] is doing StepStatusChange, new status: {}", job_id,
              step_id, new_status);
   ActivateStepStatusChangeAsync_(job_id, step_id, new_status, exit_code,
-                                 std::move(reason), std::move(timestamp));
+                                 std::move(reason), std::move(final_status),
+                                 std::move(timestamp));
 }
 
 }  // namespace Craned

--- a/src/Craned/Core/JobManager.cpp
+++ b/src/Craned/Core/JobManager.cpp
@@ -672,10 +672,9 @@ void JobManager::HandleUnexpectedSupervisorExits_() {
         "[Step #{}.{}] Supervisor exited without reporting a final step "
         "status. Marking step Failed.",
         failure.job_id, failure.step_id);
-    ActivateStepStatusChangeAsync_(
-        failure.job_id, failure.step_id, StepStatus::Failed, failure.exit_code,
-        std::move(failure.reason),
-        google::protobuf::util::TimeUtil::GetCurrentTime());
+    SendCompletingAndTerminal_(failure.job_id, failure.step_id,
+                               StepStatus::Failed, failure.exit_code,
+                               std::move(failure.reason));
   }
 }
 
@@ -1622,7 +1621,8 @@ void JobManager::EvCleanTerminateStepQueueCb_() {
     std::vector<JobInD> job_to_clean;
     {
       CRANE_INFO("[Step #{}.{}] Terminating step, terminate_source:{}.",
-                 elem.job_id, elem.step_id, static_cast<int>(elem.terminate_source));
+                 elem.job_id, elem.step_id,
+                 static_cast<int>(elem.terminate_source));
       bool terminate_job = elem.step_id == kDaemonStepId;
       auto map_ptr = m_job_map_.GetMapExclusivePtr();
       if (!map_ptr->contains(elem.job_id)) {
@@ -1762,7 +1762,8 @@ void JobManager::CleanUpJobAndStepsAsync(std::vector<JobInD>&& jobs,
             "[Step #{}.{}] Terminating non-daemon supervisor for silent "
             "cleanup.",
             step->job_id, step->step_id);
-        err = stub->TerminateStep(/*terminated_by_user=*/false);
+        err = stub->TerminateStep(
+            crane::grpc::TerminateSource::TERMINATE_SOURCE_NORMAL_COMPLETION);
       }
       if (err != CraneErrCode::SUCCESS) {
         CRANE_ERROR("[Step #{}.{}] Failed to terminate supervisor.",

--- a/src/Craned/Core/JobManager.h
+++ b/src/Craned/Core/JobManager.h
@@ -31,6 +31,12 @@ namespace Craned {
 
 constexpr int kMaxSupervisorCheckRetryCount = 10;
 
+struct CompletingStepState {
+  int alive_check_count = 0;
+  int status_wait_count = 0;
+  bool sigkill_sent = false;
+};
+
 using StepToD = crane::grpc::StepToD;
 
 // Job allocation info, where allocation = job spec + execution info
@@ -288,7 +294,7 @@ class JobManager {
 
   absl::Mutex m_free_job_step_mtx_;
   // Step may hold by a job, use raw pointer here.
-  std::unordered_map<StepInstance*, int /*retry count*/>
+  std::unordered_map<StepInstance*, CompletingStepState>
       m_completing_step_retry_map_ ABSL_GUARDED_BY(m_free_job_step_mtx_);
   std::unordered_map<job_id_t, JobInD> m_completing_job_
       ABSL_GUARDED_BY(m_free_job_step_mtx_);

--- a/src/Craned/Core/JobManager.h
+++ b/src/Craned/Core/JobManager.h
@@ -139,7 +139,14 @@ class JobManager {
   void TerminateStepAsync(job_id_t job_id, step_id_t step_id,
                           crane::grpc::TerminateSource terminate_source);
 
-  void MarkStepAsOrphanedAndTerminateAsync(job_id_t job_id, step_id_t step_id);
+  void MarkStepSilentCleanup(job_id_t job_id, step_id_t step_id);
+
+  // Send Completing + Terminal as two separate status changes.
+  // Used for error paths where Craned detects failure and needs to
+  // drive both AllNodesCompleting and AllNodesFinished on CraneCtld.
+  void SendCompletingAndTerminal_(job_id_t job_id, step_id_t step_id,
+                                  crane::grpc::JobStatus terminal_status,
+                                  uint32_t exit_code, std::string reason);
 
   /**
    *
@@ -159,6 +166,7 @@ class JobManager {
                              crane::grpc::JobStatus new_status,
                              uint32_t exit_code,
                              std::optional<std::string> reason,
+                             std::optional<crane::grpc::JobStatus> final_status,
                              const google::protobuf::Timestamp& timestamp);
 
   // Wait internal libuv base loop to exit...
@@ -243,6 +251,7 @@ class JobManager {
   void ActivateStepStatusChangeAsync_(
       job_id_t job_id, step_id_t step_id, crane::grpc::JobStatus new_status,
       uint32_t exit_code, std::optional<std::string> reason,
+      std::optional<crane::grpc::JobStatus> final_status,
       const google::protobuf::Timestamp& timestamp);
 
   // Contains all the jobs that are running on this Craned node.

--- a/src/Craned/Core/StepInstance.cpp
+++ b/src/Craned/Core/StepInstance.cpp
@@ -23,6 +23,7 @@
 
 #include "CtldClient.h"
 #include "DeviceManager.h"
+#include "JobManager.h"
 #include "crane/CriClient.h"
 
 namespace Craned {
@@ -574,13 +575,9 @@ void StepInstance::ExecuteStepAsync() {
     if (code != CraneErrCode::SUCCESS) {
       CRANE_ERROR("[Step #{}.{}] Supervisor failed to execute step, code:{}.",
                   job_id, step_id, static_cast<int>(code));
-      g_ctld_client->StepStatusChangeAsync(StepStatusChangeQueueElem{
-          .job_id = job_id,
-          .step_id = step_id,
-          .new_status = StepStatus::Failed,
-          .exit_code = ExitCode::EC_RPC_ERR,
-          .reason = "Supervisor not responding when execute step",
-          .timestamp = google::protobuf::util::TimeUtil::GetCurrentTime()});
+      g_job_mgr->SendCompletingAndTerminal_(
+          job_id, step_id, StepStatus::Failed, ExitCode::EC_RPC_ERR,
+          "Supervisor not responding when execute step");
       // Ctld will send ShutdownSupervisor after status change from
       // daemon supervisor, for common step, will shut down itself when all
       // steps finished locally.

--- a/src/Craned/Core/StepInstance.cpp
+++ b/src/Craned/Core/StepInstance.cpp
@@ -23,6 +23,7 @@
 
 #include "CtldClient.h"
 #include "DeviceManager.h"
+#include "JobManager.h"
 #include "crane/CriClient.h"
 
 namespace Craned {
@@ -572,13 +573,9 @@ void StepInstance::ExecuteStepAsync() {
     if (code != CraneErrCode::SUCCESS) {
       CRANE_ERROR("[Step #{}.{}] Supervisor failed to execute step, code:{}.",
                   job_id, step_id, static_cast<int>(code));
-      g_ctld_client->StepStatusChangeAsync(StepStatusChangeQueueElem{
-          .job_id = job_id,
-          .step_id = step_id,
-          .new_status = StepStatus::Failed,
-          .exit_code = ExitCode::EC_RPC_ERR,
-          .reason = "Supervisor not responding when execute step",
-          .timestamp = google::protobuf::util::TimeUtil::GetCurrentTime()});
+      g_job_mgr->SendCompletingAndTerminal_(
+          job_id, step_id, StepStatus::Failed, ExitCode::EC_RPC_ERR,
+          "Supervisor not responding when execute step");
       // Ctld will send ShutdownSupervisor after status change from
       // daemon supervisor, for common step, will shut down itself when all
       // steps finished locally.

--- a/src/Craned/Core/StepInstance.h
+++ b/src/Craned/Core/StepInstance.h
@@ -94,6 +94,7 @@ struct StepInstance {
   void ExecuteStepAsync();
 
   // Not implemented yet.
-  CraneExpected<void> TerminateStep(crane::grpc::TerminateSource terminate_source);
+  CraneExpected<void> TerminateStep(
+      crane::grpc::TerminateSource terminate_source);
 };
 }  // namespace Craned

--- a/src/Craned/Core/StepInstance.h
+++ b/src/Craned/Core/StepInstance.h
@@ -34,8 +34,19 @@ struct StepInstance {
   crane::grpc::StepToD step_to_d;
 
   std::atomic_bool err_before_supv_start{false};
-  uint32_t exit_code{0};
-  google::protobuf::Timestamp end_time;  // Actual end time when step finished
+  // Stored when Completing is received from supervisor.
+  // Used by FreeJobs to send the real terminal status after cleanup.
+  struct PendingTerminalStatus {
+    crane::grpc::JobStatus final_status;
+    uint32_t exit_code;
+    std::string reason;
+    google::protobuf::Timestamp timestamp;
+  };
+  std::optional<PendingTerminalStatus> pending_terminal_status;
+
+  // When true, status changes from this step are NOT forwarded to CraneCtld.
+  // Used for invalid steps (not tracked by CraneCtld) that need local cleanup.
+  bool silent_cleanup{false};
 
   StepStatus status{StepStatus::Invalid};
   std::shared_ptr<SupervisorStub> supervisor_stub{nullptr};
@@ -83,7 +94,6 @@ struct StepInstance {
   void ExecuteStepAsync();
 
   // Not implemented yet.
-  CraneExpected<void> TerminateStep(
-      bool mark_as_orphaned, crane::grpc::TerminateSource terminate_source);
+  CraneExpected<void> TerminateStep(crane::grpc::TerminateSource terminate_source);
 };
 }  // namespace Craned

--- a/src/Craned/Core/SupervisorStub.cpp
+++ b/src/Craned/Core/SupervisorStub.cpp
@@ -141,13 +141,11 @@ SupervisorStub::CheckStatus() {
   return std::unexpected(CraneErrCode::ERR_RPC_FAILURE);
 }
 
-CraneErrCode SupervisorStub::TerminateStep(
-    bool mark_as_orphaned, crane::grpc::TerminateSource terminate_source) {
+CraneErrCode SupervisorStub::TerminateStep(crane::grpc::TerminateSource terminate_source) {
   ClientContext context;
   crane::grpc::supervisor::TerminateStepRequest request;
   crane::grpc::supervisor::TerminateStepReply reply;
 
-  request.set_mark_orphaned(mark_as_orphaned);
   request.set_terminate_source(terminate_source);
 
   auto ok = m_stub_->TerminateStep(&context, request, &reply);

--- a/src/Craned/Core/SupervisorStub.cpp
+++ b/src/Craned/Core/SupervisorStub.cpp
@@ -141,7 +141,8 @@ SupervisorStub::CheckStatus() {
   return std::unexpected(CraneErrCode::ERR_RPC_FAILURE);
 }
 
-CraneErrCode SupervisorStub::TerminateStep(crane::grpc::TerminateSource terminate_source) {
+CraneErrCode SupervisorStub::TerminateStep(
+    crane::grpc::TerminateSource terminate_source) {
   ClientContext context;
   crane::grpc::supervisor::TerminateStepRequest request;
   crane::grpc::supervisor::TerminateStepReply reply;

--- a/src/Craned/Core/SupervisorStub.cpp
+++ b/src/Craned/Core/SupervisorStub.cpp
@@ -150,8 +150,7 @@ SupervisorStub::CheckStatus() {
   return std::unexpected(CraneErrCode::ERR_RPC_FAILURE);
 }
 
-CraneErrCode SupervisorStub::TerminateStep(
-    bool mark_as_orphaned, crane::grpc::TerminateSource terminate_source) {
+CraneErrCode SupervisorStub::TerminateStep(crane::grpc::TerminateSource terminate_source) {
   ClientContext context;
   context.set_wait_for_ready(true);
   context.set_deadline(std::chrono::system_clock::now() +
@@ -159,7 +158,6 @@ CraneErrCode SupervisorStub::TerminateStep(
   crane::grpc::supervisor::TerminateStepRequest request;
   crane::grpc::supervisor::TerminateStepReply reply;
 
-  request.set_mark_orphaned(mark_as_orphaned);
   request.set_terminate_source(terminate_source);
 
   auto ok = m_stub_->TerminateStep(&context, request, &reply);

--- a/src/Craned/Core/SupervisorStub.cpp
+++ b/src/Craned/Core/SupervisorStub.cpp
@@ -150,7 +150,8 @@ SupervisorStub::CheckStatus() {
   return std::unexpected(CraneErrCode::ERR_RPC_FAILURE);
 }
 
-CraneErrCode SupervisorStub::TerminateStep(crane::grpc::TerminateSource terminate_source) {
+CraneErrCode SupervisorStub::TerminateStep(
+    crane::grpc::TerminateSource terminate_source) {
   ClientContext context;
   context.set_wait_for_ready(true);
   context.set_deadline(std::chrono::system_clock::now() +

--- a/src/Craned/Core/SupervisorStub.h
+++ b/src/Craned/Core/SupervisorStub.h
@@ -48,8 +48,7 @@ class SupervisorStub {
   CraneExpected<std::tuple<job_id_t, step_id_t, pid_t, StepStatus>>
   CheckStatus();
 
-  CraneErrCode TerminateStep(bool mark_as_orphaned,
-                             crane::grpc::TerminateSource terminate_source);
+  CraneErrCode TerminateStep(crane::grpc::TerminateSource terminate_source);
   CraneErrCode ChangeStepTimeConstraint(
       std::optional<int64_t> time_limit_seconds,
       std::optional<int64_t> deadline_time);

--- a/src/Craned/Supervisor/CforedClient.cpp
+++ b/src/Craned/Supervisor/CforedClient.cpp
@@ -666,8 +666,8 @@ void CforedClient::AsyncSendRecvThread_() {
         m_clean_stop_task_io_queue_async_handle_->send();
       }
       CRANE_ERROR("Terminating step due to cfored connection failure.");
-      g_task_mgr->TerminateStepAsync(false,
-                                     TaskFinalizeCause::CFORED_DISCONNECTED);
+      g_task_mgr->TerminateStepAsync(
+          TaskFinalizeCause::CFORED_DISCONNECTED);
       state = State::End;
     }
 

--- a/src/Craned/Supervisor/CforedClient.cpp
+++ b/src/Craned/Supervisor/CforedClient.cpp
@@ -666,8 +666,7 @@ void CforedClient::AsyncSendRecvThread_() {
         m_clean_stop_task_io_queue_async_handle_->send();
       }
       CRANE_ERROR("Terminating step due to cfored connection failure.");
-      g_task_mgr->TerminateStepAsync(
-          TaskFinalizeCause::CFORED_DISCONNECTED);
+      g_task_mgr->TerminateStepAsync(TaskFinalizeCause::CFORED_DISCONNECTED);
       state = State::End;
     }
 

--- a/src/Craned/Supervisor/CranedClient.cpp
+++ b/src/Craned/Supervisor/CranedClient.cpp
@@ -40,13 +40,15 @@ void CranedClient::InitChannelAndStub(const std::string& endpoint) {
   m_async_send_thread_ = std::thread([this] { AsyncSendThread_(); });
 }
 
-void CranedClient::StepStatusChangeAsync(crane::grpc::JobStatus new_status,
-                                         uint32_t exit_code,
-                                         std::optional<std::string> reason) {
+void CranedClient::StepStatusChangeAsync(
+    crane::grpc::JobStatus new_status, uint32_t exit_code,
+    std::optional<std::string> reason,
+    std::optional<crane::grpc::JobStatus> final_status) {
   StepStatusChangeQueueElem elem{
       .new_status = new_status,
       .exit_code = exit_code,
       .reason = std::move(reason),
+      .final_status = final_status,
       .timestamp = google::protobuf::util::TimeUtil::GetCurrentTime()};
   absl::MutexLock lock(&m_mutex_);
   m_task_status_change_queue_.push_back(std::move(elem));
@@ -101,6 +103,8 @@ void CranedClient::AsyncSendThread_() {
         request.set_exit_code(elem.exit_code);
         *request.mutable_timestamp() = elem.timestamp;
         if (elem.reason.has_value()) request.set_reason(elem.reason.value());
+        if (elem.final_status.has_value())
+          request.set_final_status(elem.final_status.value());
 
         status = m_stub_->StepStatusChange(&context, request, &reply);
         if (!status.ok()) {

--- a/src/Craned/Supervisor/CranedClient.h
+++ b/src/Craned/Supervisor/CranedClient.h
@@ -30,9 +30,10 @@ class CranedClient {
   ~CranedClient();
   void Shutdown();
   void InitChannelAndStub(const std::string& endpoint);
-  void StepStatusChangeAsync(crane::grpc::JobStatus new_status,
-                             uint32_t exit_code,
-                             std::optional<std::string> reason);
+  void StepStatusChangeAsync(
+      crane::grpc::JobStatus new_status, uint32_t exit_code,
+      std::optional<std::string> reason,
+      std::optional<crane::grpc::JobStatus> final_status = std::nullopt);
 
  private:
   void AsyncSendThread_();
@@ -40,6 +41,7 @@ class CranedClient {
     crane::grpc::JobStatus new_status{};
     uint32_t exit_code{};
     std::optional<std::string> reason;
+    std::optional<crane::grpc::JobStatus> final_status;
     google::protobuf::Timestamp timestamp{};
   };
   absl::Mutex m_mutex_;

--- a/src/Craned/Supervisor/SupervisorServer.cpp
+++ b/src/Craned/Supervisor/SupervisorServer.cpp
@@ -106,7 +106,7 @@ grpc::Status SupervisorServiceImpl::TerminateStep(
     cause = TaskFinalizeCause::CANCELLED_BY_USER;
     break;
   }
-  g_task_mgr->TerminateStepAsync( cause);
+  g_task_mgr->TerminateStepAsync(cause);
   response->set_ok(true);
   return Status::OK;
 }

--- a/src/Craned/Supervisor/SupervisorServer.cpp
+++ b/src/Craned/Supervisor/SupervisorServer.cpp
@@ -106,7 +106,7 @@ grpc::Status SupervisorServiceImpl::TerminateStep(
     cause = TaskFinalizeCause::CANCELLED_BY_USER;
     break;
   }
-  g_task_mgr->TerminateStepAsync(request->mark_orphaned(), cause);
+  g_task_mgr->TerminateStepAsync( cause);
   response->set_ok(true);
   return Status::OK;
 }

--- a/src/Craned/Supervisor/TaskManager.cpp
+++ b/src/Craned/Supervisor/TaskManager.cpp
@@ -2754,11 +2754,9 @@ void TaskManager::ResolveFinishedTask_(task_id_t task_id, StepStatus new_status,
     DelTerminationTimer_();
     DelSignalTimers_();
     m_step_.StopCforedClient();
-    if (!m_step_.orphaned) {
-      g_craned_client->StepStatusChangeAsync(
-          status.final_status_on_termination, status.max_exit_code,
-          status.final_reason_on_termination);
-    }
+    g_craned_client->StepStatusChangeAsync(
+        StepStatus::Completing, status.max_exit_code,
+        status.final_reason_on_termination, status.final_status_on_termination);
     ShutdownSupervisorAsync();
   }
 }
@@ -2917,11 +2915,9 @@ std::future<CraneErrCode> TaskManager::ChangeStepTimeConstraintAsync(
   return ok_future;
 }
 
-void TaskManager::TerminateStepAsync(bool mark_as_orphaned,
-                                     TaskFinalizeCause cause) {
+void TaskManager::TerminateStepAsync(TaskFinalizeCause cause) {
   m_step_terminate_queue_.enqueue(StepTerminateQueueElem{
       .cause = cause,
-      .mark_as_orphaned = mark_as_orphaned,
   });
   m_terminate_step_async_handle_->send();
 }
@@ -2969,11 +2965,10 @@ void TaskManager::EvShutdownSupervisorCb_() {
 
     auto& [status, exit_code, reason] = final_status;
     if (m_step_.IsDaemon()) {
-      m_step_.GotNewStatus(status);
-      if (!m_step_.orphaned) {
-        CRANE_DEBUG("Sending a {} status as daemon step.", status);
-        g_craned_client->StepStatusChangeAsync(status, exit_code, reason);
-      }
+      m_step_.GotNewStatus(StepStatus::Completing);
+      CRANE_DEBUG("Sending Completing as daemon step (final: {}).", status);
+      g_craned_client->StepStatusChangeAsync(StepStatus::Completing, exit_code,
+                                             reason, status);
     }
 
     m_step_.CleanUp();
@@ -3375,24 +3370,34 @@ void TaskManager::EvCleanTerminateStepQueueCb_() {
       continue;
     }
 
-    if (elem.mark_as_orphaned) m_step_.orphaned = true;
+    auto step_status = m_step_.GetStatus();
 
-    if (!elem.mark_as_orphaned && !m_step_.IsRunning()) {
+    if (step_status == StepStatus::Configuring) {
       not_ready_elems.emplace_back(elem);
-      CRANE_DEBUG("Step is not ready to terminate, will check next time.");
+      CRANE_DEBUG("Step status {} not cancellable, defer.", step_status);
+      continue;
+    } else if (step_status == StepStatus::Completing) {
+      CRANE_DEBUG("[Step #{}.{}] Terminating a completing step, ignored.",
+                  g_config.JobId, g_config.StepId);
+      continue;
+    } else if (IsTerminalStatus(step_status)) {
+      CRANE_DEBUG("[Step #{}.{}] Terminating a finished step, ignored.",
+                  g_config.JobId, g_config.StepId);
       continue;
     }
 
-    int sig = m_step_.IsInteractive() ? SIGHUP : SIGTERM;
-
-    if (elem.mark_as_orphaned) {
-      CRANE_DEBUG("Step is terminated as orphaned, shutting down...");
+    if (step_status == StepStatus::Starting) {
+      CRANE_DEBUG("Terminating step at Starting state, shutting down...");
       g_task_mgr->ShutdownSupervisorAsync(StepStatus::Cancelled, 0U, "");
       continue;
     }
 
-    CRANE_TRACE("Terminating all running tasks (orphaned: {}, reason: {})...",
-                elem.mark_as_orphaned, static_cast<int>(elem.cause));
+    CRANE_ASSERT(!m_step_.AllTaskFinished());
+
+    int sig = m_step_.IsInteractive() ? SIGHUP : SIGTERM;
+
+    CRANE_TRACE("Terminating all running tasks (reason: {})...",
+                static_cast<int>(elem.termination_reason));
 
     for (task_id_t task_id : m_step_.GetTaskIds()) {
       auto* task = m_step_.GetTaskInstance(task_id);

--- a/src/Craned/Supervisor/TaskManager.cpp
+++ b/src/Craned/Supervisor/TaskManager.cpp
@@ -3357,16 +3357,9 @@ void TaskManager::EvCleanTerminateStepQueueCb_() {
                 g_config.JobId, g_config.StepId);
 
     if (m_step_.IsDaemon()) {
-      if (elem.mark_as_orphaned) {
-        m_step_.orphaned = true;
-        CRANE_INFO("Orphaned daemon step is shutting down directly.");
-        SetAllowDaemonShutdown();
-        ShutdownSupervisorAsync(StepStatus::Cancelled, 0U, "");
-      } else {
-        CRANE_TRACE(
-            "Terminate request for daemon step is ignored. Use "
-            "ShutdownSupervisor to actively stop a daemon pod.");
-      }
+      CRANE_TRACE(
+          "Terminate request for daemon step is ignored. Use "
+          "ShutdownSupervisor to actively stop a daemon pod.");
       continue;
     }
 
@@ -3380,7 +3373,7 @@ void TaskManager::EvCleanTerminateStepQueueCb_() {
       CRANE_DEBUG("[Step #{}.{}] Terminating a completing step, ignored.",
                   g_config.JobId, g_config.StepId);
       continue;
-    } else if (IsTerminalStatus(step_status)) {
+    } else if (IsFinishedStepStatus(step_status)) {
       CRANE_DEBUG("[Step #{}.{}] Terminating a finished step, ignored.",
                   g_config.JobId, g_config.StepId);
       continue;
@@ -3397,7 +3390,7 @@ void TaskManager::EvCleanTerminateStepQueueCb_() {
     int sig = m_step_.IsInteractive() ? SIGHUP : SIGTERM;
 
     CRANE_TRACE("Terminating all running tasks (reason: {})...",
-                static_cast<int>(elem.termination_reason));
+                static_cast<int>(elem.cause));
 
     for (task_id_t task_id : m_step_.GetTaskIds()) {
       auto* task = m_step_.GetTaskInstance(task_id);

--- a/src/Craned/Supervisor/TaskManager.cpp
+++ b/src/Craned/Supervisor/TaskManager.cpp
@@ -2752,11 +2752,9 @@ void TaskManager::ResolveFinishedTask_(task_id_t task_id, StepStatus new_status,
     DelTerminationTimer_();
     DelSignalTimers_();
     m_step_.StopCforedClient();
-    if (!m_step_.orphaned) {
-      g_craned_client->StepStatusChangeAsync(
-          status.final_status_on_termination, status.max_exit_code,
-          status.final_reason_on_termination);
-    }
+    g_craned_client->StepStatusChangeAsync(
+        StepStatus::Completing, status.max_exit_code,
+        status.final_reason_on_termination, status.final_status_on_termination);
     ShutdownSupervisorAsync();
   }
 }
@@ -2915,11 +2913,9 @@ std::future<CraneErrCode> TaskManager::ChangeStepTimeConstraintAsync(
   return ok_future;
 }
 
-void TaskManager::TerminateStepAsync(bool mark_as_orphaned,
-                                     TaskFinalizeCause cause) {
+void TaskManager::TerminateStepAsync(TaskFinalizeCause cause) {
   m_step_terminate_queue_.enqueue(StepTerminateQueueElem{
       .cause = cause,
-      .mark_as_orphaned = mark_as_orphaned,
   });
   m_terminate_step_async_handle_->send();
 }
@@ -2967,11 +2963,10 @@ void TaskManager::EvShutdownSupervisorCb_() {
 
     auto& [status, exit_code, reason] = final_status;
     if (m_step_.IsDaemon()) {
-      m_step_.GotNewStatus(status);
-      if (!m_step_.orphaned) {
-        CRANE_DEBUG("Sending a {} status as daemon step.", status);
-        g_craned_client->StepStatusChangeAsync(status, exit_code, reason);
-      }
+      m_step_.GotNewStatus(StepStatus::Completing);
+      CRANE_DEBUG("Sending Completing as daemon step (final: {}).", status);
+      g_craned_client->StepStatusChangeAsync(StepStatus::Completing, exit_code,
+                                             reason, status);
     }
 
     // Non-daemon step don't need to report the status change in shutting down.
@@ -3376,25 +3371,34 @@ void TaskManager::EvCleanTerminateStepQueueCb_() {
       continue;
     }
 
-    if (elem.mark_as_orphaned) m_step_.orphaned = true;
+    auto step_status = m_step_.GetStatus();
 
-    auto status = m_step_.GetStatus();
-    if (!elem.mark_as_orphaned && status != StepStatus::Running) {
+    if (step_status == StepStatus::Configuring) {
       not_ready_elems.emplace_back(elem);
-      CRANE_DEBUG("Step is not ready to terminate, will check next time.");
+      CRANE_DEBUG("Step status {} not cancellable, defer.", step_status);
+      continue;
+    } else if (step_status == StepStatus::Completing) {
+      CRANE_DEBUG("[Step #{}.{}] Terminating a completing step, ignored.",
+                  g_config.JobId, g_config.StepId);
+      continue;
+    } else if (IsTerminalStatus(step_status)) {
+      CRANE_DEBUG("[Step #{}.{}] Terminating a finished step, ignored.",
+                  g_config.JobId, g_config.StepId);
       continue;
     }
 
-    int sig = m_step_.IsInteractive() ? SIGHUP : SIGTERM;
-
-    if (elem.mark_as_orphaned) {
-      CRANE_DEBUG("Step is terminated as orphaned, shutting down...");
+    if (step_status == StepStatus::Starting) {
+      CRANE_DEBUG("Terminating step at Starting state, shutting down...");
       g_task_mgr->ShutdownSupervisorAsync(StepStatus::Cancelled, 0U, "");
       continue;
     }
 
-    CRANE_TRACE("Terminating all running tasks (orphaned: {}, reason: {})...",
-                elem.mark_as_orphaned, static_cast<int>(elem.cause));
+    CRANE_ASSERT(!m_step_.AllTaskFinished());
+
+    int sig = m_step_.IsInteractive() ? SIGHUP : SIGTERM;
+
+    CRANE_TRACE("Terminating all running tasks (reason: {})...",
+                static_cast<int>(elem.termination_reason));
 
     for (task_id_t task_id : m_step_.GetTaskIds()) {
       auto* task = m_step_.GetTaskInstance(task_id);

--- a/src/Craned/Supervisor/TaskManager.cpp
+++ b/src/Craned/Supervisor/TaskManager.cpp
@@ -3358,16 +3358,9 @@ void TaskManager::EvCleanTerminateStepQueueCb_() {
                 g_config.JobId, g_config.StepId);
 
     if (m_step_.IsDaemon()) {
-      if (elem.mark_as_orphaned) {
-        m_step_.orphaned = true;
-        CRANE_INFO("Orphaned daemon step is shutting down directly.");
-        SetAllowDaemonShutdown();
-        ShutdownSupervisorAsync(StepStatus::Cancelled, 0U, "");
-      } else {
-        CRANE_TRACE(
-            "Terminate request for daemon step is ignored. Use "
-            "ShutdownSupervisor to actively stop a daemon pod.");
-      }
+      CRANE_TRACE(
+          "Terminate request for daemon step is ignored. Use "
+          "ShutdownSupervisor to actively stop a daemon pod.");
       continue;
     }
 
@@ -3381,7 +3374,7 @@ void TaskManager::EvCleanTerminateStepQueueCb_() {
       CRANE_DEBUG("[Step #{}.{}] Terminating a completing step, ignored.",
                   g_config.JobId, g_config.StepId);
       continue;
-    } else if (IsTerminalStatus(step_status)) {
+    } else if (IsFinishedStepStatus(step_status)) {
       CRANE_DEBUG("[Step #{}.{}] Terminating a finished step, ignored.",
                   g_config.JobId, g_config.StepId);
       continue;
@@ -3398,7 +3391,7 @@ void TaskManager::EvCleanTerminateStepQueueCb_() {
     int sig = m_step_.IsInteractive() ? SIGHUP : SIGTERM;
 
     CRANE_TRACE("Terminating all running tasks (reason: {})...",
-                static_cast<int>(elem.termination_reason));
+                static_cast<int>(elem.cause));
 
     for (task_id_t task_id : m_step_.GetTaskIds()) {
       auto* task = m_step_.GetTaskInstance(task_id);

--- a/src/Craned/Supervisor/TaskManager.h
+++ b/src/Craned/Supervisor/TaskManager.h
@@ -58,8 +58,6 @@ class StepInstance {
   std::vector<std::shared_ptr<uvw::timer_handle>> signal_timers;
   PasswordEntry pwd;
 
-  bool orphaned{false};
-
   job_id_t job_id{};
   step_id_t step_id{};
   std::vector<task_id_t> task_ids;
@@ -647,7 +645,7 @@ class TaskManager {
   std::future<CraneErrCode> ChangeStepTimeConstraintAsync(
       std::optional<int64_t> time_limit, std::optional<int64_t> deadline_time);
 
-  void TerminateStepAsync(bool mark_as_orphaned, TaskFinalizeCause cause);
+  void TerminateStepAsync(TaskFinalizeCause cause);
 
   // A dedicated termination path for pod in daemon step.
   void TerminatePodInDaemonStepAsync();
@@ -670,7 +668,6 @@ class TaskManager {
 
   struct StepTerminateQueueElem {
     TaskFinalizeCause cause{TaskFinalizeCause::NORMAL};
-    bool mark_as_orphaned{false};
   };
 
   struct DaemonPodTerminateQueueElem {};

--- a/src/Craned/Supervisor/TaskManager.h
+++ b/src/Craned/Supervisor/TaskManager.h
@@ -58,8 +58,6 @@ class StepInstance {
   std::vector<std::shared_ptr<uvw::timer_handle>> signal_timers;
   PasswordEntry pwd;
 
-  bool orphaned{false};
-
   job_id_t job_id{};
   step_id_t step_id{};
   std::vector<task_id_t> task_ids;
@@ -641,7 +639,7 @@ class TaskManager {
   std::future<CraneErrCode> ChangeStepTimeConstraintAsync(
       std::optional<int64_t> time_limit, std::optional<int64_t> deadline_time);
 
-  void TerminateStepAsync(bool mark_as_orphaned, TaskFinalizeCause cause);
+  void TerminateStepAsync(TaskFinalizeCause cause);
 
   // A dedicated termination path for pod in daemon step.
   void TerminatePodInDaemonStepAsync();
@@ -664,7 +662,6 @@ class TaskManager {
 
   struct StepTerminateQueueElem {
     TaskFinalizeCause cause{TaskFinalizeCause::NORMAL};
-    bool mark_as_orphaned{false};
   };
 
   struct DaemonPodTerminateQueueElem {};


### PR DESCRIPTION
## Summary

Redesign step cleanup path: remove `TerminateOrphanedSteps`, unify all cleanup through `FreeSteps`/`FreeJobs`, and introduce a two-phase status reporting model (Completing → Terminal).

This PR is the infrastructure prerequisite for the upcoming requeue feature — it ensures that when a job is rescheduled to the same node, the old cgroup/supervisor is fully cleaned up before the new allocation arrives.

## Problem

Two competing cleanup paths cause race conditions:

1. **TerminateOrphanedSteps fast path**: Craned self-cleans via `FreeJobInfoNoLock_` + `CleanUpJobAndStepsAsync`, removing the job from `m_job_map_` immediately
2. **FreeJobs/FreeSteps normal path**: CraneCtld-driven cleanup

When both paths target the same node in the same batch, the fast path removes the job first → FreeJobs finds nothing → returns immediately → CraneCtld thinks cleanup is done → requeue → **cgroup name collision**.

Additional issues:
- `CranedRegister` path: orphaned supervisors skip `StepStatusChange` → `AllNodesFinished` never satisfied → **job stuck in running_map**
- No mechanism to confirm cleanup completion before rescheduling

## Design

### Two-Phase Status Reporting

Since Supervisor runs inside the step cgroup, it cannot report after cleanup (it's already dead). Split into two phases:

| Phase | Sender | Meaning | Drives |
|-------|--------|---------|--------|
| **Completing** | Supervisor | Processes dead, supervisor exiting | `AllNodesCompleting` → `FreeSteps` |
| **Terminal** | Craned | Supervisor exited + cgroup destroyed | `AllNodesFinished` → release / `FreeJobs` |

Proto change: `StepStatusChangeRequest` gains `optional JobStatus final_status = 8` to carry the intended terminal status alongside `Completing`.

### Unified Cleanup Timeline

```
Primary step:     Completing → FreeSteps → Terminal → FreeJobs (daemon) → job_finished
Non-primary step: Completing → FreeSteps → Terminal → release
```

- **FreeSteps**: step-level cleanup (wait for supervisor exit + step cgroup)
- **FreeJobs**: job-level cleanup (daemon step + job cgroup + epilog)

### All Paths Go Through Completing

| Scenario | Completing source | Terminal source |
|----------|------------------|----------------|
| Normal completion | Supervisor `TaskFinish_` | Craned `FreeStepAllocation_` |
| Cancel (Running) | Supervisor `TaskFinish_` (after kill) | Craned `FreeStepAllocation_` |
| Cancel (Starting) | Supervisor `ShutdownSupervisorAsync` | Craned `FreeStepAllocation_` |
| Configure failed | CraneCtld (failed node → `StepOnNodeCompleting`) | Craned `FreeStepAllocation_` |
| Node crash | CraneCtld synthetic Completing | CraneCtld synthetic Terminal |
| Error (stub null, RPC fail, timeout) | Craned `SendCompletingAndTerminal_` | Craned `SendCompletingAndTerminal_` |
| Invalid step (Craned reconnect) | Silent (not forwarded) | Silent (not forwarded) |

### CraneCtld State Tracking

Two independent sets per step, no "terminal implies completing":

```
completing_nodes_ → AllNodesCompleting() → triggers FreeSteps
running_nodes_    → AllNodesFinished()   → triggers release / FreeJobs
```

`step_configure_failed` is removed — configure failure enters the same completing flow.

### Supervisor Cancel Rules

```
Configuring → defer (500ms timer retry)
Starting    → ShutdownSupervisorAsync(Cancelled) directly
Running     → kill processes → TaskFinish_ → Completing
Completing  → ignored
```

Starting and Running are handled in separate branches (no fall-through).

## Changes

### Proto (3 files)
- `Crane.proto`: Add `optional JobStatus final_status = 8` to `StepStatusChangeRequest`; remove `TerminateOrphanedStep` RPC + messages
- `PublicDefs.proto`: Add `repeated string completing_nodes = 19` to `StepRuntimeAttr`
- `Supervisor.proto`: Reserve `mark_orphaned` field in `TerminateStepRequest`

### Supervisor (4 files)
- `TaskManager.cpp`: `TaskFinish_` and `EvShutdownSupervisorCb_` send Completing (not terminal); `EvCleanTerminateStepQueueCb_` supports Starting/Running cancel with explicit branches
- `TaskManager.h`: Remove `orphaned` flag, `mark_as_orphaned` from queue elem
- `CranedClient.h/cpp`: Add `final_status` parameter to `StepStatusChangeAsync`
- `SupervisorServer.cpp`: Update `TerminateStep` handler (no `mark_orphaned`)

### Craned (7 files)
- `StepInstance.h`: Add `PendingTerminalStatus`, `silent_cleanup` flag
- `StepInstance.cpp`: Error path uses `SendCompletingAndTerminal_`
- `JobManager.h/cpp`: Add `SendCompletingAndTerminal_`, `MarkStepSilentCleanup`; `CleanUpJobAndStepsAsync` Phase 1 terminates ALL supervisors (not just daemon); `FreeStepAllocation_` sends Terminal from `pending_terminal_status`; `FreeJobs`/`FreeSteps` send Completing+Terminal for missing jobs/steps; all error paths use `SendCompletingAndTerminal_`
- `CranedPublicDefs.h`: Add `final_status` to `StepStatusChangeQueueElem`
- `CranedServer.h/cpp`: Remove `TerminateOrphanedStep` handler; pass `final_status` in `StepStatusChange`
- `CtldClient.cpp`: Invalid steps use `MarkStepSilentCleanup` + `FreeSteps` (not `TerminateStepAsync`)
- `SupervisorStub.h/cpp`: Remove `mark_as_orphaned` from `TerminateStep`

### CraneCtld (6 files)
- `CtldPublicDefs.h`: Add `m_completing_nodes_`, `StepOnNodeCompleting`, `AllNodesCompleting`; remove `craned_orphaned_steps` from context
- `CtldPublicDefs.cpp`: DaemonStep/CommonStep `StepStatusChange` split Completing/Terminal handling; CommonStep removes `step_configure_failed` (unified completing flow); `completing_nodes_` persisted to embedded DB
- `JobScheduler.h/cpp`: Rename `TerminateOrphanedSteps` → `TerminateStepsOnOtherNodes` (uses `TerminateSteps` RPC); remove `orphaned_step_latch`
- `CranedKeeper.h/cpp`: Remove `TerminateOrphanedSteps` stub
- `CtldGrpcServer.cpp`: `CranedRegister` sends synthetic Completing + Terminal for crashed node, `TerminateSteps` for alive nodes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Steps gain an explicit "Completing" phase and can carry an optional final terminal status with status updates.

* **Bug Fixes**
  * More consistent Completing→Terminal signaling (including synthetic Completing/Failed when nodes re-register) and improved supervisor-failure handling to avoid lost or incorrect step states.

* **Refactor**
  * Termination flow simplified: orphan-marking removed in favor of silent-cleanup/free-jobs and streamlined cross-node step termination.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->