### PR TITLE
fix: use ViewValueOr_ for max_time_limit_per_job field

### DIFF
--- a/src/CraneCtld/DbClient.cpp
+++ b/src/CraneCtld/DbClient.cpp
@@ -3684,8 +3684,9 @@ void MongodbClient::ViewToQos_(const bsoncxx::document::view& qos_view,
         qos_view[Qos::FieldStringOfMaxSubmitJobsPerAccount()],
         int64_t(std::numeric_limits<
                 decltype(qos->max_submit_jobs_per_account)>::max()));
-    qos->max_time_limit_per_job = absl::Seconds(ViewValueOr_(
-        qos_view[Qos::FieldStringOfMaxTimeLimitPerJob()], int64_t(kJobMaxTimeLimitSec)));
+    qos->max_time_limit_per_job = absl::Seconds(
+        ViewValueOr_(qos_view[Qos::FieldStringOfMaxTimeLimitPerJob()],
+                     int64_t(kJobMaxTimeLimitSec)));
     qos->max_jobs = ViewValueOr_(
         qos_view[Qos::FieldStringOfMaxJobs()],
         int64_t(std::numeric_limits<decltype(qos->max_jobs)>::max()));

--- a/src/CraneCtld/DbClient.cpp
+++ b/src/CraneCtld/DbClient.cpp
@@ -3684,8 +3684,8 @@ void MongodbClient::ViewToQos_(const bsoncxx::document::view& qos_view,
         qos_view[Qos::FieldStringOfMaxSubmitJobsPerAccount()],
         int64_t(std::numeric_limits<
                 decltype(qos->max_submit_jobs_per_account)>::max()));
-    qos->max_time_limit_per_job = absl::Seconds(
-        qos_view[Qos::FieldStringOfMaxTimeLimitPerJob()].get_int64().value);
+    qos->max_time_limit_per_job = absl::Seconds(ViewValueOr_(
+        qos_view[Qos::FieldStringOfMaxTimeLimitPerJob()], int64_t(kJobMaxTimeLimitSec)));
     qos->max_jobs = ViewValueOr_(
         qos_view[Qos::FieldStringOfMaxJobs()],
         int64_t(std::numeric_limits<decltype(qos->max_jobs)>::max()));


### PR DESCRIPTION
Replace direct `.get_int64().value` access with `ViewValueOr_` helper for `max_time_limit_per_job` in `ViewToQos_`, providing a default value of `kJobMaxTimeLimitSec` to prevent potential crashes when the field is missing from the MongoDB document.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved system reliability by enhancing Quality of Service configuration handling. The system now safely processes QoS settings even when configuration fields are missing or contain invalid values, applying sensible defaults to ensure consistent operation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->