### PR TITLE
ci: route temporary repository runner by label

### DIFF
--- a/.github/ci/README.md
+++ b/.github/ci/README.md
@@ -11,11 +11,18 @@ the following are true:
 - `github.triggering_actor` currently has `maintain` or `admin` permission;
 - Backend and FrontEnd refs resolve to full commit SHAs.
 
-The organization runner group must allow only
+The current cutover uses the existing repository-scoped runner and selects it
+with the `cranesystemtest` label. This temporary mode does not isolate the
+runner from other workflows in `PKUHPC/CraneSched`: labels route jobs, but do
+not authorize workflows. Keep the runner stopped except for controlled CI runs
+until an organization owner completes the runner-group migration below.
+
+The target state is an organization runner group that allows only
 `PKUHPC/CraneSched/.github/workflows/build.yaml@refs/heads/master`. Its runner
-must have the `cranesystemtest` label and runner name. The workflow selects the
-group through the `CRANESCHED_PRIVILEGED_RUNNER_GROUP` repository variable so
-the group name is not duplicated in source.
+must keep the `cranesystemtest` label and runner name. After migration, restore
+the workflow's `runs-on.group` selector using the
+`CRANESCHED_PRIVILEGED_RUNNER_GROUP` repository variable so the group name is
+not duplicated in source.
 
 ## Repository variables
 
@@ -25,7 +32,7 @@ these repository variables:
 
 | Variable | Contract |
 | --- | --- |
-| `CRANESCHED_PRIVILEGED_RUNNER_GROUP` | Organization runner group restricted to `.github/workflows/build.yaml` |
+| `CRANESCHED_PRIVILEGED_RUNNER_GROUP` | Target-state organization runner group; `Default` is only a temporary cutover marker and is not consumed by label-only routing |
 | `CRANETESTKIT_RELEASE_DIR` | Absolute path to a root-owned, recursively read-only AutoTest Git release |
 | `CRANETESTKIT_AUTOTEST_SHA` | Exact 40-character commit deployed at the release path |
 | `CRANETESTKIT_EXECUTABLE_SHA256` | SHA-256 of the prepared `<release>/.venv/bin/crane_testkit` entry point |
@@ -136,6 +143,35 @@ The AutoTest release remote must not contain a PAT. Rotate any previously
 embedded PAT, then use a short-lived read-only GitHub App or deploy credential
 only during the administrator deployment. CI itself performs no AutoTest Git
 network operation.
+
+## Organization runner-group migration
+
+An organization owner must perform this migration before the Backend runner is
+left online between runs:
+
+1. Create a PKUHPC organization runner group with selected-repository access
+   limited to `PKUHPC/CraneSched` and selected-workflow access limited to
+   `PKUHPC/CraneSched/.github/workflows/build.yaml@refs/heads/master`.
+2. Stop the repository-scoped Backend runner and confirm it is idle, no
+   CraneTestKit Lease is held, and no matching Actions job is queued.
+3. Remove the repository-scoped registration and register the same runner at
+   `https://github.com/PKUHPC` in the new group. Keep runner name and custom
+   label `cranesystemtest`; preserve the verified release hooks and restricted
+   kubeconfig in the service environment. Registration and removal tokens must
+   be short-lived, passed without logging, and never stored on disk.
+4. Set `CRANESCHED_PRIVILEGED_RUNNER_GROUP` to the new group name and restore
+   the workflow selector to:
+
+   ```yaml
+   runs-on:
+     group: ${{ vars.CRANESCHED_PRIVILEGED_RUNNER_GROUP }}
+     labels: cranesystemtest
+   ```
+
+5. Start only the Backend runner, dispatch `build.yaml` from `master`, and
+   verify the `test` job reports the new organization group before leaving the
+   service enabled. The AutoTest maintenance runner remains a separate
+   registration and group.
 
 ## Artifacts and result contract
 

--- a/.github/ci/authorize.py
+++ b/.github/ci/authorize.py
@@ -159,7 +159,9 @@ class GitHubApi:
             )
         self._token = token
 
-    def _get(self, path: str, *, missing_ok: bool = False) -> dict[str, object] | None:
+    def _get(
+        self, path: str, *, missing_statuses: frozenset[int] = frozenset()
+    ) -> dict[str, object] | None:
         request = urllib.request.Request(
             f"https://api.github.com/{path}",
             headers={
@@ -173,7 +175,7 @@ class GitHubApi:
             with urllib.request.urlopen(request, timeout=30) as response:
                 value = json.load(response)
         except urllib.error.HTTPError as exc:
-            if missing_ok and exc.code == 404:
+            if exc.code in missing_statuses:
                 return None
             raise AuthorizationError(
                 f"GitHub API request failed with HTTP {exc.code}"
@@ -194,7 +196,10 @@ class GitHubApi:
 
     def commit(self, repository: str, ref: str) -> str | None:
         encoded_ref = urllib.parse.quote(ref, safe="")
-        value = self._get(f"repos/{repository}/commits/{encoded_ref}", missing_ok=True)
+        value = self._get(
+            f"repos/{repository}/commits/{encoded_ref}",
+            missing_statuses=frozenset({404, 422}),
+        )
         if value is None:
             return None
         revision = value.get("sha")

--- a/.github/ci/test_authorize.py
+++ b/.github/ci/test_authorize.py
@@ -1,9 +1,12 @@
 from __future__ import annotations
 
 import importlib.util
+import io
 import sys
 import unittest
+import urllib.error
 from pathlib import Path
+from unittest import mock
 
 
 MODULE_PATH = Path(__file__).with_name("authorize.py")
@@ -127,6 +130,37 @@ class AuthorizationPolicyTest(unittest.TestCase):
         )
         self.assertEqual(result["frontend_ref"], "master")
         self.assertEqual(result["frontend_sha"], FRONTEND_SHA)
+
+
+class GitHubApiTest(unittest.TestCase):
+    @staticmethod
+    def _http_error(status: int) -> urllib.error.HTTPError:
+        return urllib.error.HTTPError(
+            "https://api.github.com/test",
+            status,
+            "test error",
+            hdrs=None,
+            fp=io.BytesIO(b"{}"),
+        )
+
+    def test_missing_commit_accepts_github_404_and_422_responses(self) -> None:
+        api = authorize.GitHubApi("test-token")
+        for status in (404, 422):
+            with self.subTest(status=status), mock.patch.object(
+                authorize.urllib.request,
+                "urlopen",
+                side_effect=self._http_error(status),
+            ):
+                self.assertIsNone(api.commit("PKUHPC/CraneSched", "missing/ref"))
+
+    def test_permission_lookup_keeps_422_fail_closed(self) -> None:
+        api = authorize.GitHubApi("test-token")
+        with mock.patch.object(
+            authorize.urllib.request,
+            "urlopen",
+            side_effect=self._http_error(422),
+        ), self.assertRaisesRegex(authorize.AuthorizationError, "HTTP 422"):
+            api.permission("PKUHPC/CraneSched", "maintainer")
 
 
 if __name__ == "__main__":

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -97,9 +97,7 @@ jobs:
     name: test
     needs: authorize
     if: needs.authorize.outputs.authorized == 'true'
-    runs-on:
-      group: ${{ vars.CRANESCHED_PRIVILEGED_RUNNER_GROUP }}
-      labels: cranesystemtest
+    runs-on: [self-hosted, cranesystemtest]
     timeout-minutes: 180
     permissions:
       contents: read


### PR DESCRIPTION
## Summary

- route the temporary repository-scoped Backend runner by `self-hosted` and `cranesystemtest` labels
- document why label-only routing is temporary and how an organization owner migrates the runner to a workflow-restricted group

## Why

The first post-cutover run proved that a repository-scoped runner in the UI's `Default` pool cannot satisfy `runs-on.group: Default`: the hosted authorization job passed, but the matching online runner remained idle and the `test` job stayed queued. Label-only routing is required for the explicitly approved one-run validation. The runner remains stopped outside controlled runs until the organization-group migration is complete.

## Validation

- Backend CI helper tests: `23 passed`
- Ruff: passed
- actionlint: passed
- `git diff --check`: passed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Clarified privileged CI runner cutover and migration procedures.
  - Documented runner-group setup, secure re-registration, workflow configuration, and validation steps.
  - Defined the temporary use of `Default` during migration.

- **Bug Fixes**
  - Simplified test-job runner selection while preserving the required self-hosted runner label.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->