### PR TITLE
fix: exit code not set

### DIFF
--- a/src/CraneCtld/JobScheduler.cpp
+++ b/src/CraneCtld/JobScheduler.cpp
@@ -175,6 +175,7 @@ bool JobScheduler::Init() {
       auto result = AcquireJobAttributes(job.get());
       if (!result || job->type == crane::grpc::Interactive) {
         job->SetStatus(crane::grpc::Failed);
+        job->SetExitCode(ExitCode::EC_CRANED_DOWN);
         auto now = absl::Now();
         auto max_end_time = job->StartTime() + job->time_limit;
         auto end_time = std::min(now, max_end_time);

--- a/src/CraneCtld/JobScheduler.cpp
+++ b/src/CraneCtld/JobScheduler.cpp
@@ -175,7 +175,9 @@ bool JobScheduler::Init() {
       auto result = AcquireJobAttributes(job.get());
       if (!result || job->type == crane::grpc::Interactive) {
         job->SetStatus(crane::grpc::Failed);
-        job->SetExitCode(ExitCode::EC_CRANED_DOWN);
+        if (!result) {
+          job->SetExitCode(ExitCode::EC_CRANED_DOWN);
+        }
         auto now = absl::Now();
         auto max_end_time = job->StartTime() + job->time_limit;
         auto end_time = std::min(now, max_end_time);

--- a/src/CraneCtld/JobScheduler.cpp
+++ b/src/CraneCtld/JobScheduler.cpp
@@ -175,7 +175,7 @@ bool JobScheduler::Init() {
       auto result = AcquireJobAttributes(job.get());
       if (!result || job->type == crane::grpc::Interactive) {
         job->SetStatus(crane::grpc::Failed);
-        if (!result) {
+        if (result) {
           job->SetExitCode(ExitCode::EC_CRANED_DOWN);
         }
         auto now = absl::Now();


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved job recovery during restart: failed or interactive jobs are consistently marked Failed, and recovered jobs now get the specific "crane down" exit status only when their attributes could be successfully retrieved.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/PKUHPC/CraneSched/pull/893?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->