### PR TITLE
fix: handle invalid status change

### DIFF
--- a/src/CraneCtld/CtldPublicDefs.cpp
+++ b/src/CraneCtld/CtldPublicDefs.cpp
@@ -635,6 +635,7 @@ DaemonStepInCtld::StepStatusChange(crane::grpc::JobStatus new_status,
       CRANE_ERROR("Invalid daemon step status transition, current: {}, new: {}",
                   util::StepStatusToString(this->Status()),
                   util::StepStatusToString(new_status));
+      return std::nullopt;
     }
 
     if (this->AllNodesConfigured() && this->PrologComplete()) {
@@ -716,6 +717,7 @@ DaemonStepInCtld::StepStatusChange(crane::grpc::JobStatus new_status,
       CRANE_ERROR("Invalid daemon step status transition, current: {}, new: {}",
                   util::StepStatusToString(this->Status()),
                   util::StepStatusToString(new_status));
+      return std::nullopt;
     }
 
     this->StepOnNodeFinish(craned_id);


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed improper handling of invalid daemon step status transitions; the system now properly rejects invalid transitions and aborts processing instead of continuing execution with potentially incorrect state values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->