### PR TITLE
ci: validate Kubernetes authorization responses

### DIFF
--- a/.github/ci/test_validate_cranetestkit_runner.py
+++ b/.github/ci/test_validate_cranetestkit_runner.py
@@ -216,6 +216,40 @@ class NfsMountValidationTest(unittest.TestCase):
                         )
 
 
+class RuntimeValidationTest(unittest.TestCase):
+    def test_tagged_runtime_image_is_normalized_to_repository_and_digest(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary:
+            path = Path(temporary) / "runtime.json"
+            autotest_sha = "a" * 40
+            lock_sha = "b" * 64
+            image_digest = "sha256:" + "c" * 64
+            path.write_text(
+                json.dumps(
+                    {
+                        "apiVersion": "cranesched.io/v1alpha1",
+                        "kind": "CraneTestKitImageRuntime",
+                        "sourceShas": {"autotest": autotest_sha},
+                        "lockSha256": lock_sha,
+                        "autotest": {
+                            "image": "localhost/autotest:bundle-id",
+                            "digest": image_digest,
+                        },
+                    }
+                ),
+                encoding="utf-8",
+            )
+            self.assertEqual(
+                validation._validate_runtime(
+                    path,
+                    _sha256(path),
+                    autotest_sha,
+                    lock_sha,
+                    "localhost/autotest",
+                ),
+                f"localhost/autotest@{image_digest}",
+            )
+
+
 class KubeconfigValidationTest(unittest.TestCase):
     def _config(self, user: dict[str, str]) -> dict[str, object]:
         return {
@@ -402,6 +436,47 @@ class KubernetesPermissionCommandTest(unittest.TestCase):
         )
         self.assertNotIn("--subresource", " ".join(command))
         self.assertIn("jobs.batch", command)
+
+    def test_can_i_accepts_kubectl_yes_and_no_exit_codes(self) -> None:
+        for answer, return_code, expected in (("yes", 0, True), ("no", 1, False)):
+            with self.subTest(answer=answer), mock.patch.object(
+                validation.subprocess,
+                "run",
+                return_value=subprocess.CompletedProcess(
+                    args=[], returncode=return_code, stdout=f"{answer}\n", stderr=""
+                ),
+            ):
+                self.assertIs(
+                    validation._can_i(
+                        Path("/usr/local/bin/k3s"),
+                        {},
+                        "get",
+                        "secrets",
+                        "crane-testkit",
+                    ),
+                    expected,
+                )
+
+    def test_can_i_rejects_inconsistent_or_unexpected_results(self) -> None:
+        for answer, return_code in (("no", 0), ("yes", 1), ("no", 2), ("maybe", 0)):
+            with self.subTest(
+                answer=answer, return_code=return_code
+            ), mock.patch.object(
+                validation.subprocess,
+                "run",
+                return_value=subprocess.CompletedProcess(
+                    args=[], returncode=return_code, stdout=f"{answer}\n", stderr=""
+                ),
+            ), self.assertRaisesRegex(
+                validation.ValidationError, "unexpected Kubernetes authorization"
+            ):
+                validation._can_i(
+                    Path("/usr/local/bin/k3s"),
+                    {},
+                    "get",
+                    "secrets",
+                    "crane-testkit",
+                )
 
 
 class AdmissionValidationTest(unittest.TestCase):

--- a/.github/ci/validate-cranetestkit-runner.py
+++ b/.github/ci/validate-cranetestkit-runner.py
@@ -441,7 +441,7 @@ def _validate_runtime(
         )
     if pinned.rsplit("@", 1)[1] != digest:
         raise ValidationError("AutoTest image and digest fields disagree")
-    return pinned
+    return f"{repository}@{digest}"
 
 
 def _validate_nfs_mount_identity(
@@ -723,10 +723,16 @@ def _can_i(
     k3s: Path, env: dict[str, str], verb: str, resource: str, namespace: str
 ) -> bool:
     command = _can_i_command(k3s, verb, resource, namespace)
-    answer = _run(
-        command, env=env, label=f"check Kubernetes permission {verb} {resource}"
+    result = subprocess.run(
+        command,
+        env=env,
+        check=False,
+        text=True,
+        capture_output=True,
     )
-    if answer not in {"yes", "no"}:
+    answer = result.stdout.strip()
+    expected_return_code = {"yes": 0, "no": 1}.get(answer)
+    if expected_return_code is None or result.returncode != expected_return_code:
         raise ValidationError(
             f"unexpected Kubernetes authorization answer for {verb} {resource}"
         )


### PR DESCRIPTION
## Summary

- accept the documented kubectl authorization result pairs `yes/0` and `no/1` while rejecting inconsistent or unexpected responses
- normalize the AutoTest runtime image to `repository@digest`, matching CraneTestKit planning and the exact admission allowlist
- add regression coverage for both live-contract failures

## Root cause

The first real master cutover reached the trusted runner preflight and exposed two mismatches in the Backend validator. `kubectl auth can-i` returns exit code 1 for an expected denial, while the validator required exit code 0 for every query. The validator also preserved the runtime bundle tag in `tag@digest`, whereas CraneTestKit and the admission policy use canonical `repository@digest` references.

## Validation

- Backend CI helper tests: `28 passed`
- Ruff: passed
- actionlint: passed
- `git diff --check`: passed
- full live runner preflight on `cranesystemtest`: passed
- live preflight covered release checksum, NFS identity, restricted certificate, RBAC positive/negative matrix, approved Jobs, and forbidden admission mutations
