### PR TITLE
fix(ci): improve CraneTestKit system test reports

### DIFF
--- a/.github/ci/README.md
+++ b/.github/ci/README.md
@@ -183,10 +183,18 @@ collection and exact run cleanup.
 The workflow uploads only an allowlisted copy of plan, state, aggregate result,
 build/image manifests and checkpoints. Shard logs are uploaded only on failure,
 are capped at 4 MiB per file and 128 MiB in total, and pass through credential
-redaction. Every value written to the GitHub step summary uses the same
-redaction and Markdown escaping. Full NFS directories, environment files,
-kubeconfigs and Kubernetes Secrets are never uploaded. GitHub artifacts are
-retained for 14 days.
+redaction. The GitHub step summary renders the aggregate outcome, affected
+cases, infrastructure errors, per-shard balance, phase timings, slowest cases
+and folded provenance. Dynamic values use the same redaction and Markdown
+escaping, and report rows are capped before rendering. Full NFS directories,
+environment files, kubeconfigs and Kubernetes Secrets are never uploaded.
+GitHub artifacts are retained for the repository maximum of 3 days; durable
+run evidence remains under the configured NFS retention policy.
+
+The collector cross-checks the workflow-captured process exit code against the
+aggregate result, run state and terminal shard evidence. Any mismatch or
+incomplete evidence resolves to infrastructure exit code `2`, and the final
+required check uses that resolved value.
 
 CraneTestKit exit codes remain authoritative:
 

--- a/.github/ci/collect-cranetestkit-artifacts.py
+++ b/.github/ci/collect-cranetestkit-artifacts.py
@@ -6,9 +6,11 @@ from __future__ import annotations
 import argparse
 import hashlib
 import json
+import math
 import re
 import shutil
 import stat
+from datetime import datetime, timezone
 from itertools import islice
 from pathlib import Path
 
@@ -17,8 +19,14 @@ MAX_LOG_BYTES = 4 * 1024 * 1024
 MAX_TOTAL_LOG_BYTES = 128 * 1024 * 1024
 MAX_METADATA_BYTES = 8 * 1024 * 1024
 MAX_METADATA_FILES = 512
+MAX_CHECKPOINT_BYTES = 2 * 1024 * 1024
+MAX_TOTAL_CHECKPOINT_BYTES = 16 * 1024 * 1024
 MAX_LOG_FILES = 2048
 MAX_LOG_SCAN = 8192
+MAX_FAILURE_ROWS = 50
+MAX_INFRASTRUCTURE_ROWS = 20
+MAX_SLOW_CASE_ROWS = 10
+MAX_SUMMARY_BYTES = 512 * 1024
 SAFE_LOG_NAME = re.compile(r"^[A-Za-z0-9_.-]+\.log$")
 DENIED_NAME = re.compile(
     r"(?:env|context|secret|token|credential|kubeconfig)", re.IGNORECASE
@@ -26,7 +34,20 @@ DENIED_NAME = re.compile(
 LOG_RELATIVE = re.compile(
     r"^[A-Za-z0-9_.-]+/[0-9]+/(?:[A-Za-z0-9_.-]+/)*[A-Za-z0-9_.-]+\.log$"
 )
+CASE_LEVEL_DIAGNOSTIC = re.compile(
+    r"^(?:case was not run|missing case result):\s*\S+\s*$", re.IGNORECASE
+)
+EXECUTION_STAGE_MESSAGE = re.compile(
+    r"^(?:cancelled|run/wait|collect(?: cancelled)?|stop(?: cancelled| retry)?|"
+    r"lease(?: release)?):",
+    re.IGNORECASE,
+)
 REDACTIONS = (
+    re.compile(
+        r"-----BEGIN [A-Z ]*PRIVATE KEY-----.*?"
+        r"(?:-----END [A-Z ]*PRIVATE KEY-----|\Z)",
+        re.S,
+    ),
     re.compile(r"github_pat_[A-Za-z0-9_]+"),
     re.compile(r"gh[pousr]_[A-Za-z0-9]+"),
     re.compile(r"\b(?:hvs\.[A-Za-z0-9_-]+|s\.[A-Za-z0-9]{16,})\b"),
@@ -37,10 +58,10 @@ REDACTIONS = (
         r"\s*[:=]\s*)[^\s,;]+"
     ),
     re.compile(r"(?i)(https?://)[^/@\s:]+:[^/@\s]+@"),
-    re.compile(
-        r"-----BEGIN [A-Z ]*PRIVATE KEY-----.*?-----END [A-Z ]*PRIVATE KEY-----", re.S
-    ),
 )
+ANSI_ESCAPE = re.compile(r"\x1b\[[0-?]*[ -/]*[@-~]")
+UNSAFE_CONTROLS = re.compile(r"[\x00-\x08\x0b\x0c\x0e-\x1f\x7f]")
+BIDI_CONTROLS = re.compile(r"[\u202a-\u202e\u2066-\u2069]")
 
 
 def _sha256(path: Path) -> str:
@@ -119,6 +140,8 @@ def _copy_text(
 
 def _escape_markdown(value: object) -> str:
     text, _ = _redact(str(value)[:4096])
+    text = BIDI_CONTROLS.sub("", ANSI_ESCAPE.sub("", text))
+    text = UNSAFE_CONTROLS.sub(" ", text)
     return (
         text[:512]
         .replace("&", "&amp;")
@@ -131,55 +154,750 @@ def _escape_markdown(value: object) -> str:
     )
 
 
+def _reject_json_constant(constant: str) -> object:
+    raise ValueError(f"invalid JSON constant: {constant}")
+
+
 def _read_json(path: Path) -> dict[str, object]:
     try:
         if path.stat().st_size > MAX_METADATA_BYTES:
             return {}
-        value = json.loads(path.read_text(encoding="utf-8"))
-    except (OSError, json.JSONDecodeError):
+        value = json.loads(
+            path.read_text(encoding="utf-8"),
+            parse_constant=_reject_json_constant,
+        )
+    except (OSError, UnicodeError, ValueError, RecursionError):
         return {}
     return value if isinstance(value, dict) else {}
 
 
-def _write_summary(destination: Path, run_id: str, run_root: Path) -> None:
-    result = _read_json(run_root / "result.json")
-    state = _read_json(run_root / "state.json")
-    plan = _read_json(run_root / "plan/manifest.json")
+def _read_run_json(run_root: Path, relative: Path) -> dict[str, object]:
+    if not run_root.is_dir() or run_root.is_symlink():
+        return {}
+    source = _safe_source(run_root, relative)
+    return _read_json(source) if source is not None else {}
+
+
+def _number(value: object) -> float | None:
+    if isinstance(value, bool) or not isinstance(value, (int, float)):
+        return None
+    try:
+        number = float(value)
+    except (OverflowError, ValueError):
+        return None
+    return number if math.isfinite(number) and number >= 0 else None
+
+
+def _integer(value: object) -> int | None:
+    if isinstance(value, bool) or not isinstance(value, int) or value < 0:
+        return None
+    return value
+
+
+def _format_duration(value: object) -> str:
+    seconds = _number(value)
+    if seconds is None:
+        return "unavailable"
+    scaled = seconds * 100
+    if not math.isfinite(scaled):
+        return "unavailable"
+    centiseconds = int(round(scaled))
+    hours, remainder = divmod(centiseconds, 360_000)
+    minutes, remainder = divmod(remainder, 6_000)
+    whole_seconds = remainder / 100
+    if hours:
+        return f"{hours}h {minutes:02d}m {whole_seconds:05.2f}s"
+    if minutes:
+        return f"{minutes}m {whole_seconds:05.2f}s"
+    return f"{whole_seconds:.2f}s"
+
+
+def _format_case_duration(value: object) -> str:
+    seconds = _number(value)
+    return f"{seconds:.2f}s" if seconds is not None else "unavailable"
+
+
+def _timestamp(value: object) -> datetime | None:
+    if not isinstance(value, str) or not value:
+        return None
+    normalized = value[:-1] + "+00:00" if value.endswith("Z") else value
+    try:
+        parsed = datetime.fromisoformat(normalized)
+    except ValueError:
+        return None
+    return parsed.replace(tzinfo=timezone.utc) if parsed.tzinfo is None else parsed
+
+
+def _duration_between(started_at: object, finished_at: object) -> float | None:
+    started = _timestamp(started_at)
+    finished = _timestamp(finished_at)
+    if started is None or finished is None:
+        return None
+    duration = (finished - started).total_seconds()
+    return duration if math.isfinite(duration) and duration >= 0 else None
+
+
+def _case_counts(cases: object) -> dict[str, int]:
+    counts = {"passed": 0, "failed": 0, "error": 0, "not_run": 0}
+    if not isinstance(cases, list):
+        return counts
+    for case in cases:
+        if not isinstance(case, dict):
+            continue
+        status = case.get("status")
+        if isinstance(status, str) and status in counts:
+            counts[status] += 1
+    return counts
+
+
+def _allocation_by_shard(allocation: dict[str, object]) -> dict[int, tuple[str, str]]:
+    result: dict[int, tuple[str, str]] = {}
+    workers = allocation.get("workers")
+    if not isinstance(workers, dict):
+        return result
+    for worker, shard_indices in workers.items():
+        if not isinstance(worker, str) or not isinstance(shard_indices, list):
+            continue
+        for slot, shard_index in enumerate(shard_indices):
+            if _integer(shard_index) is not None:
+                result[shard_index] = (worker, str(slot))
+    return result
+
+
+def _planned_shards(plan: dict[str, object]) -> dict[int, dict[str, object]]:
+    result: dict[int, dict[str, object]] = {}
+    sharding = plan.get("sharding")
+    if not isinstance(sharding, dict) or not isinstance(sharding.get("shards"), list):
+        return result
+    for shard in sharding["shards"]:
+        if not isinstance(shard, dict):
+            continue
+        shard_index = _integer(shard.get("index"))
+        if shard_index is not None:
+            result[shard_index] = shard
+    return result
+
+
+def _shard_results(run_root: Path) -> list[tuple[Path, dict[str, object]]]:
+    results_root = run_root / "results"
+    if (
+        not results_root.is_dir()
+        or results_root.is_symlink()
+        or not run_root.is_dir()
+        or run_root.is_symlink()
+    ):
+        return []
+    records: list[tuple[Path, dict[str, object]]] = []
+    total_bytes = 0
+    for path in sorted(islice(results_root.rglob("shard-*.json"), MAX_METADATA_FILES)):
+        try:
+            relative = path.relative_to(run_root)
+        except ValueError:
+            continue
+        source = _safe_source(run_root, relative)
+        if source is None:
+            continue
+        try:
+            source_bytes = source.stat().st_size
+        except OSError:
+            continue
+        if source_bytes > MAX_CHECKPOINT_BYTES:
+            continue
+        if total_bytes + source_bytes > MAX_TOTAL_CHECKPOINT_BYTES:
+            break
+        total_bytes += source_bytes
+        value = _read_json(source)
+        if value:
+            records.append((relative, value))
+    return records
+
+
+def _shard_context(
+    run_root: Path,
+    plan: dict[str, object],
+    allocation: dict[str, object],
+) -> tuple[list[dict[str, object]], dict[str, tuple[int, str, str]], list[str]]:
+    planned = _planned_shards(plan)
+    allocated = _allocation_by_shard(allocation)
+    records_by_index: dict[int, list[tuple[Path, dict[str, object]]]] = {}
+    case_locations: dict[str, tuple[int, str, str]] = {}
+    fatals: list[str] = []
+
+    for relative, record in _shard_results(run_root):
+        shard_index = _integer(record.get("shard_index"))
+        if shard_index is None:
+            continue
+        records_by_index.setdefault(shard_index, []).append((relative, record))
+        worker, slot = allocated.get(shard_index, ("unavailable", "unavailable"))
+        if len(relative.parts) >= 4 and relative.parts[0] == "results":
+            worker, slot = relative.parts[1], relative.parts[2]
+        cases = record.get("cases")
+        if isinstance(cases, list):
+            for case in cases:
+                if isinstance(case, dict) and isinstance(case.get("id"), str):
+                    case_locations.setdefault(case["id"], (shard_index, worker, slot))
+        fatal = record.get("fatal")
+        if isinstance(fatal, dict):
+            phase = fatal.get("phase", "unknown")
+            message = fatal.get("message", "unknown fatal error")
+            phase = phase if isinstance(phase, str) else "unknown"
+            message = message if isinstance(message, str) else "unknown fatal error"
+            fatals.append(f"shard {shard_index} fatal during {phase}: {message}")
+
+    rows: list[dict[str, object]] = []
+    for shard_index in sorted(set(planned) | set(records_by_index)):
+        expected = planned.get(shard_index, {})
+        expected_cases = expected.get("cases")
+        planned_count = len(expected_cases) if isinstance(expected_cases, list) else 0
+        estimate = expected.get("estimated_duration_seconds")
+        records = records_by_index.get(shard_index, [])
+        worker, slot = allocated.get(shard_index, ("unavailable", "unavailable"))
+        if len(records) != 1:
+            rows.append(
+                {
+                    "shard": shard_index,
+                    "worker": worker,
+                    "slot": slot,
+                    "cases": planned_count,
+                    "counts": _case_counts([]),
+                    "wall": None,
+                    "case_time": None,
+                    "estimate": estimate,
+                    "result": "MISSING" if not records else f"DUPLICATE ({len(records)})",
+                    "terminal": False,
+                }
+            )
+            continue
+
+        relative, record = records[0]
+        if len(relative.parts) >= 4 and relative.parts[0] == "results":
+            worker, slot = relative.parts[1], relative.parts[2]
+        cases = record.get("cases")
+        counts = _case_counts(cases)
+        case_time = None
+        if isinstance(cases, list):
+            case_time = sum(
+                duration
+                for case in cases
+                if isinstance(case, dict)
+                and (duration := _number(case.get("duration_seconds"))) is not None
+            )
+        fatal = record.get("fatal")
+        exit_code = record.get("worker_exit_code")
+        if not isinstance(exit_code, int) or isinstance(exit_code, bool):
+            exit_code = None
+        if isinstance(fatal, dict) or exit_code == 2:
+            outcome = "INFRASTRUCTURE ERROR"
+        elif counts["not_run"]:
+            outcome = "INCOMPLETE"
+        elif counts["failed"] or counts["error"] or exit_code == 1:
+            outcome = "TEST FAILURE"
+        elif exit_code == 0 and record.get("finished_at"):
+            outcome = "PASSED"
+        else:
+            outcome = "INCOMPLETE"
+        rows.append(
+            {
+                "shard": shard_index,
+                "worker": worker,
+                "slot": slot,
+                "cases": len(cases) if isinstance(cases, list) else planned_count,
+                "counts": counts,
+                "wall": _duration_between(record.get("started_at"), record.get("finished_at")),
+                "case_time": case_time,
+                "estimate": estimate,
+                "result": outcome,
+                "terminal": exit_code in {0, 1, 2} and bool(record.get("finished_at")),
+            }
+        )
+    return rows, case_locations, fatals
+
+
+def _append_table(
+    lines: list[str], headers: tuple[str, ...], rows: list[tuple[object, ...]]
+) -> None:
+    lines.append("| " + " | ".join(headers) + " |")
+    lines.append("| " + " | ".join("---" for _ in headers) + " |")
+    lines.extend(
+        "| " + " | ".join(f"`{_escape_markdown(value)}`" for value in row) + " |"
+        for row in rows
+    )
+
+
+def _valid_exit_code(value: object) -> int | None:
+    if isinstance(value, int) and not isinstance(value, bool) and value in {0, 1, 2}:
+        return value
+    return None
+
+
+def _resolve_exit_code(
+    result: dict[str, object],
+    state: dict[str, object],
+    execute_exit_code: int | None,
+) -> tuple[int | None, list[str]]:
+    result_code = _valid_exit_code(result.get("exit_code"))
+    state_code = _valid_exit_code(state.get("exit_code"))
+
+    if execute_exit_code is not None:
+        diagnostics: list[str] = []
+        if result_code is None:
+            diagnostics.append(
+                f"Workflow exit code {execute_exit_code} was captured, but the aggregate "
+                "result is missing or has no valid exit code"
+            )
+        mismatches: list[str] = []
+        if result_code is not None and result_code != execute_exit_code:
+            mismatches.append(f"aggregate result exit code {result_code}")
+        if state_code is not None and state_code != execute_exit_code:
+            mismatches.append(f"run state exit code {state_code}")
+        if mismatches:
+            diagnostics.append(
+                f"Workflow exit code {execute_exit_code} disagrees with "
+                + " and ".join(mismatches)
+            )
+        return (2, diagnostics) if diagnostics else (execute_exit_code, [])
+
+    if result_code is not None and state_code is not None and result_code != state_code:
+        return 2, [
+            f"Aggregate result exit code {result_code} disagrees with run state exit code "
+            f"{state_code}"
+        ]
+    if result_code is not None:
+        return result_code, []
+
+    infrastructure = result.get("infrastructure_errors")
+    not_run = result.get("not_run_case_ids")
+    if (isinstance(infrastructure, list) and infrastructure) or (
+        isinstance(not_run, list) and not_run
+    ):
+        return 2, []
+    if (_integer(result.get("failed")) or 0) or (_integer(result.get("error")) or 0):
+        return 1, []
+    if state_code is not None:
+        if not result:
+            return 2, [
+                f"Run state exit code {state_code} exists, but the aggregate result is missing"
+            ]
+        return state_code, []
+    return None, []
+
+
+def _suite_digest(result: dict[str, object], plan: dict[str, object]) -> str:
+    candidates = [result.get("suite_digest")]
+    suite = plan.get("suite")
+    if isinstance(suite, dict):
+        candidates.append(suite.get("digest"))
+    sharding = plan.get("sharding")
+    if isinstance(sharding, dict):
+        candidates.append(sharding.get("suite_digest"))
+    for candidate in candidates:
+        if isinstance(candidate, str) and candidate:
+            return candidate
+    return "unavailable"
+
+
+def _unique_messages(messages: list[str]) -> list[str]:
+    result: list[str] = []
+    seen: set[str] = set()
+    for message in messages:
+        key = " ".join(message.split()).casefold()
+        if key not in seen:
+            seen.add(key)
+            result.append(message)
+    return result
+
+
+def _infrastructure_priority(message: str) -> int:
+    normalized = message.casefold()
+    causal_markers = (
+        "fatal",
+        "kubernetes job",
+        "pod ",
+        "exit code",
+        "mismatch",
+        "timed out",
+        "timeout",
+        "failed",
+    )
+    if EXECUTION_STAGE_MESSAGE.match(message) or any(
+        marker in normalized for marker in causal_markers
+    ):
+        return 0
+    if "checkpoint" in normalized or normalized.startswith("missing shard result:"):
+        return 1
+    return 2
+
+
+def _case_id_sort_key(case_id: str) -> tuple[int, tuple[int, ...], str]:
+    parts = case_id.split(".")
+    if parts and all(part.isdigit() for part in parts):
+        return 0, tuple(int(part) for part in parts), case_id
+    return 1, (), case_id
+
+
+def _shard_evidence_diagnostics(
+    plan: dict[str, object],
+    shard_rows: list[dict[str, object]],
+    aggregate_exit_code: int,
+) -> list[str]:
+    planned = _planned_shards(plan)
+    if not planned:
+        return ["Shard plan is missing; aggregate outcome cannot be verified"]
+
+    diagnostics: list[str] = []
+    for row in shard_rows:
+        shard_index = row["shard"]
+        if shard_index not in planned:
+            diagnostics.append(f"shard {shard_index} is not present in the plan")
+        if not row["terminal"]:
+            diagnostics.append(
+                f"shard {shard_index} is {str(row['result']).lower()}"
+            )
+            continue
+        shard_result = row["result"]
+        if shard_result in {"INFRASTRUCTURE ERROR", "INCOMPLETE"}:
+            conflict = (
+                "an infrastructure error"
+                if shard_result == "INFRASTRUCTURE ERROR"
+                else "incomplete coverage"
+            )
+            diagnostics.append(
+                f"shard {shard_index} reports {conflict} that conflicts "
+                f"with aggregate exit code {aggregate_exit_code}"
+            )
+        elif aggregate_exit_code == 0 and shard_result != "PASSED":
+            diagnostics.append(
+                f"shard {shard_index} reports {str(shard_result).lower()} that conflicts "
+                "with aggregate exit code 0"
+            )
+    if aggregate_exit_code == 1 and not any(
+        row["result"] == "TEST FAILURE" for row in shard_rows
+    ):
+        diagnostics.append(
+            "Aggregate exit code 1 has no matching test failure in terminal shard evidence"
+        )
+    return diagnostics
+
+
+def _write_summary(
+    destination: Path,
+    run_id: str,
+    run_root: Path,
+    *,
+    build_cache_hit: str | None = None,
+    build_duration_seconds: float | None = None,
+    execute_exit_code: int | None = None,
+) -> int | None:
+    result = _read_run_json(run_root, Path("result.json"))
+    state = _read_run_json(run_root, Path("state.json"))
+    plan = _read_run_json(run_root, Path("plan/manifest.json"))
+    allocation = _read_run_json(run_root, Path("plan/allocation.json"))
     sources = result.get("sources") or plan.get("sources") or {}
     if not isinstance(sources, dict):
         sources = {}
-    rows = (
+    shard_rows, case_locations, shard_fatals = _shard_context(run_root, plan, allocation)
+    exit_code, exit_diagnostics = _resolve_exit_code(
+        result, state, execute_exit_code
+    )
+    if exit_code in {0, 1}:
+        shard_diagnostics = _shard_evidence_diagnostics(
+            plan, shard_rows, exit_code
+        )
+        if shard_diagnostics:
+            exit_code = 2
+            exit_diagnostics.extend(shard_diagnostics)
+    outcome = {0: "PASSED", 1: "TEST FAILURE", 2: "INFRASTRUCTURE ERROR"}.get(
+        exit_code, "INCOMPLETE"
+    )
+    aggregate_cases = result.get("cases")
+    has_aggregate_cases = isinstance(aggregate_cases, list)
+    cases = aggregate_cases
+    if not has_aggregate_cases:
+        cases = []
+    not_run_case_ids = result.get("not_run_case_ids")
+    infrastructure = result.get("infrastructure_errors")
+    aggregate_infrastructure: list[str] = []
+    folded_case_diagnostics = 0
+    if isinstance(infrastructure, list):
+        for message in infrastructure:
+            if not isinstance(message, str):
+                continue
+            if CASE_LEVEL_DIAGNOSTIC.fullmatch(message):
+                folded_case_diagnostics += 1
+                continue
+            aggregate_infrastructure.append(message)
+    aggregate_infrastructure.sort(key=_infrastructure_priority)
+    infrastructure_messages = exit_diagnostics + shard_fatals + aggregate_infrastructure
+    for label, key in (
+        ("Missing cases", "missing_case_ids"),
+        ("Duplicate cases", "duplicate_case_ids"),
+        ("Extra cases", "extra_case_ids"),
+    ):
+        identifiers = result.get(key)
+        if isinstance(identifiers, list) and identifiers:
+            visible = [str(identifier) for identifier in identifiers[:10]]
+            suffix = f" (+{len(identifiers) - 10} more)" if len(identifiers) > 10 else ""
+            infrastructure_messages.append(
+                f"{label}: {len(identifiers)} ({', '.join(visible)}{suffix})"
+            )
+    infrastructure_messages = _unique_messages(infrastructure_messages)
+    if exit_code == 2 and not infrastructure_messages:
+        infrastructure_messages.append(
+            "Infrastructure failure reported without aggregate error details"
+        )
+
+    aggregate_counts = _case_counts(cases)
+    total = _integer(result.get("total"))
+    passed = _integer(result.get("passed"))
+    failed = _integer(result.get("failed"))
+    error = _integer(result.get("error"))
+    total = total if total is not None else "unavailable"
+    passed = passed if passed is not None else "unavailable"
+    failed = failed if failed is not None else "unavailable"
+    error = error if error is not None else "unavailable"
+    if isinstance(not_run_case_ids, list):
+        not_run_count: object = len(not_run_case_ids)
+    elif has_aggregate_cases:
+        not_run_count = aggregate_counts["not_run"]
+    elif shard_rows:
+        checkpoint_not_run = sum(
+            int(row["counts"]["not_run"]) for row in shard_rows
+        )
+        not_run_count = f"{checkpoint_not_run} (partial)"
+    else:
+        not_run_count = "unavailable"
+    phase_durations = result.get("phase_durations_seconds")
+    if not isinstance(phase_durations, dict):
+        phase_durations = {}
+    terminal_shards = sum(bool(row["terminal"]) for row in shard_rows)
+
+    lines = [
+        f"## CraneTestKit K3s system test: {outcome}",
+        "",
+        "### Result",
+        "",
+    ]
+    _append_table(
+        lines,
+        ("Total", "Passed", "Failed", "Error", "Not run", "Infrastructure", "Shards"),
+        [
+            (
+                total,
+                passed,
+                failed,
+                error,
+                not_run_count,
+                len(infrastructure_messages),
+                f"{terminal_shards}/{len(shard_rows)}",
+            )
+        ],
+    )
+    lines.append("")
+
+    if infrastructure_messages:
+        lines.extend(["### Infrastructure errors", ""])
+        lines.extend(
+            f"- `{_escape_markdown(message)}`"
+            for message in infrastructure_messages[:MAX_INFRASTRUCTURE_ROWS]
+        )
+        if len(infrastructure_messages) > MAX_INFRASTRUCTURE_ROWS:
+            lines.append(
+                f"- Showing {MAX_INFRASTRUCTURE_ROWS} of {len(infrastructure_messages)} errors."
+            )
+        lines.append("")
+    if folded_case_diagnostics:
+        lines.extend(
+            [
+                f"_Folded {folded_case_diagnostics} case-level not-run or missing-result "
+                "diagnostics into the aggregate case counts._",
+                "",
+            ]
+        )
+
+    interesting_cases: list[dict[str, object]] = []
+    for case in cases:
+        if not isinstance(case, dict) or case.get("status") not in {
+            "failed",
+            "error",
+            "not_run",
+        }:
+            continue
+        case_id_value = case.get("id")
+        case_id = case_id_value if isinstance(case_id_value, str) else "unavailable"
+        location = case_locations.get(case_id)
+        shard = location[0] if location else "unavailable"
+        worker = location[1] if location else "unavailable"
+        slot = location[2] if location else "unavailable"
+        interesting_cases.append(
+            {
+                "id": case_id,
+                "name": (
+                    case.get("name") if isinstance(case.get("name"), str) else "unavailable"
+                ),
+                "status": case.get("status", "unavailable"),
+                "shard": shard,
+                "worker": worker,
+                "duration": _format_case_duration(case.get("duration_seconds")),
+                "message": (
+                    case.get("message") if isinstance(case.get("message"), str) else "-"
+                ),
+                "logs": f"logs/{worker}/{slot}/" if location else "unavailable",
+            }
+        )
+    interesting_cases.sort(
+        key=lambda case: (
+            {"error": 0, "failed": 1, "not_run": 2}.get(str(case["status"]), 3),
+            _case_id_sort_key(str(case["id"])),
+        )
+    )
+    if interesting_cases:
+        lines.extend(["### Failed, errored, or not-run cases", ""])
+        _append_table(
+            lines,
+            ("Case", "Name", "Status", "Shard", "Worker", "Duration", "Message", "Logs"),
+            [
+                (
+                    case["id"],
+                    case["name"],
+                    case["status"],
+                    case["shard"],
+                    case["worker"],
+                    case["duration"],
+                    case["message"],
+                    case["logs"],
+                )
+                for case in interesting_cases[:MAX_FAILURE_ROWS]
+            ],
+        )
+        if len(interesting_cases) > MAX_FAILURE_ROWS:
+            lines.extend(
+                [
+                    "",
+                    f"Showing {MAX_FAILURE_ROWS} of {len(interesting_cases)} affected cases.",
+                ]
+            )
+        lines.append("")
+
+    if shard_rows:
+        lines.extend(["### Shards", ""])
+        _append_table(
+            lines,
+            (
+                "Shard",
+                "Worker",
+                "Cases (pass/fail/error/not run)",
+                "Wall",
+                "Case time",
+                "Estimate",
+                "Result",
+            ),
+            [
+                (
+                    row["shard"],
+                    f"{row['worker']} / {row['slot']}",
+                    (
+                        f"{row['cases']} ({row['counts']['passed']}/{row['counts']['failed']}/"
+                        f"{row['counts']['error']}/{row['counts']['not_run']})"
+                    ),
+                    _format_duration(row["wall"]),
+                    _format_duration(row["case_time"]),
+                    _format_duration(row["estimate"]),
+                    row["result"],
+                )
+                for row in shard_rows
+            ],
+        )
+        lines.append("")
+
+    timing_rows: list[tuple[object, ...]] = []
+    if _number(build_duration_seconds) is not None:
+        timing_rows.append(("Build", _format_duration(build_duration_seconds)))
+    for key, label in (
+        ("plan", "Plan"),
+        ("lease_acquire", "Lease acquire"),
+        ("run", "Submit Jobs"),
+        ("wait", "Run and wait"),
+        ("collect", "Collect"),
+        ("stop", "Stop"),
+        ("lease_release", "Lease release"),
+        ("total", "System execute total"),
+    ):
+        if _number(phase_durations.get(key)) is not None:
+            timing_rows.append((label, _format_duration(phase_durations[key])))
+    if timing_rows:
+        lines.extend(["### Timing", ""])
+        _append_table(lines, ("Phase", "Duration"), timing_rows)
+        if build_cache_hit in {"true", "false"}:
+            lines.extend(
+                [
+                    "",
+                    f"Build cache: **{'hit' if build_cache_hit == 'true' else 'miss'}**",
+                ]
+            )
+        lines.append("")
+
+    completed_cases = [
+        case
+        for case in cases
+        if isinstance(case, dict)
+        and case.get("status") != "not_run"
+        and _number(case.get("duration_seconds")) is not None
+    ]
+    completed_cases.sort(
+        key=lambda case: (-float(case["duration_seconds"]), str(case.get("id", "")))
+    )
+    if completed_cases:
+        lines.extend(["### Slowest cases", ""])
+        slow_rows: list[tuple[object, ...]] = []
+        for case in completed_cases[:MAX_SLOW_CASE_ROWS]:
+            case_id_value = case.get("id")
+            case_id = case_id_value if isinstance(case_id_value, str) else "unavailable"
+            location = case_locations.get(case_id)
+            placement = (
+                f"{location[1]} / shard {location[0]}" if location else "unavailable"
+            )
+            slow_rows.append(
+                (
+                    case_id,
+                    (
+                        case.get("name")
+                        if isinstance(case.get("name"), str)
+                        else "unavailable"
+                    ),
+                    case.get("status", "unavailable"),
+                    _format_case_duration(case.get("duration_seconds")),
+                    placement,
+                )
+            )
+        _append_table(lines, ("Case", "Name", "Status", "Duration", "Placement"), slow_rows)
+        lines.append("")
+
+    provenance_rows = [
         ("Run ID", run_id),
         ("Phase", state.get("phase", "not-created")),
-        ("Exit code", result.get("exit_code", state.get("exit_code", "unavailable"))),
-        ("Total", result.get("total", "unavailable")),
-        ("Passed", result.get("passed", "unavailable")),
-        ("Failed", result.get("failed", "unavailable")),
-        ("Error", result.get("error", "unavailable")),
+        ("Exit code", exit_code if exit_code is not None else "unavailable"),
         ("Backend SHA", sources.get("backend", "unavailable")),
         ("Frontend SHA", sources.get("frontend", "unavailable")),
         ("AutoTest SHA", sources.get("autotest", "unavailable")),
         ("Build ID", result.get("build_id", plan.get("build_id", "unavailable"))),
+        ("Suite digest", _suite_digest(result, plan)),
+        ("Plan digest", result.get("plan_digest", plan.get("plan_digest", "unavailable"))),
+        ("Image", result.get("image_digest", plan.get("image_digest", "unavailable"))),
         ("Started", result.get("started_at", "unavailable")),
         ("Finished", result.get("finished_at", "unavailable")),
-        ("Phase durations", result.get("phase_durations_seconds", "unavailable")),
-        (
-            "Plan digest",
-            result.get("plan_digest", plan.get("plan_digest", "unavailable")),
-        ),
-        ("Image", result.get("image_digest", plan.get("image_digest", "unavailable"))),
-    )
-    lines = [
-        "## CraneTestKit K3s system test",
-        "",
-        "| Field | Value |",
-        "| --- | --- |",
     ]
-    lines.extend(
-        f"| {_escape_markdown(key)} | `{_escape_markdown(value)}` |"
-        for key, value in rows
-    )
-    destination.write_text("\n".join(lines) + "\n", encoding="utf-8")
+    lines.extend(["<details>", "<summary>Provenance</summary>", ""])
+    _append_table(lines, ("Field", "Value"), provenance_rows)
+    lines.extend(["", "</details>", ""])
+
+    text = "\n".join(lines) + "\n"
+    encoded = text.encode("utf-8")
+    if len(encoded) > MAX_SUMMARY_BYTES:
+        suffix = "\n\n_Report truncated; download the JSON artifact for complete details._\n"
+        limit = MAX_SUMMARY_BYTES - len(suffix.encode("utf-8"))
+        text = encoded[:limit].decode("utf-8", errors="ignore") + suffix
+    destination.write_text(text, encoding="utf-8")
+    return exit_code
 
 
 def main() -> int:
@@ -188,15 +906,31 @@ def main() -> int:
     parser.add_argument("--destination", type=Path, required=True)
     parser.add_argument("--run-id", required=True)
     parser.add_argument("--include-logs", action="store_true")
+    parser.add_argument("--build-cache-hit", choices=("true", "false"))
+    parser.add_argument("--build-duration-seconds", type=float)
+    parser.add_argument("--execute-exit-code", type=int, choices=(0, 1, 2))
     args = parser.parse_args()
 
-    destination = args.destination.resolve()
+    destination = args.destination.absolute()
+    if destination.is_symlink():
+        parser.error("destination must not be a symlink")
+    if destination.exists() and not destination.is_dir():
+        parser.error("destination must be a directory")
     if destination.exists():
         shutil.rmtree(destination)
     destination.mkdir(parents=True)
     entries: list[dict[str, object]] = []
 
     run_root = args.run_root
+    summary_exit_code = _write_summary(
+        destination / "summary.md",
+        args.run_id,
+        run_root,
+        build_cache_hit=args.build_cache_hit,
+        build_duration_seconds=args.build_duration_seconds,
+        execute_exit_code=args.execute_exit_code,
+    )
+    include_failure_logs = args.include_logs or summary_exit_code != 0
     if run_root.exists() and not run_root.is_symlink() and run_root.is_dir():
         allowlisted = [
             Path("plan/manifest.json"),
@@ -230,7 +964,7 @@ def main() -> int:
             entry["path"] = str(relative)
             entries.append(entry)
 
-        if args.include_logs:
+        if include_failure_logs:
             total = 0
             log_files = 0
             logs_root = run_root / "logs"
@@ -258,13 +992,15 @@ def main() -> int:
                     total += min(safe.stat().st_size, MAX_LOG_BYTES)
                     log_files += 1
 
-    _write_summary(destination / "summary.md", args.run_id, run_root)
     manifest = {
         "apiVersion": "cranesched.io/v1alpha1",
         "kind": "CraneTestKitCiArtifactSet",
         "run_id": args.run_id,
         "run_present": run_root.is_dir() and not run_root.is_symlink(),
-        "failure_logs_included": args.include_logs,
+        "failure_logs_included": include_failure_logs,
+        "check_exit_code": (
+            summary_exit_code if summary_exit_code in {0, 1, 2} else 2
+        ),
         "files": entries,
     }
     (destination / "artifact-manifest.json").write_text(

--- a/.github/ci/test_collect_cranetestkit_artifacts.py
+++ b/.github/ci/test_collect_cranetestkit_artifacts.py
@@ -1,19 +1,34 @@
 from __future__ import annotations
 
+import importlib.util
 import json
+import math
 import subprocess
 import sys
 import tempfile
 import unittest
 from pathlib import Path
+from unittest import mock
 
 
 SCRIPT = Path(__file__).with_name("collect-cranetestkit-artifacts.py")
+SPEC = importlib.util.spec_from_file_location("cranesched_ci_artifact_collection", SCRIPT)
+assert SPEC is not None and SPEC.loader is not None
+collection = importlib.util.module_from_spec(SPEC)
+sys.modules[SPEC.name] = collection
+SPEC.loader.exec_module(collection)
 
 
 class ArtifactCollectionTest(unittest.TestCase):
     def _collect(
-        self, run_root: Path, destination: Path, *, logs: bool = False
+        self,
+        run_root: Path,
+        destination: Path,
+        *,
+        logs: bool = False,
+        cache_hit: str | None = None,
+        build_duration: float | None = None,
+        execute_exit_code: int | None = None,
     ) -> None:
         command = [
             sys.executable,
@@ -27,7 +42,137 @@ class ArtifactCollectionTest(unittest.TestCase):
         ]
         if logs:
             command.append("--include-logs")
+        if cache_hit is not None:
+            command.extend(("--build-cache-hit", cache_hit))
+        if build_duration is not None:
+            command.extend(("--build-duration-seconds", str(build_duration)))
+        if execute_exit_code is not None:
+            command.extend(("--execute-exit-code", str(execute_exit_code)))
         subprocess.run(command, check=True)
+
+    @staticmethod
+    def _write_json(path: Path, value: object) -> None:
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(json.dumps(value), encoding="utf-8")
+
+    @staticmethod
+    def _case(
+        case_id: str,
+        status: str,
+        duration: float,
+        *,
+        name: str | None = None,
+        message: str | None = None,
+    ) -> dict[str, object]:
+        return {
+            "id": case_id,
+            "name": name or f"case-{case_id}",
+            "path": f"Module/TC{case_id}.json",
+            "status": status,
+            "duration_seconds": duration,
+            "message": message,
+        }
+
+    def _checkpoint(
+        self,
+        run_root: Path,
+        worker: str,
+        slot: int,
+        shard: int,
+        cases: list[dict[str, object]],
+        *,
+        exit_code: int | None,
+        fatal: dict[str, str] | None = None,
+        duration: int = 30,
+    ) -> None:
+        self._write_json(
+            run_root / f"results/{worker}/{slot}/shard-{shard}.json",
+            {
+                "shard_index": shard,
+                "started_at": "2026-07-16T00:00:00Z",
+                "finished_at": f"2026-07-16T00:00:{duration:02d}Z",
+                "fatal": fatal,
+                "worker_exit_code": exit_code,
+                "cases": cases,
+            },
+        )
+
+    def _run(
+        self,
+        root: Path,
+        cases: list[dict[str, object]],
+        *,
+        exit_code: int,
+        shards: list[list[dict[str, object]]],
+        workers: dict[str, list[int]],
+        infrastructure_errors: list[str] | None = None,
+        missing_case_ids: list[str] | None = None,
+    ) -> Path:
+        run_root = root / "runs/gh-123-1"
+        planned_shards = [
+            {
+                "index": index,
+                "estimated_duration_seconds": 20 + index,
+                "cases": [{"case": case} for case in shard_cases],
+            }
+            for index, shard_cases in enumerate(shards)
+        ]
+        self._write_json(
+            run_root / "plan/manifest.json",
+            {
+                "sources": {
+                    "backend": "a" * 40,
+                    "frontend": "b" * 40,
+                    "autotest": "c" * 40,
+                },
+                "build_id": "build-1",
+                "plan_digest": "d" * 64,
+                "image_digest": "localhost/autotest@sha256:" + "e" * 64,
+                "sharding": {"shards": planned_shards},
+            },
+        )
+        self._write_json(
+            run_root / "plan/allocation.json",
+            {"run_id": "gh-123-1", "slots": len(shards), "workers": workers},
+        )
+        counts = {
+            status: sum(case["status"] == status for case in cases)
+            for status in ("passed", "failed", "error", "not_run")
+        }
+        self._write_json(
+            run_root / "result.json",
+            {
+                "exit_code": exit_code,
+                "total": len(cases),
+                "passed": counts["passed"],
+                "failed": counts["failed"],
+                "error": counts["error"],
+                "not_run_case_ids": [
+                    case["id"] for case in cases if case["status"] == "not_run"
+                ],
+                "infrastructure_errors": infrastructure_errors or [],
+                "missing_case_ids": missing_case_ids or [],
+                "duplicate_case_ids": [],
+                "extra_case_ids": [],
+                "cases": cases,
+                "sources": {
+                    "backend": "a" * 40,
+                    "frontend": "b" * 40,
+                    "autotest": "c" * 40,
+                },
+                "build_id": "build-1",
+                "suite_digest": "f" * 64,
+                "plan_digest": "d" * 64,
+                "image_digest": "localhost/autotest@sha256:" + "e" * 64,
+                "started_at": "2026-07-16T00:00:00Z",
+                "finished_at": "2026-07-16T00:01:05.200000Z",
+                "phase_durations_seconds": {"wait": 59.999, "total": 65.2},
+            },
+        )
+        self._write_json(
+            run_root / "state.json", {"phase": "stopped", "exit_code": exit_code}
+        )
+        return run_root
 
     def test_allowlists_and_redacts_failure_logs(self) -> None:
         with tempfile.TemporaryDirectory() as temporary:
@@ -50,8 +195,17 @@ class ArtifactCollectionTest(unittest.TestCase):
                 ),
                 encoding="utf-8",
             )
+            private_key = (
+                "private_key=-----BEGIN PRIVATE KEY-----\n"
+                + "A" * 5000
+            )
             (run_root / "state.json").write_text(
-                json.dumps({"phase": "password=hunter2", "exit_code": 1}),
+                json.dumps(
+                    {
+                        "phase": f"password=hunter2 {private_key}",
+                        "exit_code": 1,
+                    }
+                ),
                 encoding="utf-8",
             )
             (run_root / "result.json").write_text(
@@ -112,8 +266,572 @@ class ArtifactCollectionTest(unittest.TestCase):
             summary = (destination / "summary.md").read_text(encoding="utf-8")
             self.assertNotIn("hunter2", summary)
             self.assertNotIn("github_pat_", summary)
+            self.assertNotIn("BEGIN PRIVATE KEY", summary)
+            self.assertNotIn("A" * 100, summary)
             self.assertNotIn("<b>", summary)
             self.assertIn("build&#96;\\|&lt;b&gt;[REDACTED]", summary)
+
+    def test_pass_summary_shows_shards_timing_and_top_ten_slowest(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary:
+            root = Path(temporary)
+            cases = [
+                self._case(f"1.0.0.{index}", "passed", float(index), name=f"slow-{index}")
+                for index in range(1, 12)
+            ]
+            run_root = self._run(
+                root,
+                cases,
+                exit_code=0,
+                shards=[cases[:6], cases[6:]],
+                workers={"wrl02": [0, 1]},
+            )
+            self._checkpoint(run_root, "wrl02", 0, 0, cases[:6], exit_code=0, duration=30)
+            self._checkpoint(run_root, "wrl02", 1, 1, cases[6:], exit_code=0, duration=40)
+
+            destination = root / "artifact"
+            self._collect(
+                run_root,
+                destination,
+                cache_hit="true",
+                build_duration=59.999,
+            )
+            summary = (destination / "summary.md").read_text(encoding="utf-8")
+
+            self.assertIn("system test: PASSED", summary)
+            self.assertIn("`11`", summary)
+            self.assertIn("`2/2`", summary)
+            self.assertIn("`wrl02 / 0`", summary)
+            self.assertIn("`6 (6/0/0/0)`", summary)
+            self.assertIn("`1m 00.00s`", summary)
+            self.assertIn("Build cache: **hit**", summary)
+            self.assertLess(summary.index("slow-11"), summary.index("slow-10"))
+            self.assertNotIn("slow-1`", summary)
+            manifest = json.loads(
+                (destination / "artifact-manifest.json").read_text(encoding="utf-8")
+            )
+            self.assertEqual(manifest["check_exit_code"], 0)
+            self.assertFalse(manifest["failure_logs_included"])
+
+    def test_exit_one_summary_reports_failed_and_error_cases(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary:
+            root = Path(temporary)
+            cases = [
+                self._case("1.0.0.1", "passed", 1.0),
+                self._case(
+                    "1.0.0.2",
+                    "failed",
+                    2.25,
+                    name="failed|<case>",
+                    message="expected | value\npassword=hunter2",
+                ),
+                self._case(
+                    "1.0.0.3",
+                    "error",
+                    3.5,
+                    message="github_pat_abcdefghijklmnopqrstuvwxyz",
+                ),
+            ]
+            run_root = self._run(
+                root,
+                cases,
+                exit_code=1,
+                shards=[cases],
+                workers={"wrl03": [0]},
+            )
+            self._checkpoint(run_root, "wrl03", 0, 0, cases, exit_code=1)
+
+            destination = root / "artifact"
+            self._collect(run_root, destination)
+            summary = (destination / "summary.md").read_text(encoding="utf-8")
+
+            self.assertIn("system test: TEST FAILURE", summary)
+            self.assertIn("`1.0.0.2`", summary)
+            self.assertIn("`failed\\|&lt;case&gt;`", summary)
+            self.assertIn("`wrl03`", summary)
+            self.assertIn("`2.25s`", summary)
+            self.assertIn("[REDACTED]", summary)
+            self.assertNotIn("hunter2", summary)
+            self.assertNotIn("github_pat_", summary)
+
+    def test_exit_two_summary_prioritizes_infrastructure_and_fatal(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary:
+            root = Path(temporary)
+            cases = [
+                self._case("1.0.0.1", "failed", 2.0, message="assertion failed"),
+                self._case("1.0.0.2", "not_run", 0.0),
+            ]
+            run_root = self._run(
+                root,
+                cases,
+                exit_code=2,
+                shards=[cases],
+                workers={"wrl04": [0]},
+                infrastructure_errors=[
+                    "<script>Authorization: Bearer secret-token</script>",
+                    (
+                        "shard 0 fatal during teardown: "
+                        "password=hunter2"
+                    ),
+                ],
+                missing_case_ids=["1.0.0.2"],
+            )
+            self._checkpoint(
+                run_root,
+                "wrl04",
+                0,
+                0,
+                cases,
+                exit_code=2,
+                fatal={"phase": "teardown", "message": "password=hunter2"},
+            )
+
+            destination = root / "artifact"
+            self._collect(run_root, destination)
+            summary = (destination / "summary.md").read_text(encoding="utf-8")
+
+            self.assertIn("system test: INFRASTRUCTURE ERROR", summary)
+            self.assertIn("### Infrastructure errors", summary)
+            self.assertIn("&lt;script&gt;", summary)
+            self.assertIn("teardown", summary)
+            self.assertIn("Missing cases", summary)
+            self.assertIn("`1`", summary)
+            self.assertIn("`INFRASTRUCTURE ERROR`", summary)
+            self.assertEqual(summary.count("fatal during teardown"), 1)
+            self.assertNotIn("secret-token", summary)
+            self.assertNotIn("hunter2", summary)
+
+    def test_workflow_exit_mismatch_is_an_infrastructure_error(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary:
+            root = Path(temporary)
+            cases = [self._case("1.0.0.1", "passed", 1.0)]
+            run_root = self._run(
+                root,
+                cases,
+                exit_code=0,
+                shards=[cases],
+                workers={"wrl02": [0]},
+            )
+            self._checkpoint(run_root, "wrl02", 0, 0, cases, exit_code=0)
+
+            destination = root / "artifact"
+            self._collect(run_root, destination, execute_exit_code=2)
+            summary = (destination / "summary.md").read_text(encoding="utf-8")
+
+            self.assertIn("system test: INFRASTRUCTURE ERROR", summary)
+            self.assertIn("Workflow exit code 2 disagrees with", summary)
+            self.assertIn("aggregate result exit code 0", summary)
+            self.assertIn("run state exit code 0", summary)
+            manifest = json.loads(
+                (destination / "artifact-manifest.json").read_text(encoding="utf-8")
+            )
+            self.assertEqual(manifest["check_exit_code"], 2)
+
+    def test_workflow_success_without_aggregate_is_infrastructure_error(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary:
+            root = Path(temporary)
+            run_root = root / "runs/gh-123-1"
+            run_root.mkdir(parents=True)
+            destination = root / "artifact"
+
+            self._collect(run_root, destination, execute_exit_code=0)
+            summary = (destination / "summary.md").read_text(encoding="utf-8")
+
+            self.assertIn("system test: INFRASTRUCTURE ERROR", summary)
+            self.assertIn("aggregate result is missing", summary)
+
+    def test_infrastructure_summary_folds_not_run_and_prioritizes_root_cause(
+        self,
+    ) -> None:
+        with tempfile.TemporaryDirectory() as temporary:
+            root = Path(temporary)
+            cases = [
+                self._case(f"3.0.0.{index}", "not_run", 0.0)
+                for index in range(1, 26)
+            ]
+            infrastructure = [
+                (
+                    f"case was not run: 3.0.0.{index}"
+                    if index % 2
+                    else f"missing case result: 3.0.0.{index}"
+                )
+                for index in range(1, 26)
+            ]
+            infrastructure.extend(
+                f"shard {index} checkpoint is unfinished" for index in range(25)
+            )
+            infrastructure.append(
+                "lease: LeaseBusyError: cluster capacity is held by another run"
+            )
+            run_root = self._run(
+                root,
+                cases,
+                exit_code=2,
+                shards=[cases],
+                workers={"wrl02": [0]},
+                infrastructure_errors=infrastructure,
+            )
+            self._checkpoint(run_root, "wrl02", 0, 0, cases, exit_code=2)
+
+            destination = root / "artifact"
+            self._collect(run_root, destination, execute_exit_code=2)
+            summary = (destination / "summary.md").read_text(encoding="utf-8")
+
+            self.assertIn("lease: LeaseBusyError", summary)
+            self.assertNotIn("case was not run:", summary)
+            self.assertNotIn("missing case result:", summary)
+            self.assertIn("Folded 25 case-level not-run or missing-result", summary)
+            self.assertIn("Showing 20 of 26 errors", summary)
+
+    def test_incomplete_summary_uses_partial_checkpoint_not_run_count(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary:
+            root = Path(temporary)
+            run_root = root / "runs/gh-123-1"
+            cases = [
+                self._case("1.0.0.1", "passed", 1.0),
+                self._case("1.0.0.2", "not_run", 0.0),
+            ]
+            self._write_json(
+                run_root / "plan/manifest.json",
+                {
+                    "sharding": {
+                        "shards": [
+                            {"index": 0, "cases": []},
+                            {"index": 1, "cases": []},
+                        ]
+                    }
+                },
+            )
+            self._write_json(
+                run_root / "plan/allocation.json",
+                {"workers": {"wrl02": [0, 1]}},
+            )
+            self._write_json(run_root / "state.json", {"phase": "stopped"})
+            self._checkpoint(run_root, "wrl02", 0, 0, cases, exit_code=None)
+
+            destination = root / "artifact"
+            self._collect(run_root, destination)
+            summary = (destination / "summary.md").read_text(encoding="utf-8")
+
+            self.assertIn("system test: INCOMPLETE", summary)
+            self.assertIn("`1 (partial)`", summary)
+            self.assertIn("`0/2`", summary)
+
+    def test_success_with_missing_shard_is_an_infrastructure_error(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary:
+            root = Path(temporary)
+            cases = [
+                self._case("1.0.0.1", "passed", 1.0),
+                self._case("2.0.0.1", "passed", 1.0),
+            ]
+            run_root = self._run(
+                root,
+                cases,
+                exit_code=0,
+                shards=[[cases[0]], [cases[1]]],
+                workers={"wrl02": [0, 1]},
+            )
+            self._checkpoint(run_root, "wrl02", 0, 0, [cases[0]], exit_code=0)
+            failure_log = run_root / "logs/wrl02/0/services/cranectld.log"
+            failure_log.parent.mkdir(parents=True)
+            failure_log.write_text("missing shard diagnostic\n", encoding="utf-8")
+
+            destination = root / "artifact"
+            self._collect(run_root, destination, execute_exit_code=0)
+            summary = (destination / "summary.md").read_text(encoding="utf-8")
+            manifest = json.loads(
+                (destination / "artifact-manifest.json").read_text(encoding="utf-8")
+            )
+
+            self.assertIn("system test: INFRASTRUCTURE ERROR", summary)
+            self.assertIn("shard 1 is missing", summary)
+            self.assertEqual(manifest["check_exit_code"], 2)
+            self.assertTrue(manifest["failure_logs_included"])
+            self.assertTrue(
+                (destination / "logs/wrl02/0/services/cranectld.log").is_file()
+            )
+
+    def test_success_conflicting_with_terminal_shard_is_infrastructure_error(
+        self,
+    ) -> None:
+        for shard_exit_code in (1, 2):
+            with self.subTest(shard_exit_code=shard_exit_code):
+                with tempfile.TemporaryDirectory() as temporary:
+                    root = Path(temporary)
+                    cases = [self._case("1.0.0.1", "passed", 1.0)]
+                    run_root = self._run(
+                        root,
+                        cases,
+                        exit_code=0,
+                        shards=[cases],
+                        workers={"wrl02": [0]},
+                    )
+                    self._checkpoint(
+                        run_root,
+                        "wrl02",
+                        0,
+                        0,
+                        cases,
+                        exit_code=shard_exit_code,
+                    )
+
+                    destination = root / "artifact"
+                    self._collect(run_root, destination, execute_exit_code=0)
+                    summary = (destination / "summary.md").read_text(
+                        encoding="utf-8"
+                    )
+                    manifest = json.loads(
+                        (destination / "artifact-manifest.json").read_text(
+                            encoding="utf-8"
+                        )
+                    )
+
+                    self.assertIn("system test: INFRASTRUCTURE ERROR", summary)
+                    self.assertIn("conflicts with aggregate exit code 0", summary)
+                    self.assertEqual(manifest["check_exit_code"], 2)
+
+    def test_test_failure_conflicting_with_shard_infrastructure_is_exit_two(
+        self,
+    ) -> None:
+        with tempfile.TemporaryDirectory() as temporary:
+            root = Path(temporary)
+            cases = [self._case("1.0.0.1", "failed", 1.0)]
+            run_root = self._run(
+                root,
+                cases,
+                exit_code=1,
+                shards=[cases],
+                workers={"wrl02": [0]},
+            )
+            self._checkpoint(run_root, "wrl02", 0, 0, cases, exit_code=2)
+
+            destination = root / "artifact"
+            self._collect(run_root, destination, execute_exit_code=1)
+            summary = (destination / "summary.md").read_text(encoding="utf-8")
+            manifest = json.loads(
+                (destination / "artifact-manifest.json").read_text(encoding="utf-8")
+            )
+
+            self.assertIn("system test: INFRASTRUCTURE ERROR", summary)
+            self.assertIn("conflicts with aggregate exit code 1", summary)
+            self.assertEqual(manifest["check_exit_code"], 2)
+
+    def test_test_failure_with_incomplete_shard_is_exit_two(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary:
+            root = Path(temporary)
+            failed_case = self._case("1.0.0.1", "failed", 1.0)
+            not_run_case = self._case("2.0.0.1", "not_run", 0.0)
+            cases = [failed_case, not_run_case]
+            run_root = self._run(
+                root,
+                cases,
+                exit_code=1,
+                shards=[[failed_case], [not_run_case]],
+                workers={"wrl02": [0, 1]},
+            )
+            self._checkpoint(
+                run_root, "wrl02", 0, 0, [failed_case], exit_code=1
+            )
+            self._checkpoint(
+                run_root, "wrl02", 1, 1, [not_run_case], exit_code=0
+            )
+
+            destination = root / "artifact"
+            self._collect(run_root, destination, execute_exit_code=1)
+            summary = (destination / "summary.md").read_text(encoding="utf-8")
+            manifest = json.loads(
+                (destination / "artifact-manifest.json").read_text(encoding="utf-8")
+            )
+
+            self.assertIn("system test: INFRASTRUCTURE ERROR", summary)
+            self.assertIn("incomplete coverage", summary)
+            self.assertEqual(manifest["check_exit_code"], 2)
+
+    def test_affected_cases_use_numeric_dotted_id_order(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary:
+            root = Path(temporary)
+            cases = [
+                self._case("10.0.0.1", "not_run", 0.0),
+                self._case("2.0.0.1", "not_run", 0.0),
+                self._case("1.0.0.1", "not_run", 0.0),
+            ]
+            run_root = self._run(
+                root,
+                cases,
+                exit_code=2,
+                shards=[cases],
+                workers={"wrl02": [0]},
+                infrastructure_errors=["infrastructure failure"],
+            )
+            self._checkpoint(run_root, "wrl02", 0, 0, cases, exit_code=2)
+
+            destination = root / "artifact"
+            self._collect(run_root, destination)
+            summary = (destination / "summary.md").read_text(encoding="utf-8")
+
+            self.assertLess(summary.index("`1.0.0.1`"), summary.index("`2.0.0.1`"))
+            self.assertLess(summary.index("`2.0.0.1`"), summary.index("`10.0.0.1`"))
+
+    def test_plan_suite_digest_fallback_without_aggregate(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary:
+            root = Path(temporary)
+            run_root = root / "runs/gh-123-1"
+            self._write_json(
+                run_root / "plan/manifest.json",
+                {
+                    "suite": {"digest": "suite-primary"},
+                    "sharding": {
+                        "suite_digest": "suite-secondary",
+                        "shards": [],
+                    },
+                },
+            )
+
+            destination = root / "artifact"
+            self._collect(run_root, destination)
+            summary = (destination / "summary.md").read_text(encoding="utf-8")
+            self.assertIn("system test: INCOMPLETE", summary)
+            self.assertIn("suite-primary", summary)
+            self.assertNotIn("suite-secondary", summary)
+
+            self._write_json(
+                run_root / "plan/manifest.json",
+                {"sharding": {"suite_digest": "suite-secondary", "shards": []}},
+            )
+            fallback_destination = root / "fallback-artifact"
+            self._collect(run_root, fallback_destination)
+            fallback_summary = (fallback_destination / "summary.md").read_text(
+                encoding="utf-8"
+            )
+            self.assertIn("suite-secondary", fallback_summary)
+
+    def test_shard_metadata_scan_is_bounded_before_sorting(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary:
+            run_root = Path(temporary)
+            results_root = run_root / "results"
+            results_root.mkdir()
+
+            def shard_paths(_path: Path, _pattern: str):
+                for index in range(collection.MAX_METADATA_FILES):
+                    yield results_root / f"shard-{index}.json"
+                raise AssertionError("metadata iterator was consumed past its limit")
+
+            with mock.patch.object(Path, "rglob", shard_paths):
+                self.assertEqual(collection._shard_results(run_root), [])
+
+    def test_shard_metadata_has_a_total_byte_limit(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary:
+            run_root = Path(temporary)
+            first = run_root / "results/wrl02/0/shard-0.json"
+            second = run_root / "results/wrl02/1/shard-1.json"
+            self._write_json(first, {"shard_index": 0, "cases": []})
+            self._write_json(second, {"shard_index": 1, "cases": []})
+
+            with mock.patch.object(
+                collection, "MAX_TOTAL_CHECKPOINT_BYTES", first.stat().st_size
+            ):
+                records = collection._shard_results(run_root)
+
+            self.assertEqual([record[1]["shard_index"] for record in records], [0])
+
+    def test_symlinked_run_inputs_do_not_leak_into_summary(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary:
+            root = Path(temporary)
+            run_root = root / "runs/gh-123-1"
+            (run_root / "results/wrl02/0").mkdir(parents=True)
+            outside_result = root / "outside-result.json"
+            outside_checkpoint = root / "outside-checkpoint.json"
+            secret = "password=outside-secret"
+            self._write_json(
+                outside_result,
+                {"exit_code": 0, "total": 1, "passed": 1, "secret": secret},
+            )
+            self._write_json(
+                outside_checkpoint,
+                {
+                    "shard_index": 0,
+                    "worker_exit_code": 0,
+                    "finished_at": "2026-07-16T00:00:01Z",
+                    "cases": [self._case("1.0.0.1", "passed", 1.0, message=secret)],
+                },
+            )
+            (run_root / "result.json").symlink_to(outside_result)
+            (run_root / "results/wrl02/0/shard-0.json").symlink_to(outside_checkpoint)
+            self._write_json(
+                run_root / "plan/manifest.json",
+                {
+                    "sharding": {
+                        "shards": [
+                            {
+                                "index": 0,
+                                "estimated_duration_seconds": 1,
+                                "cases": [],
+                            }
+                        ]
+                    }
+                },
+            )
+
+            destination = root / "artifact"
+            self._collect(run_root, destination)
+            summary = (destination / "summary.md").read_text(encoding="utf-8")
+
+            self.assertIn("system test: INCOMPLETE", summary)
+            self.assertIn("`MISSING`", summary)
+            self.assertNotIn("outside-secret", summary)
+            self.assertFalse((destination / "result.json").exists())
+            self.assertFalse((destination / "results/wrl02/0/shard-0.json").exists())
+
+            linked_run = root / "linked-run"
+            linked_run.symlink_to(run_root, target_is_directory=True)
+            linked_destination = root / "linked-artifact"
+            self._collect(linked_run, linked_destination)
+            linked_summary = (linked_destination / "summary.md").read_text(encoding="utf-8")
+            self.assertNotIn("outside-secret", linked_summary)
+            self.assertIn("system test: INCOMPLETE", linked_summary)
+
+    def test_destination_symlink_is_rejected_without_deleting_target(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary:
+            root = Path(temporary)
+            run_root = root / "run"
+            run_root.mkdir()
+            target = root / "sentinel"
+            target.mkdir()
+            sentinel = target / "keep.txt"
+            sentinel.write_text("keep", encoding="utf-8")
+            destination = root / "artifact"
+            destination.symlink_to(target, target_is_directory=True)
+            result = subprocess.run(
+                [
+                    sys.executable,
+                    str(SCRIPT),
+                    "--run-root",
+                    str(run_root),
+                    "--destination",
+                    str(destination),
+                    "--run-id",
+                    "gh-123-1",
+                ],
+                check=False,
+                capture_output=True,
+                text=True,
+            )
+            self.assertNotEqual(result.returncode, 0)
+            self.assertEqual(sentinel.read_text(encoding="utf-8"), "keep")
+
+    def test_duration_formatting(self) -> None:
+        cases = (
+            (0, "0.00s"),
+            (1.234, "1.23s"),
+            (59.999, "1m 00.00s"),
+            (65.2, "1m 05.20s"),
+            (3661.75, "1h 01m 01.75s"),
+        )
+        for value, expected in cases:
+            with self.subTest(value=value):
+                self.assertEqual(collection._format_duration(value), expected)
+        for value in (None, -1, True, math.nan, math.inf, 1e308, 10**309):
+            with self.subTest(invalid=value):
+                self.assertEqual(collection._format_duration(value), "unavailable")
 
     def test_missing_run_still_produces_diagnostic_artifact(self) -> None:
         with tempfile.TemporaryDirectory() as temporary:

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -295,6 +295,7 @@ jobs:
           set -euo pipefail
           build_output="$RUNNER_TEMP/crane-build-output"
           build_log="$RUNNER_TEMP/crane-build.jsonl"
+          build_started_seconds=$SECONDS
           mkdir -p "$build_output"
           exec {maintenance_lock_fd}<"$CRANETESTKIT_CACHE_ROOT/.maintenance.lock"
           /usr/bin/flock --shared "$maintenance_lock_fd"
@@ -321,10 +322,12 @@ jobs:
           )"
           [[ "$build_manifest" == "$CRANETESTKIT_NFS_ROOT/builds/"*"/manifest.json" ]]
           [[ -f "$build_manifest" && ! -L "$build_manifest" ]]
+          build_duration_seconds=$((SECONDS - build_started_seconds))
           {
             echo "build_manifest=$build_manifest"
             echo "build_id=$build_id"
             echo "cache_hit=$cache_hit"
+            echo "duration_seconds=$build_duration_seconds"
           } >> "$GITHUB_OUTPUT"
 
       - name: Execute sharded system tests
@@ -352,6 +355,8 @@ jobs:
         if: always() && steps.verify-controls.outcome == 'success'
         env:
           EXECUTE_EXIT_CODE: ${{ steps.execute.outputs.exit_code }}
+          BUILD_CACHE_HIT: ${{ steps.build.outputs.cache_hit }}
+          BUILD_DURATION_SECONDS: ${{ steps.build.outputs.duration_seconds }}
         run: |
           set -euo pipefail
           artifact_dir="$RUNNER_TEMP/crane-testkit-artifacts"
@@ -363,8 +368,24 @@ jobs:
           if [[ "$EXECUTE_EXIT_CODE" != "0" ]]; then
             arguments+=(--include-logs)
           fi
+          if [[ "$EXECUTE_EXIT_CODE" =~ ^[012]$ ]]; then
+            arguments+=(--execute-exit-code "$EXECUTE_EXIT_CODE")
+          fi
+          if [[ "$BUILD_CACHE_HIT" == "true" || "$BUILD_CACHE_HIT" == "false" ]]; then
+            arguments+=(--build-cache-hit "$BUILD_CACHE_HIT")
+          fi
+          if [[ "$BUILD_DURATION_SECONDS" =~ ^[0-9]+([.][0-9]+)?$ ]]; then
+            arguments+=(--build-duration-seconds "$BUILD_DURATION_SECONDS")
+          fi
           /usr/bin/python3 -I trusted-ci/.github/ci/collect-cranetestkit-artifacts.py "${arguments[@]}"
-          echo "artifact_dir=$artifact_dir" >> "$GITHUB_OUTPUT"
+          check_exit_code="$(
+            jq -er '.check_exit_code | select(. == 0 or . == 1 or . == 2)' \
+              "$artifact_dir/artifact-manifest.json"
+          )"
+          {
+            echo "artifact_dir=$artifact_dir"
+            echo "exit_code=$check_exit_code"
+          } >> "$GITHUB_OUTPUT"
 
       - name: Publish job summary
         if: always() && steps.collect-artifacts.outcome == 'success'
@@ -376,16 +397,18 @@ jobs:
         with:
           name: crane-testkit-${{ github.run_id }}-${{ github.run_attempt }}
           path: ${{ steps.collect-artifacts.outputs.artifact_dir }}
-          retention-days: 14
+          retention-days: 3
           if-no-files-found: error
           include-hidden-files: false
 
       - name: Enforce CraneTestKit exit contract
         if: always()
         env:
+          CHECK_EXIT_CODE: ${{ steps.collect-artifacts.outputs.exit_code }}
           EXECUTE_EXIT_CODE: ${{ steps.execute.outputs.exit_code }}
         run: |
-          case "$EXECUTE_EXIT_CODE" in
+          exit_code="${CHECK_EXIT_CODE:-$EXECUTE_EXIT_CODE}"
+          case "$exit_code" in
             0) exit 0 ;;
             1) echo "System tests completed with test failures." >&2; exit 1 ;;
             2) echo "System tests ended with an infrastructure error." >&2; exit 2 ;;


### PR DESCRIPTION
## Summary

- replace the JSON-only job summary with an outcome-first Markdown report
- show affected cases, actionable infrastructure errors, shard balance, timings, slow cases, and provenance
- cross-check workflow, aggregate, state, and shard exit evidence before enforcing the final `0/1/2` result
- automatically attach bounded, redacted failure logs when the resolved result is nonzero
- harden report inputs against symlink traversal, unbounded checkpoint reads, malformed durations, Markdown injection, and credential leakage

## Why

The K3s system test currently uploads useful JSON artifacts, but the GitHub check is difficult to scan without downloading and correlating those files manually. Infrastructure runs can also contain hundreds of case-level bookkeeping messages before the actual Pod, Job, lease, or execution-stage failure.

This change keeps the JSON artifacts as evidence while making the GitHub Summary immediately useful. Repetitive not-run and missing-result messages are folded into aggregate counts, and causal diagnostics are shown first.

## Validation

- `python3 -m unittest discover -s .github/ci -p 'test_*.py'`: 48 passed
- Python bytecode compilation passed
- workflow YAML parsing passed
- `git diff --check` passed
- replayed a real `458/458`, `8/8` successful run
- replayed fatal, incomplete, admission-policy, and large infrastructure-error runs
- independent final reviews found no blocking, P1, or P2 issues


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * CI reports now provide clearer, safer summaries with sanitized dynamic content and limited report size.
  * Artifact collection includes richer failure, infrastructure, shard, timing, and provenance details.
  * CI now validates exit-code evidence more consistently and identifies incomplete or conflicting results.
  * Build cache status and build duration are included in collected run evidence.
  * Sanitized CI artifact retention has been reduced to 3 days while durable run evidence remains available under existing policies.

* **Security**
  * Sensitive files and data remain excluded from uploaded artifacts, with stronger redaction and control-character handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->