### PR TITLE
fix: Gres limit not applied when no gres requested

### DIFF
--- a/src/Craned/Common/CgroupManager.cpp
+++ b/src/Craned/Common/CgroupManager.cpp
@@ -2285,13 +2285,13 @@ bool ResourceInNodeV3Allocator::Allocate(const ResourceInNodeV3& resource,
       all_request_slots.insert(slots.cbegin(), slots.cend());
   }
 
-  if (!all_request_slots.empty()) {
-    if (!cg->SetDeviceAccess(all_request_slots, CgConstant::kCgLimitDeviceRead,
-                             CgConstant::kCgLimitDeviceWrite,
-                             CgConstant::kCgLimitDeviceMknod)) {
-      CRANE_WARN("Allocate devices access failed.");
-      return false;
-    }
+  if (g_this_node_device.empty()) return true;
+
+  if (!cg->SetDeviceAccess(all_request_slots, CgConstant::kCgLimitDeviceRead,
+                           CgConstant::kCgLimitDeviceWrite,
+                           CgConstant::kCgLimitDeviceMknod)) {
+    CRANE_WARN("Allocate devices access failed in Cgroup V1.");
+    return false;
   }
 
   return ok;

--- a/src/Craned/Core/StepInstance.cpp
+++ b/src/Craned/Core/StepInstance.cpp
@@ -46,7 +46,8 @@ StepInstance::StepInstance(const crane::grpc::StepToD& step_to_d,
       supervisor_stub(supervisor_stub) {}
 
 void StepInstance::CleanUp() {
-  if (!IsFinishedStepStatus(this->status)) {
+  if (this->status != StepStatus::Completing &&
+      !IsFinishedStepStatus(this->status)) {
     CRANE_WARN(
         "[Step #{}.{}] Cleaning up a step which is not in finished status, "
         "current status: {}.",


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Skip device isolation setup when the node has no configured devices, improving startup efficiency.
  * More specific warning when device access setup fails.
  * Suppress an unnecessary cleanup warning during step completion; warning now appears only for truly non‑finished states.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->