### PR TITLE
fix: clean cgroup pids and wipe flags

### DIFF
--- a/scripts/wipe_data.py
+++ b/scripts/wipe_data.py
@@ -247,7 +247,15 @@ def _main():
     if args.mode in ["mongo", "all"]:
         db = connect_to_mongo(username, password, host, port, dbname)
         to_wipe = []
-        if not any([args.acct_table, args.qos_table, args.job_table, args.user_table, args.wckey_table, args.resource_table]):
+        if not any([
+            args.acct_table,
+            args.qos_table,
+            args.job_table,
+            args.user_table,
+            args.wckey_table,
+            args.resource_table,
+            args.summary_table,
+        ]):
             to_wipe = [
                 Collection.ACCT,
                 Collection.QOS,

--- a/src/Craned/Common/CgroupManager.cpp
+++ b/src/Craned/Common/CgroupManager.cpp
@@ -1416,7 +1416,8 @@ bool CgroupV1::KillAllProcesses(int signum) {
 
     if (rc == 0) {
       for (int j = 0; j < size; ++j) {
-        kill(-pids[j], signum);
+        // cgroup_get_procs returns PIDs, not process group IDs.
+        kill(pids[j], signum);
       }
       free(pids);
     } else {
@@ -1919,8 +1920,8 @@ bool CgroupV2::KillAllProcesses(int signum) {
 
   if (rc == 0) {
     for (int i = 0; i < size; ++i) {
-      // Kill the process group
-      kill(-pids[i], signum);
+      // cgroup_get_procs returns PIDs, not process group IDs.
+      kill(pids[i], signum);
     }
     free(pids);
     return true;

--- a/src/Craned/Supervisor/TaskManager.cpp
+++ b/src/Craned/Supervisor/TaskManager.cpp
@@ -2195,7 +2195,7 @@ CraneErrCode ProcInstance::Prepare() {
       auto [path, fwd] =
           CrunParseFilePattern_(GetParentStep().io_meta().input_file_pattern());
       meta->fwd_stdin = fwd;
-      meta->parsed_output_file_pattern = path;
+      meta->parsed_input_file_pattern = path;
     }
     {
       auto [path, fwd] =


### PR DESCRIPTION
## Summary

- kill exact PIDs returned by `cgroup_get_procs()` instead of treating them as process group IDs
- store crun input file pattern parsing result in `parsed_input_file_pattern`
- include `--summary_table` in the Mongo wipe flag guard so it does not fall back to wiping all tables

## Testing

- `git diff --check`
- `python3 -m py_compile scripts/wipe_data.py`
- `systemd-run --user --pty -p MemoryMax=15G --working-directory /work/CraneSched/cmake-build-debug ninja -j6 craned csupervisor`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes

- Fixed process termination to correctly target individual processes
- Corrected input file pattern handling for task execution
- Adjusted data wipe behavior when using collection-specific flags

<!-- end of auto-generated comment: release notes by coderabbit.ai -->