### PR TITLE
fix: Fix residual call in BPF building and remove redundant methods

### DIFF
--- a/src/CraneCtld/CtldPublicDefs.cpp
+++ b/src/CraneCtld/CtldPublicDefs.cpp
@@ -755,8 +755,13 @@ DaemonStepInCtld::StepStatusChange(crane::grpc::JobStatus new_status,
       // FreeJobs() and TerminateOrphanedStep() could be called concurrently for
       // the same daemon step, both trying to free the supervisor, double-freed.
 
-      // FreeJobs() is enough to free the daemon step's supervisor.
-      context->craned_jobs_to_free[craned_id].emplace_back(job->JobId());
+      // FreeJobs() is enough to free the daemon step's supervisor. It must be
+      // sent to every node allocated to this daemon step; otherwise nodes that
+      // did not trigger the final Configuring status change would never receive
+      // ShutdownSupervisor.
+      for (const auto& node : this->CranedIds()) {
+        context->craned_jobs_to_free[node].emplace_back(job->JobId());
+      }
       if (job->IsInteractive()) {
         auto& meta = std::get<InteractiveMeta>(job->meta);
         if (!meta.has_been_cancelled_on_front_end) {

--- a/src/Craned/Common/CgroupManager.cpp
+++ b/src/Craned/Common/CgroupManager.cpp
@@ -548,7 +548,7 @@ CgroupManager::AllocateAndGetCgroup(
       return cg_unique_ptr;
     }
     auto *cg_v2_ptr = dynamic_cast<CgroupV2 *>(cg_unique_ptr.get());
-    cg_v2_ptr->RecoverFromResInNode(resource);
+    cg_v2_ptr->RecoverFromCgSpec(resource);
 #endif
 
     return cg_unique_ptr;

--- a/src/Craned/Core/JobManager.cpp
+++ b/src/Craned/Core/JobManager.cpp
@@ -174,20 +174,6 @@ void ThawFrozenJobsWithPendingSigkill_(
   }
 }
 
-bool IsFinishedStepStatus_(StepStatus status) {
-  switch (status) {
-  case StepStatus::ExceedTimeLimit:
-  case StepStatus::OutOfMemory:
-  case StepStatus::Cancelled:
-  case StepStatus::Failed:
-  case StepStatus::Completed:
-    return true;
-
-  default:
-    return false;
-  }
-}
-
 std::optional<std::pair<uint32_t, std::string>>
 BuildUnexpectedSupervisorExitInfo_(pid_t pid, int status) {
   if (WIFSIGNALED(status)) {
@@ -569,7 +555,7 @@ void JobManager::RecordUnexpectedSupervisorExit_(pid_t pid, int status) {
 
       if (step->err_before_supv_start ||
           step->status == StepStatus::Completing ||
-          IsFinishedStepStatus_(step->status)) {
+          IsFinishedStepStatus(step->status)) {
         CRANE_TRACE(
             "[Step #{}.{}] Supervisor pid {} exited after step reached status "
             "{}, ignoring.",
@@ -647,7 +633,7 @@ void JobManager::HandleUnexpectedSupervisorExits_() {
       } else {
         auto* step = step_it->second.get();
         resolved = step->status == StepStatus::Completing ||
-                   IsFinishedStepStatus_(step->status);
+                   IsFinishedStepStatus(step->status);
       }
     }
 
@@ -882,20 +868,45 @@ CraneExpected<void> JobManager::ChangeStepTimeConstraint(
     job_id_t job_id, step_id_t step_id,
     std::optional<int64_t> time_limit_seconds,
     std::optional<int64_t> deadline_time) {
-  auto job = m_job_map_.GetValueExclusivePtr(job_id);
-  if (!job) {
-    CRANE_ERROR("[Step #{}.{}] Failed to find job allocation", job_id, step_id);
-    return std::unexpected{CraneErrCode::ERR_NON_EXISTENT};
+  auto is_step_missing_or_finished = [this, job_id, step_id]() {
+    auto job = m_job_map_.GetValueExclusivePtr(job_id);
+    if (!job) return true;
+
+    absl::MutexLock lock(job->step_map_mtx.get());
+    auto step_it = job->step_map.find(step_id);
+    if (step_it == job->step_map.end()) return true;
+
+    auto status = step_it->second->status;
+    return status == StepStatus::Completing || IsFinishedStepStatus(status);
+  };
+
+  std::shared_ptr<SupervisorStub> stub;
+  {
+    auto job = m_job_map_.GetValueExclusivePtr(job_id);
+    if (!job) {
+      CRANE_ERROR("[Step #{}.{}] Failed to find job allocation", job_id,
+                  step_id);
+      return std::unexpected{CraneErrCode::ERR_NON_EXISTENT};
+    }
+
+    absl::MutexLock lock(job->step_map_mtx.get());
+    auto step_it = job->step_map.find(step_id);
+    if (step_it == job->step_map.end()) {
+      CRANE_ERROR("[Step #{}.{}] Failed to find step allocation", job_id,
+                  step_id);
+      return std::unexpected{CraneErrCode::ERR_NON_EXISTENT};
+    }
+
+    auto status = step_it->second->status;
+    if (status == StepStatus::Completing || IsFinishedStepStatus(status))
+      return {};
+
+    stub = step_it->second->supervisor_stub;
   }
-  absl::MutexLock lock(job->step_map_mtx.get());
-  auto step_it = job->step_map.find(step_id);
-  if (step_it == job->step_map.end()) {
-    CRANE_ERROR("[Step #{}.{}] Failed to find step allocation", job_id,
-                step_id);
-    return std::unexpected{CraneErrCode::ERR_NON_EXISTENT};
-  }
-  auto& stub = step_it->second->supervisor_stub;
+
   if (!stub) {
+    if (is_step_missing_or_finished()) return {};
+
     CRANE_ERROR(
         "[Step #{}.{}] Supervisor stub is null when changing time constraint",
         job_id, step_id);
@@ -905,9 +916,12 @@ CraneExpected<void> JobManager::ChangeStepTimeConstraint(
         google::protobuf::util::TimeUtil::GetCurrentTime());
     return std::unexpected{CraneErrCode::ERR_RPC_FAILURE};
   }
+
   auto err = stub->ChangeStepTimeConstraint(time_limit_seconds, deadline_time);
   int64_t sec = time_limit_seconds.value_or(deadline_time.value_or(0));
   if (err != CraneErrCode::SUCCESS) {
+    if (is_step_missing_or_finished()) return {};
+
     CRANE_ERROR(
         "[Step #{}.{}] Failed to change step time constraint to {} seconds via "
         "supervisor RPC, err={}",

--- a/src/Craned/Supervisor/SupervisorServer.cpp
+++ b/src/Craned/Supervisor/SupervisorServer.cpp
@@ -154,6 +154,7 @@ grpc::Status SupervisorServiceImpl::ShutdownSupervisor(
              IsFinishedStepStatus(status)) {
     g_task_mgr->ShutdownSupervisorAsync(status);
   } else {
+    // Shutdown with default completed status.
     g_task_mgr->ShutdownSupervisorAsync();
   }
   return Status::OK;

--- a/src/Craned/Supervisor/TaskManager.cpp
+++ b/src/Craned/Supervisor/TaskManager.cpp
@@ -3378,7 +3378,8 @@ void TaskManager::EvCleanTerminateStepQueueCb_() {
 
     if (elem.mark_as_orphaned) m_step_.orphaned = true;
 
-    if (!elem.mark_as_orphaned && !m_step_.IsRunning()) {
+    auto status = m_step_.GetStatus();
+    if (!elem.mark_as_orphaned && status != StepStatus::Running) {
       not_ready_elems.emplace_back(elem);
       CRANE_DEBUG("Step is not ready to terminate, will check next time.");
       continue;
@@ -3442,16 +3443,10 @@ void TaskManager::EvCleanChangeStepTimeConstraintQueueCb_() {
       continue;
     }
 
-    if (!m_step_.IsRunning()) {
+    if (status != StepStatus::Running) {
       not_ready_elems.emplace_back(std::move(elem));
       CRANE_DEBUG(
           "Step is not ready to change time constraint will check next time.");
-      continue;
-    }
-
-    if (m_step_.AllTaskFinished()) {
-      CRANE_DEBUG("Change time constraint for a completing step, ignored.");
-      elem.ok_prom.set_value(CraneErrCode::SUCCESS);
       continue;
     }
 
@@ -3518,9 +3513,9 @@ void TaskManager::EvCleanChangeStepTimeConstraintQueueCb_() {
 
     elem.ok_prom.set_value(CraneErrCode::SUCCESS);
   }
-  for (auto& not_ready_elem : not_ready_elems) {
-    m_step_time_constraint_change_queue_.enqueue(std::move(not_ready_elem));
-  }
+
+  m_step_time_constraint_change_queue_.enqueue_bulk(
+      std::make_move_iterator(not_ready_elems.begin()), not_ready_elems.size());
 }
 
 void TaskManager::EvGrpcExecuteStepCb_() {

--- a/src/Craned/Supervisor/TaskManager.cpp
+++ b/src/Craned/Supervisor/TaskManager.cpp
@@ -2131,7 +2131,7 @@ CraneErrCode ProcInstance::Prepare() {
     auto meta = std::make_unique<BatchInstanceMeta>();
     m_meta_ = std::move(meta);
   }
-  if (IsCrun()) {
+  if (m_parent_step_inst_->IsCrun()) {
     auto* meta = GetCrunMeta_();
     {
       auto [path, fwd] = CrunParseFilePattern_(
@@ -2974,11 +2974,11 @@ void TaskManager::EvShutdownSupervisorCb_() {
       }
     }
 
+    // Non-daemon step don't need to report the status change in shutting down.
     m_step_.CleanUp();
 
     g_craned_client->Shutdown();
     g_server->Shutdown();
-
     this->Shutdown();
   } while (!got_final_status);
 }

--- a/src/Craned/Supervisor/TaskManager.cpp
+++ b/src/Craned/Supervisor/TaskManager.cpp
@@ -310,11 +310,9 @@ void StepInstance::GotNewStatus(StepStatus new_status) {
   }
 
   case StepStatus::Completing: {
-    // Daemon pod bootstrap may fail before the step ever reaches Running.
-    // In that case TaskFinish_ still drains the single synthetic pod task and
-    // transitions the step into Completing before reporting the final failure.
-    if (m_status_ != StepStatus::Running &&
-        !(this->IsDaemon() && m_status_ == StepStatus::Configuring))
+    // TODO: Daemon pod bootstrap may fail before the step ever reaches
+    // Running...
+    if (m_status_ != StepStatus::Running)
       CRANE_WARN(
           "[Step {}.{}] Step status is not 'Running' when receiving new "
           "status 'Completing', current status: {}.",
@@ -2822,8 +2820,8 @@ void TaskManager::EvExecuteDaemonPodCb_() {
     }
     requested = true;
 
-    // For pod step, use task_id=0 for placeholder.
-    task_id_t task_id = 0;
+    // CRI-managed steps only have one task whose id is fixed to kCriStepTaskId.
+    task_id_t task_id = kCriStepTaskId;
     m_step_.AddTaskInstance(task_id,
                             std::make_unique<PodInstance>(&m_step_, task_id));
     m_step_.task_ids.emplace_back(task_id);
@@ -3060,14 +3058,19 @@ void TaskManager::EvCleanSigchldQueueCb_() {
 
 void TaskManager::EvCleanCriEventQueueCb_() {
   // TODO: Refactor this to Craned.
+  CRANE_ASSERT_MSG(
+      m_step_.IsPod() || m_step_.IsContainer(),
+      "CRI event queue should only be used by pod/container steps");
+
   cri::api::ContainerStatus status;
   while (m_cri_event_queue_.try_dequeue(status)) {
     // NOTE: a CRI event comes at LEAST once.
-    // For container related steps, task_id always equals to 0.
-    auto* t = m_step_.GetTaskInstance(0);
+    auto* t = m_step_.GetTaskInstance(kCriStepTaskId);
     if (t == nullptr) continue;  // Duplicated event
 
     if (m_step_.IsPod()) {
+      // TODO: This branch is unused as pod doesn't have exit event in
+      // containerd currently.
       auto* task = dynamic_cast<PodInstance*>(t);
       const auto& exit_info = task->HandlePodExited();
 
@@ -3087,7 +3090,7 @@ void TaskManager::EvCleanCriEventQueueCb_() {
       std::unreachable();
     }
 
-    FinalizeTaskAsync(0);
+    FinalizeTaskAsync(kCriStepTaskId);
   }
 }
 
@@ -3282,8 +3285,6 @@ void TaskManager::EvCleanFinalizingTaskQueueCb_() {
 }
 
 void TaskManager::EvCleanTerminateDaemonPodQueueCb_() {
-  constexpr task_id_t kDaemonPodTaskId = 0;
-
   DaemonPodTerminateQueueElem elem;
   while (m_daemon_pod_terminate_queue_.try_dequeue(elem)) {
     CRANE_TRACE("Receive shutdown request for daemon pod #{}.{}.",
@@ -3317,7 +3318,7 @@ void TaskManager::EvCleanTerminateDaemonPodQueueCb_() {
     }
 
     auto shutdown = [&]() -> CraneExpectedRich<void> {
-      auto* task = m_step_.GetTaskInstance(kDaemonPodTaskId);
+      auto* task = m_step_.GetTaskInstance(kCriStepTaskId);
       if (task == nullptr) {
         CraneRichError rich_err;
         rich_err.set_code(CraneErrCode::ERR_NON_EXISTENT);
@@ -3339,7 +3340,7 @@ void TaskManager::EvCleanTerminateDaemonPodQueueCb_() {
         return std::unexpected(std::move(rich_err));
       }
 
-      FinalizeTaskAsync(kDaemonPodTaskId);
+      FinalizeTaskAsync(kCriStepTaskId);
       return {};
     };
 

--- a/src/Craned/Supervisor/TaskManager.cpp
+++ b/src/Craned/Supervisor/TaskManager.cpp
@@ -3434,17 +3434,27 @@ void TaskManager::EvCleanChangeStepTimeConstraintQueueCb_() {
   ChangeStepTimeConstraintQueueElem elem;
   std::vector<ChangeStepTimeConstraintQueueElem> not_ready_elems;
   while (m_step_time_constraint_change_queue_.try_dequeue(elem)) {
+    auto status = m_step_.GetStatus();
+    if (status == StepStatus::Completing || IsFinishedStepStatus(status)) {
+      CRANE_DEBUG(
+          "Change time constraint for a finished or completing step, ignored.");
+      elem.ok_prom.set_value(CraneErrCode::SUCCESS);
+      continue;
+    }
+
     if (!m_step_.IsRunning()) {
       not_ready_elems.emplace_back(std::move(elem));
       CRANE_DEBUG(
           "Step is not ready to change time constraint will check next time.");
       continue;
     }
+
     if (m_step_.AllTaskFinished()) {
       CRANE_DEBUG("Change time constraint for a completing step, ignored.");
       elem.ok_prom.set_value(CraneErrCode::SUCCESS);
       continue;
     }
+
     // Delete the old timer.
     DelTerminationTimer_();
     DelSignalTimers_();

--- a/src/Craned/Supervisor/TaskManager.h
+++ b/src/Craned/Supervisor/TaskManager.h
@@ -261,10 +261,7 @@ class ITaskInstance {
   ITaskInstance& operator=(ITaskInstance&&) = delete;
   ITaskInstance& operator=(const ITaskInstance&) = delete;
 
-  [[nodiscard]] bool IsBatch() const { return m_parent_step_inst_->IsBatch(); }
-  [[nodiscard]] bool IsCrun() const { return m_parent_step_inst_->IsCrun(); }
   // Helper methods shared by all task instances
-  StepInstance* GetParentStepInstance() const { return m_parent_step_inst_; }
   const StepToSupv& GetParentStep() const {
     return m_parent_step_inst_->GetStep();
   }

--- a/src/Craned/Supervisor/TaskManager.h
+++ b/src/Craned/Supervisor/TaskManager.h
@@ -158,9 +158,6 @@ class StepInstance {
   [[nodiscard]] bool IsContainer() const noexcept;
 
   [[nodiscard]] StepStatus GetStatus() const noexcept { return m_status_; }
-  [[nodiscard]] bool IsRunning() const noexcept {
-    return m_status_ == StepStatus::Running;
-  }
 
   const StepToSupv& GetStep() const noexcept { return m_step_to_supv_; }
   StepToSupv& GetMutableStep() { return m_step_to_supv_; }

--- a/src/Utilities/PublicHeader/include/crane/PublicHeader.h
+++ b/src/Utilities/PublicHeader/include/crane/PublicHeader.h
@@ -67,6 +67,8 @@ constexpr int MaxHealthCheckWaitTimeMs = 60000;
 
 inline const char* const kDefaultHost = "0.0.0.0";
 
+// CRI-managed steps (daemon pod / container step) only carry one task.
+constexpr task_id_t kCriStepTaskId = 0;
 constexpr step_id_t kDaemonStepId = 0;
 constexpr step_id_t kPrimaryStepId = 1;
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved cgroup v2 recovery behavior for certain recoveries.
  * Fixed daemon pod/task identification and ensured daemon cleanup is enqueued for all associated nodes.
  * Avoided erroneous errors when changing time constraints for already-missing or finished steps.

* **Refactor**
  * Consolidated task identifier handling using a standardized constant.
  * Simplified internal helper interfaces and streamlined step-status checks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->