### PR TITLE
fix: fix daemon step unable to be cancelled

### DIFF
--- a/src/CraneCtld/CtldPublicDefs.cpp
+++ b/src/CraneCtld/CtldPublicDefs.cpp
@@ -636,14 +636,7 @@ DaemonStepInCtld::StepStatusChange(crane::grpc::JobStatus new_status,
 
   switch (this->Status()) {
   case crane::grpc::JobStatus::Configuring:
-    // Configuring -> Failed / Running
-    if (craned_id != kCtldPrologInternalNodeIndex) [[likely]] {
-      this->NodeConfigured(craned_id);
-    } else {
-      // CraneCtld Prolog completion event
-      this->SetCtldPrologPending(false);
-    }
-
+    // Validate the result before advancing the configuration barrier.
     switch (new_status) {
     case crane::grpc::JobStatus::Running:
       break;
@@ -654,11 +647,35 @@ DaemonStepInCtld::StepStatusChange(crane::grpc::JobStatus new_status,
       this->SetErrorExitCode(exit_code);
       break;
 
+    case crane::grpc::JobStatus::Completing:
+      if (craned_id == kCtldPrologInternalNodeIndex) [[unlikely]] {
+        CRANE_ERROR(
+            "Invalid CraneCtld Prolog status transition, current: {}, new: {}",
+            util::StepStatusToString(this->Status()),
+            util::StepStatusToString(new_status));
+        return std::nullopt;
+      }
+
+      // The daemon workload ended before the global configuration barrier
+      // converged. Local cleanup is still pending, so retain Completing for
+      // the node while recording a failed configuration result globally.
+      this->StepOnNodeCompleting(craned_id);
+      this->SetErrorStatus(crane::grpc::JobStatus::Failed);
+      this->SetErrorExitCode(exit_code);
+      break;
+
     [[unlikely]] default:
       CRANE_ERROR("Invalid daemon step status transition, current: {}, new: {}",
                   util::StepStatusToString(this->Status()),
                   util::StepStatusToString(new_status));
       return std::nullopt;
+    }
+
+    if (craned_id != kCtldPrologInternalNodeIndex) [[likely]] {
+      this->NodeConfigured(craned_id);
+    } else {
+      // CraneCtld Prolog completion event
+      this->SetCtldPrologPending(false);
     }
 
     if (this->AllNodesConfigured() && this->PrologComplete()) {

--- a/src/Craned/Core/JobManager.cpp
+++ b/src/Craned/Core/JobManager.cpp
@@ -1649,17 +1649,45 @@ void JobManager::LaunchStepMt_(std::unique_ptr<StepInstance> step) {
     return;
   }
   auto* job = job_ptr.get();
+  auto* step_ptr = step.get();
+
+  // A daemon owns job-level resources and must remain addressable until Ctld
+  // authorizes cleanup, even if setup fails before the supervisor is spawned.
+  if (step_ptr->IsDaemonStep()) {
+    absl::MutexLock lk(job->step_map_mtx.get());
+    auto [it, inserted] = job->step_map.emplace(step_id, std::move(step));
+    if (!inserted) {
+      CRANE_WARN("[Step #{}.{}] Step is already allocated, ignoring duplicate.",
+                 job_id, step_id);
+      return;
+    }
+    step_ptr = it->second.get();
+  }
+
+  auto report_config_failure = [this, step_ptr](uint32_t exit_code,
+                                                std::string reason) {
+    step_ptr->err_before_supv_start = true;
+    if (step_ptr->IsDaemonStep()) {
+      SendCompletingAndTerminal_(step_ptr->job_id, step_ptr->step_id,
+                                 StepStatus::Failed, exit_code,
+                                 std::move(reason));
+      return;
+    }
+
+    ActivateStepStatusChangeAsync_(
+        step_ptr->job_id, step_ptr->step_id, StepStatus::Failed, exit_code,
+        std::move(reason), std::nullopt,
+        google::protobuf::util::TimeUtil::GetCurrentTime());
+  };
 
   // Check if the step is acceptable.
   // We keep this container check here in case we support enabling/disabling
   // container functionality on parts of nodes in the future.
-  if (step->IsContainer() && !g_config.Container.Enabled) {
+  if (step_ptr->IsContainer() && !g_config.Container.Enabled) {
     CRANE_ERROR("Container support is disabled but job #{} requires it.",
                 job_id);
-    ActivateStepStatusChangeAsync_(
-        job_id, step_id, crane::grpc::JobStatus::Failed,
-        ExitCode::EC_SPAWN_FAILED, "Container is not enabled in this craned.",
-        std::nullopt, google::protobuf::util::TimeUtil::GetCurrentTime());
+    report_config_failure(ExitCode::EC_SPAWN_FAILED,
+                          "Container is not enabled in this craned.");
     return;
   }
 
@@ -1675,19 +1703,22 @@ void JobManager::LaunchStepMt_(std::unique_ptr<StepInstance> step) {
           CgroupManager::MakeCgroupPathInfo(job->job_id, res_v3.GetCpuSet());
     } else {
       CRANE_ERROR("Failed to get cgroup for job#{}", job_id);
-      ActivateStepStatusChangeAsync_(
-          job_id, step_id, crane::grpc::JobStatus::Failed,
+      report_config_failure(
           ExitCode::EC_CGROUP_ERR,
-          fmt::format("Failed to get cgroup for job#{} ", job_id), std::nullopt,
-          google::protobuf::util::TimeUtil::GetCurrentTime());
+          fmt::format("Failed to get cgroup for job#{} ", job_id));
       return;
     }
   }
 
-  auto* step_ptr = step.get();
-  {
+  if (!step_ptr->IsDaemonStep()) {
     absl::MutexLock lk(job->step_map_mtx.get());
-    job->step_map.emplace(step->step_id, std::move(step));
+    auto [it, inserted] = job->step_map.emplace(step_id, std::move(step));
+    if (!inserted) {
+      CRANE_WARN("[Step #{}.{}] Step is already allocated, ignoring duplicate.",
+                 job_id, step_id);
+      return;
+    }
+    step_ptr = it->second.get();
   }
 
   // err will NOT be kOk ONLY if fork() is not called due to some failure
@@ -1697,24 +1728,18 @@ void JobManager::LaunchStepMt_(std::unique_ptr<StepInstance> step) {
   CraneErrCode err = step_ptr->Prepare(job->path_info);
   if (err != CraneErrCode::SUCCESS) {
     CRANE_ERROR("[Step #{}.{}] Failed to prepare.", job_id, step_id);
-    step_ptr->err_before_supv_start = true;
-    ActivateStepStatusChangeAsync_(
-        job_id, step_id, crane::grpc::JobStatus::Failed,
+    report_config_failure(
         ExitCode::EC_CGROUP_ERR,
         fmt::format("Cannot create cgroup for the instance of step {}.{}",
-                    job_id, step_id),
-        std::nullopt, google::protobuf::util::TimeUtil::GetCurrentTime());
+                    job_id, step_id));
     return;
   }
   err = step_ptr->SpawnSupervisor(job->GetJobEnvMap());
   if (err != CraneErrCode::SUCCESS) {
-    step_ptr->err_before_supv_start = true;
-    ActivateStepStatusChangeAsync_(
-        job_id, step_id, crane::grpc::JobStatus::Failed,
+    report_config_failure(
         ExitCode::EC_SPAWN_FAILED,
         fmt::format("Cannot spawn a new process inside the instance of job #{}",
-                    job_id),
-        std::nullopt, google::protobuf::util::TimeUtil::GetCurrentTime());
+                    job_id));
   } else {
     // kOk means that SpawnSupervisor_ has successfully forked a child
     // process.

--- a/src/Craned/Core/StepInstance.cpp
+++ b/src/Craned/Core/StepInstance.cpp
@@ -567,10 +567,14 @@ void StepInstance::GotNewStatus(const StepStatus& new_status) {
   case StepStatus::Completing: {
     // Starting -> Completing is used when a termination request reaches the
     // supervisor before ExecuteStep gets a chance to launch tasks.
-    if (status != StepStatus::Running && status != StepStatus::Starting)
+    const bool daemon_configuration_failed =
+        this->IsDaemonStep() && status == StepStatus::Configuring;
+    if (status != StepStatus::Running && status != StepStatus::Starting &&
+        !daemon_configuration_failed)
       CRANE_WARN(
-          "[Step {}.{}] Step status is not 'Running/Starting' when receiving "
-          "new status 'Completing', current status: {}.",
+          "[Step {}.{}] Step status is not "
+          "'Running/Starting/daemon Configuring' when receiving new status "
+          "'Completing', current status: {}.",
           job_id, step_id, this->status);
     break;
   }

--- a/src/Craned/Supervisor/Supervisor.cpp
+++ b/src/Craned/Supervisor/Supervisor.cpp
@@ -27,6 +27,7 @@
 #include "TaskManager.h"
 #include "crane/PasswordEntry.h"
 #include "crane/PluginClient.h"
+#include "crane/PublicHeader.h"
 #include "crane/String.h"
 #include "crane/Tracing.h"
 #ifdef CRANE_ENABLE_TRACING
@@ -414,9 +415,64 @@ void GlobalVariableInit(int grpc_output_fd) {
   close(grpc_output_fd);
 }
 
+bool RunDaemonPrologs() {
+  if (g_config.JobLifecycleHook.Prologs.empty()) return true;
+
+  CRANE_TRACE("Running Prologs...");
+  RunPrologEpilogArgs run_prolog_args{
+      .scripts = g_config.JobLifecycleHook.Prologs,
+      .envs = g_config.JobEnv,
+      .timeout_sec = g_config.JobLifecycleHook.PrologTimeout,
+      .run_uid = 0,
+      .run_gid = 0,
+      .output_size = g_config.JobLifecycleHook.MaxOutputSize};
+  if (g_config.JobLifecycleHook.PrologEpilogTimeout > 0)
+    run_prolog_args.timeout_sec = g_config.JobLifecycleHook.PrologEpilogTimeout;
+
+  auto result = util::os::RunPrologOrEpiLog(run_prolog_args);
+  if (!result) {
+    const auto& status = result.error();
+    CRANE_DEBUG("Prolog failed status={}:{}", status.exit_code,
+                status.signal_num);
+    return false;
+  }
+
+  CRANE_DEBUG("Prolog success");
+  return true;
+}
+
+void InitializeAndReportDaemonStep() {
+  using Craned::Supervisor::StepStatus;
+
+  if (g_config.StepSpec.has_pod_meta()) {
+    if (!g_config.Container.Enabled) {
+      CRANE_ERROR(
+          "Container config is required for daemon step with pod spec.");
+      g_task_mgr->SupervisorFinishInitFailure(
+          StepStatus::Failed, ExitCode::EC_SPAWN_FAILED,
+          "Container support is disabled for daemon pod.");
+      return;
+    }
+
+    auto err_prom = g_task_mgr->ExecutePodInDaemonStepAsync();
+    if (auto err = err_prom.get(); err != CraneErrCode::SUCCESS) {
+      CRANE_ERROR("Failed to start daemon step, code: {}",
+                  static_cast<int>(err));
+      // Pod task initialization failures are published by the task finalizer.
+      return;
+    }
+  }
+
+  if (!RunDaemonPrologs()) {
+    g_task_mgr->SupervisorFinishInit(StepStatus::Failed);
+    return;
+  }
+
+  g_task_mgr->SupervisorFinishInit(StepStatus::Running);
+}
+
 void StartServer(int grpc_output_fd) {
   using crane::grpc::StepType;
-  using Craned::Supervisor::StepStatus;
 
   constexpr uint64_t file_max = 640000;
   if (!util::os::SetMaxFileDescriptorNumber(file_max)) {
@@ -432,59 +488,11 @@ void StartServer(int grpc_output_fd) {
   CRANE_INFO("Supervisor started for step type: {}.",
              static_cast<int>(g_config.StepSpec.step_type()));
 
-  StepStatus status{StepStatus::Invalid};
   if (g_config.StepSpec.step_type() == StepType::DAEMON) {
-    // For container jobs, the daemon step need to setup a pod per node,
-    // then the following common steps will launch containers inside the pod.
-    bool ready = true;
-    if (g_config.StepSpec.has_pod_meta()) {
-      if (!g_config.Container.Enabled) {
-        CRANE_ERROR(
-            "Container config is required for daemon step with pod spec.");
-        ready = false;
-      } else {
-        // Just wait here for pod setup. if pod failed, daemon step failed.
-        auto err_prom = g_task_mgr->ExecutePodInDaemonStepAsync();
-        if (auto err = err_prom.get(); err != CraneErrCode::SUCCESS) {
-          CRANE_ERROR("Failed to start daemon step, code: {}",
-                      static_cast<int>(err));
-          ready = false;
-        }
-      }
-    }
-
-    if (!g_config.JobLifecycleHook.Prologs.empty()) {
-      CRANE_TRACE("Running Prologs...");
-      RunPrologEpilogArgs run_prolog_args{
-          .scripts = g_config.JobLifecycleHook.Prologs,
-          .envs = g_config.JobEnv,
-          .timeout_sec = g_config.JobLifecycleHook.PrologTimeout,
-          .run_uid = 0,
-          .run_gid = 0,
-          .output_size = g_config.JobLifecycleHook.MaxOutputSize};
-      if (g_config.JobLifecycleHook.PrologEpilogTimeout > 0)
-        run_prolog_args.timeout_sec =
-            g_config.JobLifecycleHook.PrologEpilogTimeout;
-
-      auto result = util::os::RunPrologOrEpiLog(run_prolog_args);
-      if (!result) {
-        auto status = result.error();
-        CRANE_DEBUG("Prolog failed status={}:{}", status.exit_code,
-                    status.signal_num);
-        ready = false;
-      } else {
-        CRANE_DEBUG("Prolog success");
-      }
-    }
-
-    // Daemon step is RUNNING after supervisor and related resources are ready.
-    status = ready ? StepStatus::Running : StepStatus::Failed;
+    InitializeAndReportDaemonStep();
   } else {
-    // Common step is Starting after supervisor is ready.
-    status = StepStatus::Starting;
+    g_task_mgr->SupervisorFinishInit(crane::grpc::JobStatus::Starting);
   }
-
-  g_task_mgr->SupervisorFinishInit(status);
 
   g_server->Wait();
   g_server.reset();

--- a/src/Craned/Supervisor/TaskManager.cpp
+++ b/src/Craned/Supervisor/TaskManager.cpp
@@ -336,10 +336,14 @@ void StepInstance::GotNewStatus(StepStatus new_status) {
   case StepStatus::Completing: {
     // Starting -> Completing is used when a termination request reaches the
     // supervisor before ExecuteStep gets a chance to launch tasks.
-    if (m_status_ != StepStatus::Running && m_status_ != StepStatus::Starting)
+    const bool daemon_configuration_failed =
+        this->IsDaemon() && m_status_ == StepStatus::Configuring;
+    if (m_status_ != StepStatus::Running && m_status_ != StepStatus::Starting &&
+        !daemon_configuration_failed)
       CRANE_WARN(
-          "[Step {}.{}] Step status is not 'Running/Starting' when receiving "
-          "new status 'Completing', current status: {}.",
+          "[Step {}.{}] Step status is not "
+          "'Running/Starting/daemon Configuring' when receiving new status "
+          "'Completing', current status: {}.",
           job_id, step_id, m_status_.load());
     break;
   }
@@ -2747,6 +2751,23 @@ void TaskManager::SupervisorFinishInit(StepStatus status) {
   g_craned_client->StepStatusChangeAsync(status, 0, std::nullopt);
 }
 
+void TaskManager::SupervisorFinishInitFailure(StepStatus final_status,
+                                              uint32_t exit_code,
+                                              std::string reason) {
+  CRANE_ASSERT(m_step_.IsDaemon());
+  CRANE_ASSERT(IsFinishedStepStatus(final_status) &&
+               final_status != StepStatus::Completed);
+
+  auto& termination = m_step_.final_termination_status;
+  termination.final_status_on_termination = final_status;
+  termination.max_exit_code = exit_code;
+  termination.final_reason_on_termination = reason;
+
+  m_step_.GotNewStatus(StepStatus::Completing);
+  g_craned_client->StepStatusChangeAsync(StepStatus::Completing, exit_code,
+                                         std::move(reason), final_status);
+}
+
 bool TaskManager::ReceivePmixPort(
     const crane::grpc::supervisor::ReceivePmixPortRequest& request) {
   if (!m_step_.pmix_server) {
@@ -2881,7 +2902,9 @@ void TaskManager::ResolveFinishedTask_(task_id_t task_id, StepStatus new_status,
     g_craned_client->StepStatusChangeAsync(
         StepStatus::Completing, status.max_exit_code,
         status.final_reason_on_termination, status.final_status_on_termination);
-    ShutdownSupervisorAsync();
+    ShutdownSupervisorAsync(status.final_status_on_termination,
+                            status.max_exit_code,
+                            status.final_reason_on_termination);
   }
 }
 
@@ -3133,7 +3156,9 @@ void TaskManager::EvShutdownSupervisorCb_() {
     }
 
     auto& [status, exit_code, reason] = final_status;
-    if (m_step_.IsDaemon()) {
+    // The task finalizer may have already published Completing. In that case,
+    // explicit shutdown only authorizes cleanup and supervisor exit.
+    if (m_step_.IsDaemon() && m_step_.GetStatus() != StepStatus::Completing) {
       m_step_.GotNewStatus(StepStatus::Completing);
       CRANE_DEBUG("Sending Completing as daemon step (final: {}).", status);
       g_craned_client->StepStatusChangeAsync(StepStatus::Completing, exit_code,

--- a/src/Craned/Supervisor/TaskManager.h
+++ b/src/Craned/Supervisor/TaskManager.h
@@ -553,6 +553,8 @@ class TaskManager {
   TaskManager& operator=(TaskManager&&) = delete;
 
   void SupervisorFinishInit(StepStatus status);
+  void SupervisorFinishInitFailure(StepStatus final_status, uint32_t exit_code,
+                                   std::string reason);
 
   bool ReceivePmixPort(
       const crane::grpc::supervisor::ReceivePmixPortRequest& request);


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of daemon-step initialization failures, including clearer failure statuses, exit codes, and reasons.
  * Corrected status transitions when daemon steps move from configuring to completing.
  * Prevented duplicate completion notifications during supervisor shutdown.
  * Improved handling of failures during container setup, supervisor startup, and configured initialization scripts.
* **Reliability**
  * Improved consistency of step ownership and status reporting during daemon startup and failure scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->