### PR TITLE
refactor: Round client CPU counts in gRPC replies

### DIFF
--- a/src/CraneCtld/Database/DbClient.cpp
+++ b/src/CraneCtld/Database/DbClient.cpp
@@ -965,7 +965,7 @@ bool MongodbClient::FetchJobRecords(
 
         auto* mutable_req_total_res_view =
             job_info.mutable_req_total_res_view();
-        mutable_req_total_res_view->set_cpu_count(static_cast<double>(
+        mutable_req_total_res_view->set_cpu_count(ConvertCpuCountForClient(
             cpu_t::from_raw_value(view["cpus_req"].get_int64().value)));
         auto mem_req = ViewGetArithmeticValue_<uint64_t>(view["mem_req"]);
         mutable_req_total_res_view->set_memory_bytes(mem_req);
@@ -973,7 +973,7 @@ bool MongodbClient::FetchJobRecords(
 
         auto* mutable_allocated_res_view =
             job_info.mutable_allocated_res_view();
-        mutable_allocated_res_view->set_cpu_count(static_cast<double>(
+        mutable_allocated_res_view->set_cpu_count(ConvertCpuCountForClient(
             cpu_t::from_raw_value(view["cpus_alloc"].get_int64().value)));
         auto mem_alloc = ViewGetArithmeticValue_<uint64_t>(view["mem_alloc"]);
         mutable_allocated_res_view->set_memory_bytes(mem_alloc);
@@ -5698,7 +5698,7 @@ void MongodbClient::ViewToStepInfo_(const bsoncxx::document::view& view,
   step_id_t step_id = view["step_id"].get_int32().value;
   step_info->set_step_id(step_id);
   auto* mutable_req_total_res_view = step_info->mutable_req_total_res_view();
-  mutable_req_total_res_view->set_cpu_count(static_cast<double>(
+  mutable_req_total_res_view->set_cpu_count(ConvertCpuCountForClient(
       cpu_t::from_raw_value(view["cpus_req"].get_int64().value)));
   mutable_req_total_res_view->set_memory_bytes(
       view["mem_req"].get_int64().value);
@@ -5743,9 +5743,12 @@ void MongodbClient::ViewToStepInfo_(const bsoncxx::document::view& view,
       static_cast<crane::grpc::JobType>(view["type"].get_int32().value));
 
   step_info->set_extra_attr(view["extra_attr"].get_string().value.data());
+  auto allocated_res_view =
+      BsonToResourceV3(view["res_alloc"].get_document().value).View();
   *step_info->mutable_allocated_res_view() =
-      static_cast<crane::grpc::ResourceView>(
-          BsonToResourceV3(view["res_alloc"].get_document().value).View());
+      static_cast<crane::grpc::ResourceView>(allocated_res_view);
+  step_info->mutable_allocated_res_view()->set_cpu_count(
+      ConvertCpuCountForClient(allocated_res_view.GetCpuCount()));
   step_info->set_step_type(
       static_cast<crane::grpc::StepType>(view["step_type"].get_int32().value));
 

--- a/src/CraneCtld/JobScheduler.cpp
+++ b/src/CraneCtld/JobScheduler.cpp
@@ -6480,6 +6480,10 @@ void JobScheduler::QueryJobsInRam(
       step->SetFieldsOfStepInfo(step_info);
       step_info->mutable_elapsed_time()->set_seconds(
           ToInt64Seconds(now - step->StartTime()));
+      step_info->mutable_req_total_res_view()->set_cpu_count(
+          ConvertCpuCountForClient(step->req_total_res_view.GetCpuCount()));
+      step_info->mutable_allocated_res_view()->set_cpu_count(
+          ConvertCpuCountForClient(step->AllocatedRes().View().GetCpuCount()));
     }
   };
 
@@ -6490,6 +6494,10 @@ void JobScheduler::QueryJobsInRam(
     job.SetFieldsOfJobInfo(&job_info);
     job_info.mutable_elapsed_time()->set_seconds(
         ToInt64Seconds(now - job.StartTime()));
+    job_info.mutable_req_total_res_view()->set_cpu_count(
+        ConvertCpuCountForClient(job.req_total_res_view.GetCpuCount()));
+    job_info.mutable_allocated_res_view()->set_cpu_count(
+        ConvertCpuCountForClient(job.allocated_res_view.GetCpuCount()));
 
     crane::grpc::JobStatus display_status = job.EffectiveDisplayStatus();
     if (!job.IsArrayParent() &&

--- a/src/CraneCtld/Node/CranedMetaContainer.cpp
+++ b/src/CraneCtld/Node/CranedMetaContainer.cpp
@@ -471,10 +471,16 @@ CranedMetaContainer::QueryAllPartitionInfo() {
 
     *part_info->mutable_res_total() = static_cast<crane::grpc::ResourceView>(
         part_meta->partition_global_meta.res_total);
+    part_info->mutable_res_total()->set_cpu_count(ConvertCpuCountForClient(
+        part_meta->partition_global_meta.res_total.GetCpuCount()));
     *part_info->mutable_res_avail() = static_cast<crane::grpc::ResourceView>(
         part_meta->partition_global_meta.res_avail);
+    part_info->mutable_res_avail()->set_cpu_count(ConvertCpuCountForClient(
+        part_meta->partition_global_meta.res_avail.GetCpuCount()));
     *part_info->mutable_res_alloc() = static_cast<crane::grpc::ResourceView>(
         part_meta->partition_global_meta.res_in_use);
+    part_info->mutable_res_alloc()->set_cpu_count(ConvertCpuCountForClient(
+        part_meta->partition_global_meta.res_in_use.GetCpuCount()));
     part_info->set_default_mem_per_cpu(
         g_config.Partitions[part_name].default_mem_per_cpu);
     part_info->set_max_mem_per_cpu(
@@ -536,10 +542,16 @@ crane::grpc::QueryPartitionInfoReply CranedMetaContainer::QueryPartitionInfo(
 
   *part_info->mutable_res_total() = static_cast<crane::grpc::ResourceView>(
       part_meta->partition_global_meta.res_total);
+  part_info->mutable_res_total()->set_cpu_count(ConvertCpuCountForClient(
+      part_meta->partition_global_meta.res_total.GetCpuCount()));
   *part_info->mutable_res_avail() = static_cast<crane::grpc::ResourceView>(
       part_meta->partition_global_meta.res_avail);
+  part_info->mutable_res_avail()->set_cpu_count(ConvertCpuCountForClient(
+      part_meta->partition_global_meta.res_avail.GetCpuCount()));
   *part_info->mutable_res_alloc() = static_cast<crane::grpc::ResourceView>(
       part_meta->partition_global_meta.res_in_use);
+  part_info->mutable_res_alloc()->set_cpu_count(ConvertCpuCountForClient(
+      part_meta->partition_global_meta.res_in_use.GetCpuCount()));
 
   return reply;
 }
@@ -573,11 +585,17 @@ crane::grpc::QueryReservationInfoReply CranedMetaContainer::QueryAllResvInfo() {
 
     reservation_info->mutable_res_total()->CopyFrom(
         static_cast<crane::grpc::ResourceView>(res_total));
+    reservation_info->mutable_res_total()->set_cpu_count(
+        ConvertCpuCountForClient(res_total.GetCpuCount()));
     reservation_info->mutable_res_avail()->CopyFrom(
         static_cast<crane::grpc::ResourceView>(res_avail));
+    reservation_info->mutable_res_avail()->set_cpu_count(
+        ConvertCpuCountForClient(res_avail.GetCpuCount()));
     reservation_info->mutable_res_alloc()->CopyFrom(
         static_cast<crane::grpc::ResourceView>(res_total -=
                                                resv_meta_ptr->res_avail));
+    reservation_info->mutable_res_alloc()->set_cpu_count(
+        ConvertCpuCountForClient(res_total.GetCpuCount()));
 
     if (resv_meta_ptr->accounts_black_list) {
       for (auto const& account : resv_meta_ptr->accounts) {
@@ -631,11 +649,17 @@ crane::grpc::QueryReservationInfoReply CranedMetaContainer::QueryResvInfo(
 
   reservation_info->mutable_res_total()->CopyFrom(
       static_cast<crane::grpc::ResourceView>(res_total));
+  reservation_info->mutable_res_total()->set_cpu_count(
+      ConvertCpuCountForClient(res_total.GetCpuCount()));
   reservation_info->mutable_res_avail()->CopyFrom(
       static_cast<crane::grpc::ResourceView>(res_avail));
+  reservation_info->mutable_res_avail()->set_cpu_count(
+      ConvertCpuCountForClient(res_avail.GetCpuCount()));
   reservation_info->mutable_res_alloc()->CopyFrom(
       static_cast<crane::grpc::ResourceView>(res_total -=
                                              resv_meta_ptr->res_avail));
+  reservation_info->mutable_res_alloc()->set_cpu_count(
+      ConvertCpuCountForClient(res_total.GetCpuCount()));
 
   if (resv_meta_ptr->accounts_black_list) {
     for (auto const& account : resv_meta_ptr->accounts) {
@@ -1083,10 +1107,16 @@ void CranedMetaContainer::SetGrpcCranedInfoByCranedMeta_(
 
   *craned_info->mutable_res_total() =
       static_cast<crane::grpc::ResourceInNodeV3>(craned_meta.res_total);
+  craned_info->mutable_res_total()->set_cpu_count(
+      ConvertCpuCountForClient(craned_meta.res_total.GetCpuSet().cpu_count));
   *craned_info->mutable_res_avail() =
       static_cast<crane::grpc::ResourceInNodeV3>(craned_meta.res_avail);
+  craned_info->mutable_res_avail()->set_cpu_count(
+      ConvertCpuCountForClient(craned_meta.res_avail.GetCpuSet().cpu_count));
   *craned_info->mutable_res_alloc() =
       static_cast<crane::grpc::ResourceInNodeV3>(craned_meta.res_in_use);
+  craned_info->mutable_res_alloc()->set_cpu_count(
+      ConvertCpuCountForClient(craned_meta.res_in_use.GetCpuSet().cpu_count));
 
   craned_info->set_hostname(craned_meta.static_meta.hostname);
   craned_info->set_craned_version(craned_meta.remote_meta.craned_version);

--- a/src/CraneCtld/RpcService/CtldGrpcServer.cpp
+++ b/src/CraneCtld/RpcService/CtldGrpcServer.cpp
@@ -2014,8 +2014,12 @@ grpc::Status CraneCtldServiceImpl::QueryAccountInfo(
       auto& proto_limit = (*partition_resource_limit_map)[partition];
       proto_limit.mutable_max_tres()->CopyFrom(
           static_cast<crane::grpc::ResourceView>(limit.max_tres));
+      proto_limit.mutable_max_tres()->set_cpu_count(
+          ConvertCpuCountForClient(limit.max_tres.GetCpuCount()));
       proto_limit.mutable_max_tres_per_job()->CopyFrom(
           static_cast<crane::grpc::ResourceView>(limit.max_tres_per_job));
+      proto_limit.mutable_max_tres_per_job()->set_cpu_count(
+          ConvertCpuCountForClient(limit.max_tres_per_job.GetCpuCount()));
       proto_limit.set_max_jobs(limit.max_jobs);
       proto_limit.set_max_submit_jobs(limit.max_submit_jobs);
       proto_limit.set_max_wall(absl::ToInt64Seconds(limit.max_wall));
@@ -2110,8 +2114,12 @@ grpc::Status CraneCtldServiceImpl::QueryUserInfo(
         auto& proto_limit = (*partition_resource_limit_map)[partition];
         proto_limit.mutable_max_tres()->CopyFrom(
             static_cast<crane::grpc::ResourceView>(limit.max_tres));
+        proto_limit.mutable_max_tres()->set_cpu_count(
+            ConvertCpuCountForClient(limit.max_tres.GetCpuCount()));
         proto_limit.mutable_max_tres_per_job()->CopyFrom(
             static_cast<crane::grpc::ResourceView>(limit.max_tres_per_job));
+        proto_limit.mutable_max_tres_per_job()->set_cpu_count(
+            ConvertCpuCountForClient(limit.max_tres_per_job.GetCpuCount()));
         proto_limit.set_max_jobs(limit.max_jobs);
         proto_limit.set_max_submit_jobs(limit.max_submit_jobs);
         proto_limit.set_max_wall(absl::ToInt64Seconds(limit.max_wall));
@@ -2204,7 +2212,8 @@ grpc::Status CraneCtldServiceImpl::QueryQosInfo(
     qos_info->set_priority(qos.priority);
     qos_info->set_max_jobs_per_user(qos.max_jobs_per_user);
     qos_info->set_max_jobs_per_account(qos.max_jobs_per_account);
-    qos_info->set_max_cpus_per_user(static_cast<double>(qos.max_cpus_per_user));
+    qos_info->set_max_cpus_per_user(
+        ConvertCpuCountForClient(qos.max_cpus_per_user));
     qos_info->set_max_submit_jobs_per_user(qos.max_submit_jobs_per_user);
     qos_info->set_max_submit_jobs_per_account(qos.max_submit_jobs_per_account);
     qos_info->set_max_time_limit_per_job(
@@ -2217,10 +2226,16 @@ grpc::Status CraneCtldServiceImpl::QueryQosInfo(
     // properly serializes GresMap including zero-value entries.
     qos_info->mutable_max_tres()->CopyFrom(
         static_cast<crane::grpc::ResourceView>(qos.max_tres));
+    qos_info->mutable_max_tres()->set_cpu_count(
+        ConvertCpuCountForClient(qos.max_tres.GetCpuCount()));
     qos_info->mutable_max_tres_per_user()->CopyFrom(
         static_cast<crane::grpc::ResourceView>(qos.max_tres_per_user));
+    qos_info->mutable_max_tres_per_user()->set_cpu_count(
+        ConvertCpuCountForClient(qos.max_tres_per_user.GetCpuCount()));
     qos_info->mutable_max_tres_per_account()->CopyFrom(
         static_cast<crane::grpc::ResourceView>(qos.max_tres_per_account));
+    qos_info->mutable_max_tres_per_account()->set_cpu_count(
+        ConvertCpuCountForClient(qos.max_tres_per_account.GetCpuCount()));
     qos_info->set_flags(qos.flags.ToInt64());
     for (const auto& preempt_name : qos.preempt) {
       qos_info->add_preempt(preempt_name);

--- a/src/Utilities/PublicHeader/include/crane/PublicHeader.h
+++ b/src/Utilities/PublicHeader/include/crane/PublicHeader.h
@@ -50,6 +50,18 @@ using LicenseId = std::string;
 // representation. (1LL << 53) / 256 = 35184372088832 CPUs.
 inline const cpu_t kUnlimitedCpu = cpu_t::from_raw_value(int64_t{1} << 53);
 
+inline double ConvertCpuCountForClient(cpu_t cpu) {
+  constexpr int64_t kDecimalScale = 100;
+  const __int128 raw_scale = cpu_t{1}.raw_value();
+  __int128 scaled_raw = static_cast<__int128>(cpu.raw_value()) * kDecimalScale;
+  if (scaled_raw >= 0) {
+    scaled_raw = (scaled_raw + raw_scale / 2) / raw_scale;
+  } else {
+    scaled_raw = (scaled_raw - raw_scale / 2) / raw_scale;
+  }
+  return static_cast<double>(scaled_raw) / kDecimalScale;
+}
+
 using CraneErrCode = crane::grpc::ErrCode;
 
 using CraneRichError = crane::grpc::RichError;


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed CPU count display inconsistencies in client-facing query results for jobs, steps, nodes, partitions, reservations, and scheduler/accounting limits.
  * Resource view CPU values are now explicitly converted and populated during gRPC response serialization, avoiding missing or mismatched CPU counts.
  * Updated rounding/conversion logic to make CPU values more accurate and predictable in client responses.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->