### PR TITLE
docs: Update CRI/CNI support status for Slurm and LSF

### DIFF
--- a/docs/en/index.md
+++ b/docs/en/index.md
@@ -116,7 +116,7 @@ CraneSched comprehensively benchmarks against Slurm in scheduling capabilities, 
 | Job Dependencies | :material-check-circle:{ .success } | :material-check-circle:{ .success } | :material-check-circle:{ .success } | Control dependency relationships between jobs |
 | Job Arrays | :material-check-circle:{ .success } | :material-check-circle:{ .success } | :material-check-circle:{ .success } | Batch submission of parameterized jobs |
 | QOS Management | :material-check-circle:{ .success } | :material-check-circle:{ .success } | :material-check-circle:{ .success } | Differentiated service level control |
-| Native Container Orchestration (CRI/CNI) | :material-check-circle:{ .success } | :material-close-circle:{ .danger } | :material-close-circle:{ .danger } | Native container orchestration based on CRI/CNI standards |
+| Native Container Orchestration (CRI/CNI) | :material-check-circle:{ .success } | :material-check-circle:{ .success } | :material-check-circle:{ .success } | Native container orchestration based on CRI/CNI standards |
 | Multi-Tenant Container Network Isolation | :material-check-circle:{ .success } | :material-close-circle:{ .danger } | :material-close-circle:{ .danger } | CNI-based multi-tenant network isolation (Calico Underlay) |
 | Container RDMA Network Support | :material-check-circle:{ .success } | :material-close-circle:{ .danger } | :material-close-circle:{ .danger } | Supports SR-IOV shared RNIC and direct passthrough |
 | Extended Hardware Compatibility | :material-check-circle:{ .success } | :material-close-circle:{ .danger } | :material-close-circle:{ .danger } | Supports diverse CPU architectures (x86, ARM, RISC-V) and accelerators from multiple vendors including Nvidia, AMD, Huawei Ascend, and more |

--- a/docs/zh/index.md
+++ b/docs/zh/index.md
@@ -116,7 +116,7 @@ hide:
 | 作业依赖（Job Dependencies） | :material-check-circle:{ .success } | :material-check-circle:{ .success } | :material-check-circle:{ .success } | 作业间依赖关系控制 |
 | 作业数组（Job Array） | :material-check-circle:{ .success } | :material-check-circle:{ .success } | :material-check-circle:{ .success } | 批量提交参数化作业 |
 | QOS 服务质量管理 | :material-check-circle:{ .success } | :material-check-circle:{ .success } | :material-check-circle:{ .success } | 差异化服务等级控制 |
-| 容器原生编排（CRI/CNI） | :material-check-circle:{ .success } | :material-close-circle:{ .danger } | :material-close-circle:{ .danger } | 基于 CRI/CNI 标准的原生容器编排 |
+| 容器原生编排（CRI/CNI） | :material-check-circle:{ .success } | :material-check-circle:{ .success } | :material-check-circle:{ .success } | 基于 CRI/CNI 标准的原生容器编排 |
 | 多租户容器网络隔离 | :material-check-circle:{ .success } | :material-close-circle:{ .danger } | :material-close-circle:{ .danger } | 支持 CNI 多租户网络隔离（Calico Underlay） |
 | 容器 RDMA 网络支持 | :material-check-circle:{ .success } | :material-close-circle:{ .danger } | :material-close-circle:{ .danger } | 支持 SR-IOV 共享 RNIC 和直接透传 |
 | 国产化信创全面适配 | :material-check-circle:{ .success } | :material-close-circle:{ .danger } | :material-close-circle:{ .danger } | 全面适配国产 CPU、GPU/NPU、操作系统 |


### PR DESCRIPTION
Mark Slurm and LSF as supporting Native Container Orchestration (CRI/CNI) in the feature comparison table for both zh and en docs.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Updated Native Container Orchestration (CRI/CNI) feature support status for Slurm and LSF in feature completeness documentation, with updates applied to both English and Chinese versions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->