### PR TITLE
docs: Add memlock configuration for craned.service in deployment guides

### DIFF
--- a/docs/en/deployment/backend/CentOS7.md
+++ b/docs/en/deployment/backend/CentOS7.md
@@ -186,7 +186,18 @@ sudo useradd --system --gid crane --shell /usr/sbin/nologin --create-home crane 
 
 Then start services:
 
+For jobs that need to lock a large amount of memory, configure unlimited memlock for `craned.service` on all compute nodes. Create a systemd drop-in before starting `craned`:
+
 ```bash
+sudo mkdir -p /etc/systemd/system/craned.service.d
+sudo tee /etc/systemd/system/craned.service.d/override.conf >/dev/null <<'EOF'
+[Service]
+LimitMEMLOCK=infinity
+EOF
+```
+
+```bash
+systemctl daemon-reload
 systemctl start cranectld  # Control node
 systemctl start craned     # Compute node
 ```

--- a/docs/en/deployment/backend/Rocky9.md
+++ b/docs/en/deployment/backend/Rocky9.md
@@ -190,6 +190,16 @@ sudo useradd --system --gid crane --shell /usr/sbin/nologin --create-home crane 
 
 Then start services:
 
+For jobs that need to lock a large amount of memory, configure unlimited memlock for `craned.service` on all compute nodes. Create a systemd drop-in before starting `craned`:
+
+```bash
+sudo mkdir -p /etc/systemd/system/craned.service.d
+sudo tee /etc/systemd/system/craned.service.d/override.conf >/dev/null <<'EOF'
+[Service]
+LimitMEMLOCK=infinity
+EOF
+```
+
 ```bash
 systemctl daemon-reload
 systemctl enable cranectld --now  # Control node

--- a/docs/en/deployment/backend/Ubuntu.md
+++ b/docs/en/deployment/backend/Ubuntu.md
@@ -263,6 +263,16 @@ sudo useradd --system --gid crane --shell /usr/sbin/nologin --create-home crane 
 
 Then start services:
 
+For jobs that need to lock a large amount of memory, configure unlimited memlock for `craned.service` on all compute nodes. Create a systemd drop-in before starting `craned`:
+
+```bash
+sudo mkdir -p /etc/systemd/system/craned.service.d
+sudo tee /etc/systemd/system/craned.service.d/override.conf >/dev/null <<'EOF'
+[Service]
+LimitMEMLOCK=infinity
+EOF
+```
+
 ```bash
 systemctl daemon-reload
 systemctl enable cranectld --now  # Control node

--- a/docs/en/deployment/packaging.md
+++ b/docs/en/deployment/packaging.md
@@ -145,6 +145,17 @@ Both packages automatically:
 
 After installation, configure `/etc/crane/config.yaml` and `/etc/crane/database.yaml` (for cranectld), then start the services:
 
+For jobs that need to lock a large amount of memory, configure unlimited memlock for `craned.service` on all compute nodes. Create a systemd drop-in before starting `craned`:
+
+```bash
+sudo mkdir -p /etc/systemd/system/craned.service.d
+sudo tee /etc/systemd/system/craned.service.d/override.conf >/dev/null <<'EOF'
+[Service]
+LimitMEMLOCK=infinity
+EOF
+sudo systemctl daemon-reload
+```
+
 ```bash
 # On control node
 systemctl enable --now cranectld

--- a/docs/zh/deployment/backend/CentOS7.md
+++ b/docs/zh/deployment/backend/CentOS7.md
@@ -182,7 +182,18 @@ sudo useradd --system --gid crane --shell /usr/sbin/nologin --create-home crane 
 
 然后启动服务：
 
+对于需要锁定大量内存的作业，建议在所有计算节点为 `craned.service` 配置无限制的 memlock。启动 `craned` 前创建 systemd drop-in：
+
 ```bash
+sudo mkdir -p /etc/systemd/system/craned.service.d
+sudo tee /etc/systemd/system/craned.service.d/override.conf >/dev/null <<'EOF'
+[Service]
+LimitMEMLOCK=infinity
+EOF
+```
+
+```bash
+systemctl daemon-reload
 systemctl start cranectld  # 控制节点
 systemctl start craned     # 计算节点
 ```

--- a/docs/zh/deployment/backend/Rocky9.md
+++ b/docs/zh/deployment/backend/Rocky9.md
@@ -191,6 +191,16 @@ sudo useradd --system --gid crane --shell /usr/sbin/nologin --create-home crane 
 
 然后启动服务：
 
+对于需要锁定大量内存的作业，建议在所有计算节点为 `craned.service` 配置无限制的 memlock。启动 `craned` 前创建 systemd drop-in：
+
+```bash
+sudo mkdir -p /etc/systemd/system/craned.service.d
+sudo tee /etc/systemd/system/craned.service.d/override.conf >/dev/null <<'EOF'
+[Service]
+LimitMEMLOCK=infinity
+EOF
+```
+
 ```bash
 systemctl daemon-reload
 systemctl enable cranectld --now  # 控制节点

--- a/docs/zh/deployment/backend/Ubuntu.md
+++ b/docs/zh/deployment/backend/Ubuntu.md
@@ -262,6 +262,16 @@ sudo useradd --system --gid crane --shell /usr/sbin/nologin --create-home crane 
 
 然后启动服务：
 
+对于需要锁定大量内存的作业，建议在所有计算节点为 `craned.service` 配置无限制的 memlock。启动 `craned` 前创建 systemd drop-in：
+
+```bash
+sudo mkdir -p /etc/systemd/system/craned.service.d
+sudo tee /etc/systemd/system/craned.service.d/override.conf >/dev/null <<'EOF'
+[Service]
+LimitMEMLOCK=infinity
+EOF
+```
+
 ```bash
 systemctl daemon-reload
 systemctl enable cranectld --now  # 控制节点

--- a/docs/zh/deployment/packaging.md
+++ b/docs/zh/deployment/packaging.md
@@ -145,6 +145,17 @@ sudo dpkg -i CraneSched-*-craned.deb
 
 安装后，配置 `/etc/crane/config.yaml` 和 `/etc/crane/database.yaml`（用于 cranectld），然后启动服务：
 
+对于需要锁定大量内存的作业，建议在所有计算节点为 `craned.service` 配置无限制的 memlock。启动 `craned` 前创建 systemd drop-in：
+
+```bash
+sudo mkdir -p /etc/systemd/system/craned.service.d
+sudo tee /etc/systemd/system/craned.service.d/override.conf >/dev/null <<'EOF'
+[Service]
+LimitMEMLOCK=infinity
+EOF
+sudo systemctl daemon-reload
+```
+
 ```bash
 # 在控制节点上
 systemctl enable --now cranectld


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added deployment guidance for compute nodes to increase memory-locking limits when running jobs that need it.
  * Included step-by-step systemd drop-in setup instructions before starting services across CentOS 7, Rocky 9, Ubuntu, and packaging docs.
  * Updated both English and Chinese deployment guides to reflect the new startup workflow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->