### PR TITLE
feat: Add detaching docs and remove redundant code

### DIFF
--- a/docs/en/command/ccon.md
+++ b/docs/en/command/ccon.md
@@ -64,6 +64,9 @@ ccon [Crane Options] run [Run Options] IMAGE [COMMAND] [ARG...]
 !!! tip "Crane Options Placement"
     Crane options (like `-p`, `-N`, `--mem`) must be placed between `ccon` and `run`, not after `run`.
 
+!!! note "Interactive Detach Key"
+    In an interactive TTY session such as `ccon run -it`, press `Ctrl-P + Ctrl-Q` to detach from the client without stopping the container. Use `ccon attach CONTAINER` to reconnect later.
+
 ### Crane Options (Resource Scheduling)
 
 These options control job resource allocation and scheduling behavior:
@@ -388,6 +391,9 @@ Connect to running container's stdin, stdout, and stderr.
 ccon attach [options] CONTAINER
 ```
 
+!!! note "Detach Key"
+    When attaching with a TTY, press `Ctrl-P + Ctrl-Q` to detach without stopping the container.
+
 **--stdin**
 
 :   Connect stdin. Default: `true`.
@@ -426,6 +432,9 @@ Execute command inside running container.
 ```bash
 ccon exec [options] CONTAINER COMMAND [ARG...]
 ```
+
+!!! note "Detach Key"
+    In an interactive TTY exec session such as `ccon exec -it`, press `Ctrl-P + Ctrl-Q` to detach without stopping the container.
 
 **-i, --interactive**
 

--- a/docs/en/reference/container/examples.md
+++ b/docs/en/reference/container/examples.md
@@ -19,6 +19,7 @@ ccon -p CPU -c 4 --mem 8G -t 2:00:00 run python:3.11 \
 
 # Interactive container
 #   -i  keep stdin open    -t  allocate a pseudo-TTY
+#   Ctrl-P + Ctrl-Q detaches without stopping the container
 ccon -p CPU run -it ubuntu:22.04 /bin/bash
 
 # Background execution: returns the container ID and detaches from the terminal
@@ -159,6 +160,7 @@ ccon logs -f 123.1          # -f follow output in real time
 ccon logs --tail 100 123.1  # show only the last 100 lines
 
 # Exec into a running container
+#   Ctrl-P + Ctrl-Q detaches without stopping the container
 ccon exec -it 123.1 /bin/bash
 
 # Inspect

--- a/docs/en/reference/container/quickstart.md
+++ b/docs/en/reference/container/quickstart.md
@@ -86,6 +86,8 @@ Parameter description:
 
 Once inside the container, you can execute commands as in a normal terminal. The job automatically ends when you exit.
 
+To detach from an interactive TTY session without stopping the container, press `Ctrl-P + Ctrl-Q`.
+
 ---
 
 ## Background Container
@@ -196,7 +198,7 @@ ccon logs --tail 100 123.1
 ccon attach 123.1
 ```
 
-Use `Ctrl+C` to disconnect (does not terminate the container).
+When attached with a TTY, press `Ctrl-P + Ctrl-Q` to detach without terminating the container.
 
 ### Execute Commands in Container
 
@@ -207,6 +209,8 @@ ccon exec 123.1 ls -la /app
 # Start interactive shell
 ccon exec -it 123.1 /bin/bash
 ```
+
+For an interactive TTY exec session, press `Ctrl-P + Ctrl-Q` to detach without stopping the container.
 
 ---
 

--- a/docs/zh/command/ccon.md
+++ b/docs/zh/command/ccon.md
@@ -64,6 +64,9 @@ ccon [Crane 选项] run [Run 选项] IMAGE [COMMAND] [ARG...]
 !!! tip "Crane 选项位置"
     Crane 选项（如 `-p`、`-N`、`--mem`）必须放在 `ccon` 和 `run` 之间，而非 `run` 之后。
 
+!!! note "交互式脱离快捷键"
+    在 `ccon run -it` 等交互式 TTY 会话中，按 `Ctrl-P + Ctrl-Q` 可从客户端脱离且不停止容器。之后可使用 `ccon attach CONTAINER` 重新连接。
+
 ### Crane 选项（资源调度）
 
 以下选项用于控制作业的资源分配和调度行为：
@@ -387,6 +390,9 @@ ccon logs --tail 100 123.1
 ccon attach [选项] CONTAINER
 ```
 
+!!! note "脱离快捷键"
+    在 TTY attach 会话中，按 `Ctrl-P + Ctrl-Q` 可脱离客户端且不停止容器。
+
 **--stdin**
 
 :   连接标准输入。默认：`true`。
@@ -425,6 +431,9 @@ ccon attach 123.1
 ```bash
 ccon exec [选项] CONTAINER COMMAND [ARG...]
 ```
+
+!!! note "脱离快捷键"
+    在 `ccon exec -it` 等交互式 TTY exec 会话中，按 `Ctrl-P + Ctrl-Q` 可脱离客户端且不停止容器。
 
 **-i, --interactive**
 

--- a/docs/zh/reference/container/examples.md
+++ b/docs/zh/reference/container/examples.md
@@ -19,6 +19,7 @@ ccon -p CPU -c 4 --mem 8G -t 2:00:00 run python:3.11 \
 
 # 交互式容器
 #   -i  保持 stdin 打开    -t  分配伪终端
+#   Ctrl-P + Ctrl-Q 可脱离连接且不停止容器
 ccon -p CPU run -it ubuntu:22.04 /bin/bash
 
 # 后台运行：命令返回容器 ID 后立即脱离终端
@@ -159,6 +160,7 @@ ccon logs -f 123.1          # -f 持续跟踪输出
 ccon logs --tail 100 123.1  # 仅显示最后 100 行
 
 # 进入容器
+#   Ctrl-P + Ctrl-Q 可脱离连接且不停止容器
 ccon exec -it 123.1 /bin/bash
 
 # 查看详情

--- a/docs/zh/reference/container/quickstart.md
+++ b/docs/zh/reference/container/quickstart.md
@@ -86,6 +86,8 @@ ccon -p CPU run -it ubuntu:22.04 /bin/bash
 
 进入容器后，你可以像使用普通终端一样执行命令。退出容器后，作业自动结束。
 
+如需在不停止容器的情况下从交互式 TTY 会话脱离，按 `Ctrl-P + Ctrl-Q`。
+
 ---
 
 ## 后台运行容器
@@ -196,7 +198,7 @@ ccon logs --tail 100 123.1
 ccon attach 123.1
 ```
 
-使用 `Ctrl+C` 断开连接（不会终止容器）。
+使用 TTY 连接时，按 `Ctrl-P + Ctrl-Q` 可脱离连接（不会终止容器）。
 
 ### 在容器内执行命令
 
@@ -207,6 +209,8 @@ ccon exec 123.1 ls -la /app
 # 启动交互式 shell
 ccon exec -it 123.1 /bin/bash
 ```
+
+在交互式 TTY exec 会话中，按 `Ctrl-P + Ctrl-Q` 可脱离连接且不停止容器。
 
 ---
 

--- a/src/CraneCtld/JobScheduler.cpp
+++ b/src/CraneCtld/JobScheduler.cpp
@@ -21,6 +21,8 @@
 #include <absl/time/internal/cctz/src/time_zone_if.h>
 #include <google/protobuf/util/time_util.h>
 
+#include <iterator>
+
 #include "Account/AccountManager.h"
 #include "Accounting/AccountMetaContainer.h"
 #include "Accounting/LicenseManager.h"
@@ -4698,7 +4700,7 @@ void JobScheduler::CleanCancelJobQueueCb_() {
   if (approximate_size == 0) return;
 
   std::vector<CancelJobQueueElem> jobs_to_cancel;
-  jobs_to_cancel.resize(approximate_size);
+  jobs_to_cancel.reserve(approximate_size);
 
   // Carry the ownership of JobInCtld for automatic destruction.
   std::vector<std::unique_ptr<JobInCtld>> pending_job_ptr_vec;
@@ -4711,8 +4713,7 @@ void JobScheduler::CleanCancelJobQueueCb_() {
       running_job_craned_id_map;
 
   size_t actual_size = m_cancel_job_queue_.try_dequeue_bulk(
-      jobs_to_cancel.begin(), approximate_size);
-  jobs_to_cancel.resize(actual_size);
+      std::back_inserter(jobs_to_cancel), approximate_size);
   if (actual_size == 0) return;
 
   // For pending jobs and array parents, finish scheduler-side metadata. For

--- a/src/Craned/Supervisor/CforedClient.cpp
+++ b/src/Craned/Supervisor/CforedClient.cpp
@@ -510,7 +510,16 @@ void CforedClient::CleanOutputQueueAndWriteToStreamThread_(
         stream,
     std::atomic<bool>* write_pending) {
   CRANE_TRACE("CleanOutputQueueThread started.");
-  FwdRequest fwd_req;
+  FwdRequest fwd_req{
+      .type = StreamStepIORequest::TASK_OUTPUT,
+      .data =
+          IOFwdRequest{
+              .is_stdout = true,
+              .task_id = 0,
+              .data = nullptr,
+              .len = 0,
+          },
+  };
   bool ok = m_task_fwd_req_queue_.try_dequeue(fwd_req);
 
   // Make sure before exit all output has been drained.

--- a/src/Craned/Supervisor/TaskManager.cpp
+++ b/src/Craned/Supervisor/TaskManager.cpp
@@ -3657,7 +3657,8 @@ void TaskManager::EvGrpcExecuteStepCb_() {
       std::unique_ptr<ITaskInstance> instance;
       if (m_step_.IsPod()) {
         // Pod
-        CRANE_ERROR(
+        CRANE_ASSERT_MSG(
+            false,
             "PodInstance should have been created in EvExecutePodCb_, "
             "unexpected to create it here.");
       } else if (m_step_.IsContainer()) {
@@ -3698,41 +3699,36 @@ void TaskManager::EvGrpcExecuteStepCb_() {
       }
     }
 
-    // TODO: We dont need to exec task for a calloc job
+    // Add a timer to limit the execution time of a task.
+    int64_t time_limit_sec = m_step_.GetStep().time_limit().seconds();
+    int64_t deadline_sec = m_step_.GetStep().deadline_time().seconds() -
+                           absl::ToUnixSeconds(absl::Now());
+    int64_t sec = std::min(deadline_sec, time_limit_sec);
 
-    if (!m_step_.IsDaemon()) {
-      // Add a timer to limit the execution time of a task.
+    std::string log_timer =
+        deadline_sec <= time_limit_sec ? "deadline" : "time_limit";
+    bool is_deadline = deadline_sec <= time_limit_sec;
 
-      int64_t time_limit_sec = m_step_.GetStep().time_limit().seconds();
-      int64_t deadline_sec = m_step_.GetStep().deadline_time().seconds() -
-                             absl::ToUnixSeconds(absl::Now());
-      int64_t sec = std::min(deadline_sec, time_limit_sec);
+    AddTerminationTimer_(sec, is_deadline);
+    CRANE_TRACE("Add a {} timer of {} seconds", log_timer, sec);
 
-      std::string log_timer =
-          deadline_sec <= time_limit_sec ? "deadline" : "time_limit";
-      bool is_deadline = deadline_sec <= time_limit_sec ? true : false;
-
-      AddTerminationTimer_(sec, is_deadline);
-      CRANE_TRACE("Add a {} timer of {} seconds", log_timer, sec);
-
-      for (const auto& signal : m_step_.GetStep().signals()) {
-        if (signal.signal_flag() == crane::grpc::Signal_SignalFlag_BATCH_ONLY &&
-            !m_step_.IsPrimary())
-          continue;
-        if (signal.signal_flag() != crane::grpc::Signal_SignalFlag_BATCH_ONLY &&
-            m_step_.IsPrimary())
-          continue;
-        if (signal.signal_time() >= sec) {
-          CRANE_TRACE(
-              "signal time of {}s > time_limit {}s, ignore this signal.",
-              signal.signal_time(), sec);
-          continue;
-        }
-        AddSignalTimer_(sec - signal.signal_time(), signal.signal_number());
-        CRANE_INFO("Add a signal time of {}s for signal {}",
-                   signal.signal_time(), signal.signal_number());
+    for (const auto& signal : m_step_.GetStep().signals()) {
+      if (signal.signal_flag() == crane::grpc::Signal_SignalFlag_BATCH_ONLY &&
+          !m_step_.IsPrimary())
+        continue;
+      if (signal.signal_flag() != crane::grpc::Signal_SignalFlag_BATCH_ONLY &&
+          m_step_.IsPrimary())
+        continue;
+      if (signal.signal_time() >= sec) {
+        CRANE_TRACE("signal time of {}s > time_limit {}s, ignore this signal.",
+                    signal.signal_time(), sec);
+        continue;
       }
+      AddSignalTimer_(sec - signal.signal_time(), signal.signal_number());
+      CRANE_INFO("Add a signal time of {}s for signal {}", signal.signal_time(),
+                 signal.signal_number());
     }
+
     // TODO: We dont need to exec task for a calloc job
     // Calloc tasks have no scripts to run. Just return.
     if (m_step_.IsCalloc()) {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified that in interactive container TTY sessions, pressing **Ctrl-P + Ctrl-Q** detaches **without stopping the container**, including for `run`, `attach`, and `exec` workflows (updated across English and Chinese docs).

* **Bug Fixes**
  * Improved step termination timing and signal-handling behavior for background execution, ensuring termination and signal timers are scheduled more consistently.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->