### PR TITLE
fix: Fix missing license lookups in plugin updates

### DIFF
--- a/src/CraneCtld/Accounting/LicenseManager.cpp
+++ b/src/CraneCtld/Accounting/LicenseManager.cpp
@@ -300,7 +300,9 @@ void LicenseManager::MallocLicenseWhenRecoverRunning(
     std::vector<crane::grpc::LicenseInfo> license_infos;
     license_infos.reserve(actual_license.size());
     for (const auto& [lic_id, _] : actual_license) {
-      auto lic = licenses_map->find(lic_id)->second.GetExclusivePtr();
+      auto iter = licenses_map->find(lic_id);
+      if (iter == licenses_map->end()) continue;
+      auto lic = iter->second.GetExclusivePtr();
       crane::grpc::LicenseInfo license_info;
       license_info.set_name(lic->license_id);
       license_info.set_total(lic->total);
@@ -339,7 +341,9 @@ void LicenseManager::FreeLicense(
     std::vector<crane::grpc::LicenseInfo> license_infos;
     license_infos.reserve(actual_license.size());
     for (const auto& [lic_id, _] : actual_license) {
-      auto lic = licenses_map->find(lic_id)->second.GetExclusivePtr();
+      auto iter = licenses_map->find(lic_id);
+      if (iter == licenses_map->end()) continue;
+      auto lic = iter->second.GetExclusivePtr();
       crane::grpc::LicenseInfo license_info;
       license_info.set_name(lic->license_id);
       license_info.set_total(lic->total);


### PR DESCRIPTION
## Summary

- Skip plugin update entries whose license was already removed from the local license map.
- Apply the same guard while rebuilding plugin license state for recovered running jobs.

## Root cause

With the license plugin enabled, deleting a license can leave its ID in the task's calculated license set while the corresponding entry has already been removed from `licenses_map`. Both `FreeLicense()` and `MallocLicenseWhenRecoverRunning()` dereferenced the result of `find()` without checking for `end()`, causing an abort in checked builds.

The scheduled master CI runs `29056336181` and `29128968628` both finished at 451/452 with `TC3.5.2.1` as the only failing case.

## Impact

License deletion no longer crashes CraneCtld while synchronizing plugin state. Recovery of running jobs also tolerates licenses that were removed before the plugin update list is generated.

## Validation

- `TC3.5.2.1` passed three consecutive runs with the plugin enabled.
- Plugin-disabled A/B run passed.
- Standard AutoTest entry completed with 452/452 passed, 0 failed, 0 errors.
- Ctld restart and recovery coverage passed, including `TC6.3.0.14` and `TC10.3.0.1`.
- `git diff --check` passed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved license recovery and release handling to safely skip missing license records.
  * Prevented potential errors when notifying plugins about license updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->