### PR TITLE
feat: async launching tasks and make image pulling timeout configurable

### DIFF
--- a/docs/en/deployment/configuration/config.md
+++ b/docs/en/deployment/configuration/config.md
@@ -401,6 +401,12 @@ Container:
   # Path to image service socket (usually same as RuntimeEndpoint)
   ImageEndpoint: /run/containerd/containerd.sock
 
+  # Image pulling timeout in seconds
+  ImagePullingTimeout: 600
+
+  # Whether to enable user namespace by default when submitting containers
+  UserNsEnabledByDefault: true
+
   # DNS configuration (optional)
   Dns:
     ClusterDomain: "cluster.local"

--- a/docs/en/deployment/container.md
+++ b/docs/en/deployment/container.md
@@ -423,6 +423,12 @@ Container:
   # CRI image service socket (usually same as RuntimeEndpoint)
   ImageEndpoint: /run/containerd/containerd.sock
 
+  # Image pulling timeout in seconds
+  ImagePullingTimeout: 600
+
+  # Whether to enable user namespace by default when submitting containers
+  UserNsEnabledByDefault: true
+
   # DNS configuration
   Dns:
     ClusterDomain: "cluster.local"
@@ -454,6 +460,8 @@ Container:
 | `TempDir` | string | `supervisor/containers/` | Temporary data directory during container runtime, relative to `CraneBaseDir`. Stores container metadata, logs, etc. |
 | `RuntimeEndpoint` | string | - | **Required**. Unix socket path for the CRI runtime service, used for container lifecycle management (create, start, stop, etc.) |
 | `ImageEndpoint` | string | Same as `RuntimeEndpoint` | Unix socket path for the CRI image service, used for image pulling and management. Usually the same as `RuntimeEndpoint` |
+| `ImagePullingTimeout` | integer | `600` | Image pulling RPC timeout in seconds |
+| `UserNsEnabledByDefault` | bool | `true` | Whether to enable user namespace by default when submitting containers. Affects the default of `ccon run --userns` and `cbatch --pod --pod-userns`; explicit CLI flags still take priority |
 
 ### DNS Configuration
 

--- a/docs/zh/deployment/configuration/config.md
+++ b/docs/zh/deployment/configuration/config.md
@@ -399,6 +399,12 @@ Container:
   # 镜像服务套接字路径（通常与 RuntimeEndpoint 相同）
   ImageEndpoint: /run/containerd/containerd.sock
 
+  # 镜像拉取超时时间（秒）
+  ImagePullingTimeout: 600
+
+  # 提交容器时是否默认启用用户命名空间
+  UserNsEnabledByDefault: true
+
   # DNS 配置
   Dns:
     ClusterDomain: "cluster.local"

--- a/docs/zh/deployment/container.md
+++ b/docs/zh/deployment/container.md
@@ -421,6 +421,12 @@ Container:
   # CRI 镜像服务套接字（通常与 RuntimeEndpoint 相同）
   ImageEndpoint: /run/containerd/containerd.sock
 
+  # 镜像拉取超时时间（秒）
+  ImagePullingTimeout: 600
+
+  # 提交容器时是否默认启用用户命名空间
+  UserNsEnabledByDefault: true
+
   # DNS 配置
   Dns:
     ClusterDomain: "cluster.local"
@@ -435,7 +441,7 @@ Container:
       - { Id: 0, IdCount: 2000, SubIdStart: 100000, SubIdSize: 65536 }
     GidMappings:
       - { Id: 0, IdCount: 2000, SubIdStart: 100000, SubIdSize: 65536 }
-  
+
   # BindFs 配置（可选，用于用户命名空间映射）
   BindFs:
     Enabled: false
@@ -452,6 +458,8 @@ Container:
 | `TempDir` | string | `supervisor/containers/` | 容器运行期间的临时数据目录，相对于 `CraneBaseDir`。存储容器元数据、日志等 |
 | `RuntimeEndpoint` | string | — | **必填**。CRI 运行时服务的 Unix 套接字路径，用于容器生命周期管理（创建、启动、停止等） |
 | `ImageEndpoint` | string | 同 `RuntimeEndpoint` | CRI 镜像服务的 Unix 套接字路径，用于镜像拉取与管理。大多数情况下与 `RuntimeEndpoint` 相同 |
+| `ImagePullingTimeout` | integer | `600` | 镜像拉取 RPC 超时时间，单位为秒 |
+| `UserNsEnabledByDefault` | bool | `true` | 提交容器时是否默认启用用户命名空间。影响 `ccon run --userns` 与 `cbatch --pod --pod-userns` 的默认值，显式指定的命令行参数仍具有更高优先级 |
 
 ### DNS 配置
 

--- a/etc/config.yaml
+++ b/etc/config.yaml
@@ -248,6 +248,8 @@ Container:
   RuntimeEndpoint: /run/containerd/containerd.sock
   # In most cases, ImageEndpoint is the same as RuntimeEndpoint
   ImageEndpoint: /run/containerd/containerd.sock
+  # Image pulling timeout in seconds
+  ImagePullingTimeout: 600
   # Toggle whether to enable user namespace by default when submitting containers
   UserNsEnabledByDefault: true
   # DNS configuration for containers

--- a/protos/Supervisor.proto
+++ b/protos/Supervisor.proto
@@ -75,6 +75,8 @@ message InitSupervisorRequest {
       repeated string options = 4;
     }
     DnsConfig dns_config = 6;
+
+    optional int64 image_pulling_timeout_seconds = 7;
   }
   ContainerConfig container_config = 15;
 

--- a/src/CraneCtld/JobScheduler.cpp
+++ b/src/CraneCtld/JobScheduler.cpp
@@ -21,6 +21,8 @@
 #include <absl/time/internal/cctz/src/time_zone_if.h>
 #include <google/protobuf/util/time_util.h>
 
+#include <iterator>
+
 #include "Account/AccountManager.h"
 #include "Accounting/AccountMetaContainer.h"
 #include "Accounting/LicenseManager.h"
@@ -4522,7 +4524,7 @@ void JobScheduler::CleanCancelJobQueueCb_() {
   if (approximate_size == 0) return;
 
   std::vector<CancelJobQueueElem> jobs_to_cancel;
-  jobs_to_cancel.resize(approximate_size);
+  jobs_to_cancel.reserve(approximate_size);
 
   // Carry the ownership of JobInCtld for automatic destruction.
   std::vector<std::unique_ptr<JobInCtld>> pending_job_ptr_vec;
@@ -4535,8 +4537,7 @@ void JobScheduler::CleanCancelJobQueueCb_() {
       running_job_craned_id_map;
 
   size_t actual_size = m_cancel_job_queue_.try_dequeue_bulk(
-      jobs_to_cancel.begin(), approximate_size);
-  jobs_to_cancel.resize(actual_size);
+      std::back_inserter(jobs_to_cancel), approximate_size);
   if (actual_size == 0) return;
 
   // For pending jobs and array parents, finish scheduler-side metadata. For

--- a/src/Craned/Core/Craned.cpp
+++ b/src/Craned/Core/Craned.cpp
@@ -334,6 +334,18 @@ void ParseContainerConfig(const YAML::Node& container_config) {
       YamlValueOr(container_config["ImageEndpoint"],
                   g_config.Container.RuntimeEndpoint.string());
 
+  auto image_pulling_timeout_sec =
+      YamlValueOr<int64_t>(container_config["ImagePullingTimeout"],
+                           cri::kCriDefaultImagePullingTimeout.count());
+  if (image_pulling_timeout_sec <= 0) {
+    CRANE_WARN(
+        "Container.ImagePullingTimeout is {}, fallback to default {} seconds.",
+        image_pulling_timeout_sec, cri::kCriDefaultImagePullingTimeout.count());
+    image_pulling_timeout_sec = cri::kCriDefaultImagePullingTimeout.count();
+  }
+  g_config.Container.ImagePullingTimeout =
+      std::chrono::seconds(image_pulling_timeout_sec);
+
   // Prepend unix protocol
   g_config.Container.RuntimeEndpoint =
       fmt::format("unix://{}", g_config.Container.RuntimeEndpoint);

--- a/src/Craned/Core/CranedPublicDefs.h
+++ b/src/Craned/Core/CranedPublicDefs.h
@@ -107,6 +107,7 @@ struct Config {
     std::filesystem::path TempDir;
     std::filesystem::path RuntimeEndpoint;
     std::filesystem::path ImageEndpoint;
+    std::chrono::seconds ImagePullingTimeout;
 
     struct DnsConfig {
       std::string ClusterDomain{"cluster.local"};

--- a/src/Craned/Core/StepInstance.cpp
+++ b/src/Craned/Core/StepInstance.cpp
@@ -253,6 +253,8 @@ CraneErrCode StepInstance::SpawnSupervisor(const EnvMap& job_env_map) {
       container_conf->set_temp_dir(g_config.Container.TempDir);
       container_conf->set_runtime_endpoint(g_config.Container.RuntimeEndpoint);
       container_conf->set_image_endpoint(g_config.Container.ImageEndpoint);
+      container_conf->set_image_pulling_timeout_seconds(
+          g_config.Container.ImagePullingTimeout.count());
       auto* dns_conf = container_conf->mutable_dns_config();
       dns_conf->set_cluster_domain(g_config.Container.Dns.ClusterDomain);
       for (const auto& s : g_config.Container.Dns.Servers)

--- a/src/Craned/Core/SupervisorStub.cpp
+++ b/src/Craned/Core/SupervisorStub.cpp
@@ -104,9 +104,9 @@ CraneErrCode SupervisorStub::ExecuteStep() {
   crane::grpc::supervisor::StepExecutionRequest request;
   crane::grpc::supervisor::StepExecutionReply reply;
 
-  auto ok = m_stub_->ExecuteStep(&context, request, &reply);
-  if (!ok.ok()) {
-    CRANE_ERROR("ExecuteStep failed: reply {},{}", ok.ok(), ok.error_message());
+  auto status = m_stub_->ExecuteStep(&context, request, &reply);
+  if (!status.ok()) {
+    CRANE_ERROR("ExecuteStep RPC failed: {}", status.error_message());
     return CraneErrCode::ERR_RPC_FAILURE;
   }
 

--- a/src/Craned/Supervisor/CforedClient.cpp
+++ b/src/Craned/Supervisor/CforedClient.cpp
@@ -510,7 +510,16 @@ void CforedClient::CleanOutputQueueAndWriteToStreamThread_(
         stream,
     std::atomic<bool>* write_pending) {
   CRANE_TRACE("CleanOutputQueueThread started.");
-  FwdRequest fwd_req;
+  FwdRequest fwd_req{
+      .type = StreamStepIORequest::TASK_OUTPUT,
+      .data =
+          IOFwdRequest{
+              .is_stdout = true,
+              .task_id = 0,
+              .data = nullptr,
+              .len = 0,
+          },
+  };
   bool ok = m_task_fwd_req_queue_.try_dequeue(fwd_req);
 
   // Make sure before exit all output has been drained.

--- a/src/Craned/Supervisor/Supervisor.cpp
+++ b/src/Craned/Supervisor/Supervisor.cpp
@@ -25,6 +25,7 @@
 #include "CranedClient.h"
 #include "SupervisorServer.h"
 #include "TaskManager.h"
+#include "crane/CriClient.h"
 #include "crane/PasswordEntry.h"
 #include "crane/PluginClient.h"
 #include "crane/String.h"
@@ -136,6 +137,21 @@ int InitFromStdin(int argc, char** argv) {
     g_config.Container.RuntimeEndpoint =
         msg.container_config().runtime_endpoint();
     g_config.Container.ImageEndpoint = msg.container_config().image_endpoint();
+    g_config.Container.ImagePullingTimeout =
+        msg.container_config().has_image_pulling_timeout_seconds()
+            ? std::chrono::seconds(
+                  msg.container_config().image_pulling_timeout_seconds())
+            : cri::kCriDefaultImagePullingTimeout;
+    if (g_config.Container.ImagePullingTimeout <=
+        std::chrono::seconds::zero()) {
+      CRANE_WARN(
+          "Container.ImagePullingTimeout is {}, fallback to default {} "
+          "seconds.",
+          g_config.Container.ImagePullingTimeout.count(),
+          cri::kCriDefaultImagePullingTimeout.count());
+      g_config.Container.ImagePullingTimeout =
+          cri::kCriDefaultImagePullingTimeout;
+    }
 
     if (msg.container_config().has_dns_config()) {
       const auto& dc = msg.container_config().dns_config();

--- a/src/Craned/Supervisor/Supervisor.cpp
+++ b/src/Craned/Supervisor/Supervisor.cpp
@@ -144,11 +144,8 @@ int InitFromStdin(int argc, char** argv) {
             : cri::kCriDefaultImagePullingTimeout;
     if (g_config.Container.ImagePullingTimeout <=
         std::chrono::seconds::zero()) {
-      CRANE_WARN(
-          "Container.ImagePullingTimeout is {}, fallback to default {} "
-          "seconds.",
-          g_config.Container.ImagePullingTimeout.count(),
-          cri::kCriDefaultImagePullingTimeout.count());
+      // Sliently reset to default if the configured timeout is invalid.
+      // No log because supervisor is not ready yet.
       g_config.Container.ImagePullingTimeout =
           cri::kCriDefaultImagePullingTimeout;
     }

--- a/src/Craned/Supervisor/SupervisorPublicDefs.h
+++ b/src/Craned/Supervisor/SupervisorPublicDefs.h
@@ -56,6 +56,7 @@ struct Config {
     std::filesystem::path TempDir;
     std::filesystem::path RuntimeEndpoint;
     std::filesystem::path ImageEndpoint;
+    std::chrono::seconds ImagePullingTimeout;
 
     struct DnsConfig {
       std::string ClusterDomain{"cluster.local"};

--- a/src/Craned/Supervisor/SupervisorServer.cpp
+++ b/src/Craned/Supervisor/SupervisorServer.cpp
@@ -28,12 +28,10 @@ grpc::Status SupervisorServiceImpl::ExecuteStep(
     const crane::grpc::supervisor::StepExecutionRequest* request,
     crane::grpc::supervisor::StepExecutionReply* response) {
   CRANE_ASSERT(g_config.StepSpec.step_type() != crane::grpc::StepType::DAEMON);
-  std::future<CraneErrCode> code_future = g_task_mgr->ExecuteStepAsync();
+  auto code_future = g_task_mgr->ExecuteStepAsync();
   code_future.wait();
 
-  CraneErrCode ok = code_future.get();
-  response->set_code(ok);
-
+  response->set_code(code_future.get());
   return Status::OK;
 }
 

--- a/src/Craned/Supervisor/TaskManager.cpp
+++ b/src/Craned/Supervisor/TaskManager.cpp
@@ -3812,7 +3812,7 @@ void TaskManager::EvGrpcExecuteStepCb_() {
       }
 
       auto exec_id = task->GetExecId().value();
-      CRANE_INFO("[task #{}] Launched exection, id: {}.", task_id,
+      CRANE_INFO("[task #{}] Launched execution, id: {}.", task_id,
                  std::visit([](auto&& arg) { return std::format("{}", arg); },
                             exec_id));
       m_exec_id_task_id_map_[exec_id] = task_id;

--- a/src/Craned/Supervisor/TaskManager.cpp
+++ b/src/Craned/Supervisor/TaskManager.cpp
@@ -2881,6 +2881,39 @@ CraneErrCode TaskManager::LaunchExecution_(ITaskInstance* task) {
   return CraneErrCode::SUCCESS;
 }
 
+void TaskManager::AbortTasksAfterLaunchFailure_(task_id_t failed_task_id,
+                                                const std::string& reason) {
+  CRANE_ASSERT_MSG(
+      !m_step_.IsDaemon(),
+      "Daemon step should not use this fail-fast path for multiple tasks.");
+
+  for (auto task_id : m_step_.GetTaskIds()) {
+    // The failed task was already finalized by LaunchExecution_; keep its root
+    // failure cause instead of rewriting it as a sibling launch abort.
+    if (task_id == failed_task_id) continue;
+
+    auto* task = m_step_.GetTaskInstance(task_id);
+    if (task == nullptr) continue;
+
+    auto* final_info = task->GetFinalInfo();
+    final_info->cause = TaskFinalizeCause::STEP_LAUNCH_ABORTED;
+    final_info->reason = reason;
+
+    if (task->GetExecId().has_value()) {
+      // Process-backed tasks must be finalized by their exit event after Kill();
+      // finalizing here would race the SIGCHLD/CRI/cfored completion path.
+      auto err = task->Kill(SIGKILL);
+      if (err != CraneErrCode::SUCCESS) {
+        CRANE_WARN("[task #{}] Failed to kill after launch failure: {}",
+                   task_id, static_cast<int>(err));
+      }
+      continue;
+    }
+
+    FinalizeTaskAsync(task_id, TaskFinalizeCause::STEP_LAUNCH_ABORTED, reason);
+  }
+}
+
 void TaskManager::EvExecuteDaemonPodCb_() {
   // This method is only for pod in daemon step.
   CRANE_ASSERT_MSG(m_step_.IsPod(), "PreparePodTask is called in other cases!");
@@ -3266,6 +3299,10 @@ void TaskManager::EvCleanFinalizingTaskQueueCb_() {
     case TaskFinalizeCause::TASK_SPAWN_FAILED:
       ResolveFinishedTask_(task_id, crane::grpc::JobStatus::Failed,
                            ExitCode::EC_SPAWN_FAILED, fi->reason);
+      continue;
+    case TaskFinalizeCause::STEP_LAUNCH_ABORTED:
+      ResolveFinishedTask_(task_id, crane::grpc::JobStatus::Failed, 0,
+                           fi->reason);
       continue;
     case TaskFinalizeCause::STEP_PWD_LOOKUP_FAILED:
       ResolveFinishedTask_(task_id, crane::grpc::JobStatus::Failed,
@@ -3696,8 +3733,7 @@ void TaskManager::EvGrpcExecuteStepCb_() {
       }
     }
 
-    // TODO: We dont need to exec task for a calloc job
-
+    // TODO: We don't need to exec task for a calloc job
     if (!m_step_.IsDaemon()) {
       // Add a timer to limit the execution time of a task.
 
@@ -3708,7 +3744,7 @@ void TaskManager::EvGrpcExecuteStepCb_() {
 
       std::string log_timer =
           deadline_sec <= time_limit_sec ? "deadline" : "time_limit";
-      bool is_deadline = deadline_sec <= time_limit_sec ? true : false;
+      bool is_deadline = deadline_sec <= time_limit_sec;
 
       AddTerminationTimer_(sec, is_deadline);
       CRANE_TRACE("Add a {} timer of {} seconds", log_timer, sec);
@@ -3760,24 +3796,23 @@ void TaskManager::EvGrpcExecuteStepCb_() {
     m_step_.InitOomBaseline();
     // Single threaded here, it is always safe to ask TaskManager to
     // operate (Like terminate due to cfored conn err for crun task) any task.
-    // Per-task launch failures are reported by LaunchExecution_ itself via
-    // FinalizeTaskAsync(TASK_PREPARE_FAILED / TASK_SPAWN_FAILED), which
-    // routes through ResolveFinishedTask_ -> StepStatusChangeAsync.
-    // Surviving siblings keep running; the step terminal is emitted when
-    // the last survivor finishes.
+    // TODO: Maybe we can launch tasks in parallel?
     for (auto task_id : m_step_.task_ids) {
       auto* task = m_step_.GetTaskInstance(task_id);
-      // TODO: Maybe we can launch tasks in parallel
-      auto task_err = LaunchExecution_(task);
-      if (task_err != CraneErrCode::SUCCESS) {
+      auto err = LaunchExecution_(task);
+      if (err != CraneErrCode::SUCCESS) {
         CRANE_WARN("[task #{}] Failed to launch process.", task_id);
-      } else {
-        auto exec_id = task->GetExecId().value();
-        CRANE_INFO("[task #{}] Launched exection, id: {}.", task_id,
-                   std::visit([](auto&& arg) { return std::format("{}", arg); },
-                              exec_id));
-        m_exec_id_task_id_map_[exec_id] = task_id;
+        AbortTasksAfterLaunchFailure_(
+            task_id, std::format("Task #{} failed to launch, code: {}", task_id,
+                                 static_cast<int>(err)));
+        break;
       }
+
+      auto exec_id = task->GetExecId().value();
+      CRANE_INFO("[task #{}] Launched exection, id: {}.", task_id,
+                 std::visit([](auto&& arg) { return std::format("{}", arg); },
+                            exec_id));
+      m_exec_id_task_id_map_[exec_id] = task_id;
     }
   }
 }

--- a/src/Craned/Supervisor/TaskManager.cpp
+++ b/src/Craned/Supervisor/TaskManager.cpp
@@ -2848,9 +2848,9 @@ std::future<CraneErrCode> TaskManager::ExecuteStepAsync() {
   std::future ok_future = ok_promise.get_future();
 
   auto elem = ExecuteStepElem{.ok_prom = std::move(ok_promise)};
-
   m_grpc_execute_step_queue_.enqueue(std::move(elem));
   m_grpc_execute_step_async_handle_->send();
+
   return ok_future;
 }
 
@@ -3643,13 +3643,13 @@ void TaskManager::EvGrpcExecuteStepCb_() {
           "Container step #{}.{} has {} tasks, but container steps only "
           "support exactly one task. Rejecting.",
           m_step_.job_id, m_step_.step_id, m_step_.task_ids.size());
-      for (auto task_id : m_step_.task_ids)
-        g_task_mgr->FinalizeTaskAsync(
-            task_id, TaskFinalizeCause::STEP_PREPARE_FAILED,
-            "Container steps only support exactly one task");
       elem.ok_prom.set_value(CraneErrCode::ERR_INVALID_PARAM);
       continue;
     }
+
+    // Admission checks passed. Return to the ExecuteStep RPC caller before any
+    // potentially slow pwd/prepare/cgroup/container image pull/spawn work.
+    elem.ok_prom.set_value(CraneErrCode::SUCCESS);
 
     m_step_.GotNewStatus(StepStatus::Running);
 
@@ -3678,7 +3678,6 @@ void TaskManager::EvGrpcExecuteStepCb_() {
             task_id, TaskFinalizeCause::STEP_PWD_LOOKUP_FAILED,
             fmt::format("Failed to look up password entry for uid {}",
                         m_step_.uid));
-      elem.ok_prom.set_value(CraneErrCode::ERR_SYSTEM_ERR);
       continue;
     }
 
@@ -3693,7 +3692,6 @@ void TaskManager::EvGrpcExecuteStepCb_() {
               std::format("Failed to prepare step, code: {}",
                           static_cast<int>(err)));
         }
-        elem.ok_prom.set_value(CraneErrCode::ERR_SYSTEM_ERR);
         continue;
       }
     }
@@ -3741,7 +3739,6 @@ void TaskManager::EvGrpcExecuteStepCb_() {
       // get short-circuited by the "no running task" fast path before the
       // interactive no-process finalization logic can run.
       m_exec_id_task_id_map_[0] = 0;
-      elem.ok_prom.set_value(CraneErrCode::SUCCESS);
       continue;
     }
     auto cg_expt = CgroupManager::AllocateAndGetCgroup(
@@ -3756,7 +3753,6 @@ void TaskManager::EvGrpcExecuteStepCb_() {
                                       TaskFinalizeCause::STEP_CGROUP_FAILED,
                                       "Failed to allocate cgroup");
       }
-      elem.ok_prom.set_value(CraneErrCode::ERR_CGROUP);
       continue;
     }
     m_step_.step_user_cg = std::move(cg_expt.value());
@@ -3764,14 +3760,17 @@ void TaskManager::EvGrpcExecuteStepCb_() {
     m_step_.InitOomBaseline();
     // Single threaded here, it is always safe to ask TaskManager to
     // operate (Like terminate due to cfored conn err for crun task) any task.
-    CraneErrCode err = CraneErrCode::SUCCESS;
+    // Per-task launch failures are reported by LaunchExecution_ itself via
+    // FinalizeTaskAsync(TASK_PREPARE_FAILED / TASK_SPAWN_FAILED), which
+    // routes through ResolveFinishedTask_ -> StepStatusChangeAsync.
+    // Surviving siblings keep running; the step terminal is emitted when
+    // the last survivor finishes.
     for (auto task_id : m_step_.task_ids) {
       auto* task = m_step_.GetTaskInstance(task_id);
       // TODO: Maybe we can launch tasks in parallel
       auto task_err = LaunchExecution_(task);
       if (task_err != CraneErrCode::SUCCESS) {
         CRANE_WARN("[task #{}] Failed to launch process.", task_id);
-        err = task_err;
       } else {
         auto exec_id = task->GetExecId().value();
         CRANE_INFO("[task #{}] Launched exection, id: {}.", task_id,
@@ -3780,8 +3779,6 @@ void TaskManager::EvGrpcExecuteStepCb_() {
         m_exec_id_task_id_map_[exec_id] = task_id;
       }
     }
-
-    elem.ok_prom.set_value(err);
   }
 }
 

--- a/src/Craned/Supervisor/TaskManager.cpp
+++ b/src/Craned/Supervisor/TaskManager.cpp
@@ -2900,8 +2900,9 @@ void TaskManager::AbortTasksAfterLaunchFailure_(task_id_t failed_task_id,
     final_info->reason = reason;
 
     if (task->GetExecId().has_value()) {
-      // Process-backed tasks must be finalized by their exit event after Kill();
-      // finalizing here would race the SIGCHLD/CRI/cfored completion path.
+      // Process-backed tasks must be finalized by their exit event after
+      // Kill(); finalizing here would race the SIGCHLD/CRI/cfored completion
+      // path.
       auto err = task->Kill(SIGKILL);
       if (err != CraneErrCode::SUCCESS) {
         CRANE_WARN("[task #{}] Failed to kill after launch failure: {}",
@@ -3301,6 +3302,7 @@ void TaskManager::EvCleanFinalizingTaskQueueCb_() {
                            ExitCode::EC_SPAWN_FAILED, fi->reason);
       continue;
     case TaskFinalizeCause::STEP_LAUNCH_ABORTED:
+      // Do not let sibling aborts override the root launch failure exit code.
       ResolveFinishedTask_(task_id, crane::grpc::JobStatus::Failed, 0,
                            fi->reason);
       continue;

--- a/src/Craned/Supervisor/TaskManager.cpp
+++ b/src/Craned/Supervisor/TaskManager.cpp
@@ -1704,7 +1704,8 @@ CraneErrCode ContainerInstance::Prepare() {
   // Pull image according to pull policy
   auto image_id_opt = cri_client->PullImage(
       ca_meta->image().image(), ca_meta->image().username(),
-      ca_meta->image().password(), ca_meta->image().pull_policy());
+      ca_meta->image().password(), ca_meta->image().pull_policy(),
+      g_config.Container.ImagePullingTimeout);
 
   if (!image_id_opt.has_value()) {
     CRANE_ERROR("Failed to pull image {} for container step #{}.{}",

--- a/src/Craned/Supervisor/TaskManager.h
+++ b/src/Craned/Supervisor/TaskManager.h
@@ -43,6 +43,7 @@ enum class TaskFinalizeCause : uint8_t {
   STEP_PWD_LOOKUP_FAILED,
   STEP_PREPARE_FAILED,
   STEP_CGROUP_FAILED,
+  STEP_LAUNCH_ABORTED,
   CANCELLED_BY_USER,
   CFORED_DISCONNECTED,
   DAEMON_POD_SHUTDOWN_REQUESTED,
@@ -618,6 +619,8 @@ class TaskManager {
   }
 
   CraneErrCode LaunchExecution_(ITaskInstance* task);
+  void AbortTasksAfterLaunchFailure_(task_id_t failed_task_id,
+                                     const std::string& reason);
   // NOLINTEND(readability-identifier-naming)
 
   // Just like a SIGCHLD sig handler (implictly set by uvw).

--- a/src/Craned/Supervisor/TaskManager.h
+++ b/src/Craned/Supervisor/TaskManager.h
@@ -637,6 +637,8 @@ class TaskManager {
   void FinalizeTaskAsync(task_id_t task_id, TaskFinalizeCause cause,
                          std::optional<std::string> reason = std::nullopt);
 
+  // Returns after lightweight admission checks. Slow execution failures
+  // after admission are reported asynchronously via StepStatusChange.
   std::future<CraneErrCode> ExecuteStepAsync();
 
   std::future<CraneErrCode> ExecutePodInDaemonStepAsync();

--- a/src/Utilities/CriClient/CriClient.cpp
+++ b/src/Utilities/CriClient/CriClient.cpp
@@ -150,7 +150,8 @@ std::optional<std::string> CriClient::GetImageId(
 
 std::optional<std::string> CriClient::PullImage(
     const std::string& image_name, const std::string& username,
-    const std::string& password, const std::string& pull_policy) const {
+    const std::string& password, const std::string& pull_policy,
+    std::chrono::seconds timeout) const {
   using api::PullImageRequest;
   using api::PullImageResponse;
 
@@ -223,10 +224,14 @@ std::optional<std::string> CriClient::PullImage(
   PullImageRequest request{};
   PullImageResponse response{};
 
-  // TODO: Make it configurable in config files, now setting to 1 minutes
+  if (timeout <= std::chrono::seconds::zero()) {
+    CRANE_WARN("Invalid image pulling timeout {}s, fallback to {}s",
+               timeout.count(), kCriDefaultImagePullingTimeout.count());
+    timeout = kCriDefaultImagePullingTimeout;
+  }
+
   grpc::ClientContext context;
-  context.set_deadline(std::chrono::system_clock::now() +
-                       kCriDefaultImagePullingTimeout);
+  context.set_deadline(std::chrono::system_clock::now() + timeout);
 
   auto* image = request.mutable_image();
   image->set_image(image_name);

--- a/src/Utilities/CriClient/include/crane/CriClient.h
+++ b/src/Utilities/CriClient/include/crane/CriClient.h
@@ -64,8 +64,9 @@ inline constexpr std::string_view kCriAnnotationPrefix = "cranesched.internal/";
 
 inline constexpr std::chrono::seconds kCriDefaultReqTimeout =
     std::chrono::seconds(5);
+// TODO: Make this configurable.
 inline constexpr std::chrono::seconds kCriDefaultImagePullingTimeout =
-    std::chrono::seconds(60);
+    std::chrono::seconds(600);
 
 using ContainerEventCallback =
     std::function<void(const api::ContainerEventResponse&)>;

--- a/src/Utilities/CriClient/include/crane/CriClient.h
+++ b/src/Utilities/CriClient/include/crane/CriClient.h
@@ -64,7 +64,6 @@ inline constexpr std::string_view kCriAnnotationPrefix = "cranesched.internal/";
 
 inline constexpr std::chrono::seconds kCriDefaultReqTimeout =
     std::chrono::seconds(5);
-// TODO: Make this configurable.
 inline constexpr std::chrono::seconds kCriDefaultImagePullingTimeout =
     std::chrono::seconds(600);
 
@@ -156,10 +155,10 @@ class CriClient {
   std::optional<std::string> GetImageId(const std::string& image_name) const;
   // NOTE: No `server_addr` here as it is used to identify registry in auth
   // config, which we already done from submiting side.
-  std::optional<std::string> PullImage(const std::string& image_name,
-                                       const std::string& username,
-                                       const std::string& password,
-                                       const std::string& pull_policy) const;
+  std::optional<std::string> PullImage(
+      const std::string& image_name, const std::string& username,
+      const std::string& password, const std::string& pull_policy,
+      std::chrono::seconds timeout = kCriDefaultImagePullingTimeout) const;
 
   // ==== Helpers ====
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * RPC handlers now report success after admission; later failures are delivered asynchronously. Task launch failures now abort sibling tasks and preserve root exit semantics. Fixed uninitialized output-forwarding state.

* **Refactor**
  * Simplified logging and removed redundant intermediate variables in execution paths.

* **Behavior**
  * Default image-pulling timeout increased to 600s; added configurable image-pulling timeout and a UserNsEnabledByDefault option.

* **Documentation**
  * Config and container docs updated to document the new options.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->