### PR TITLE
ci: accept package cache misses

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -311,7 +311,14 @@ jobs:
           build_json="$(tail -n 1 "$build_log")"
           build_manifest="$(jq -er '.manifest' <<<"$build_json")"
           build_id="$(jq -er '.build_id' <<<"$build_json")"
-          cache_hit="$(jq -er '.cache_hit' <<<"$build_json")"
+          cache_hit="$(
+            jq -er '
+              .cache_hit
+              | if type == "boolean" then tostring
+                else error("cache_hit must be a boolean")
+                end
+            ' <<<"$build_json"
+          )"
           [[ "$build_manifest" == "$CRANETESTKIT_NFS_ROOT/builds/"*"/manifest.json" ]]
           [[ -f "$build_manifest" && ! -L "$build_manifest" ]]
           {


### PR DESCRIPTION
## Summary

- preserve a valid `cache_hit: false` result from `crane_testkit env build`
- keep strict type validation for the build JSON contract

## Root cause

The first successful exact build published build `cfc3d2b066e6be002ac386dfecdbad07554d267a064abaec12e2eed756f2dc8d`, then the workflow parsed `.cache_hit` with `jq -e`. jq intentionally exits 1 when its final value is boolean false, so a normal first-build cache miss failed the step after package publication.

## Validation

- parser accepts only `true` and `false`, preserving both as strings
- parser rejects missing and string-typed values
- actionlint: passed
- Backend CI helper tests: `28 passed`
- `git diff --check`: passed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved build validation by ensuring cache status values are valid booleans.
  * Build processing now reports a clear error when cache status data has an unexpected type.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->