### PR TITLE
fix: use bundled lz4 for rocksdb

### DIFF
--- a/dependencies/cmake/rocksdb/CMakeLists.txt
+++ b/dependencies/cmake/rocksdb/CMakeLists.txt
@@ -9,9 +9,18 @@ if (NOT lz4_repo_POPULATED)
     FetchContent_Populate(lz4_repo)
 endif ()
 
-find_library(CRANE_LZ4_LIBRARY NAMES lz4 liblz4.so.1)
-if (NOT CRANE_LZ4_LIBRARY)
-    message(FATAL_ERROR "RocksDB LZ4 support requires liblz4 runtime library.")
+set(LZ4_BUNDLED_MODE ON CACHE BOOL "" FORCE)
+set(LZ4_BUILD_CLI OFF CACHE BOOL "" FORCE)
+add_subdirectory("${lz4_repo_SOURCE_DIR}/build/cmake"
+        "${lz4_repo_BINARY_DIR}" EXCLUDE_FROM_ALL)
+
+set(CRANE_LZ4_LIBRARY
+        "${lz4_repo_BINARY_DIR}/${CMAKE_STATIC_LIBRARY_PREFIX}lz4${CMAKE_STATIC_LIBRARY_SUFFIX}")
+if (NOT TARGET lz4::lz4)
+    add_library(lz4::lz4 UNKNOWN IMPORTED GLOBAL)
+    set_target_properties(lz4::lz4 PROPERTIES
+            IMPORTED_LOCATION "${CRANE_LZ4_LIBRARY}"
+            INTERFACE_INCLUDE_DIRECTORIES "${lz4_repo_SOURCE_DIR}/lib")
 endif ()
 
 set(lz4_INCLUDE_DIRS "${lz4_repo_SOURCE_DIR}/lib" CACHE PATH "" FORCE)
@@ -40,3 +49,9 @@ FetchContent_Declare(rocksdb_repo
         )
 
 FetchContent_MakeAvailable(rocksdb_repo)
+
+foreach (rocksdb_target rocksdb rocksdb-shared)
+    if (TARGET ${rocksdb_target} AND TARGET lz4_static)
+        add_dependencies(${rocksdb_target} lz4_static)
+    endif ()
+endforeach ()


### PR DESCRIPTION
## Summary

Fix the current master CI build failure when linking cranectld with RocksDB LZ4 support.

The failed CI job builds RocksDB against fetched LZ4 v1.10 headers, but then resolves LZ4 symbols from the system liblz4. On the CI image, that system library does not provide LZ4_resetStreamHC_fast, so the final cranectld link fails.

This change builds the fetched LZ4 source as a bundled static library and points RocksDB LZ4 discovery at that archive, keeping the LZ4 headers and library from the same version.

## Validation

- git diff --check
- TMPDIR=/nfs/home/wenruilin/tmp cmake --build cmake-build-release-tracing --target cranectld craned csupervisor -j 8


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved bundled support for a compression library used by storage components, reducing reliance on a system-installed version.
  * Build setup now ensures the needed library is prepared automatically during compilation.
  * Updated build ordering so related components compile reliably with the correct library dependency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->