### PR TITLE
ci: enforce repository runner routing

### DIFF
--- a/.github/actionlint.yaml
+++ b/.github/actionlint.yaml
@@ -2,7 +2,6 @@ self-hosted-runner:
   labels:
     - cranesystemtest
 config-variables:
-  - CRANESCHED_PRIVILEGED_RUNNER_GROUP
   - CRANETESTKIT_RELEASE_DIR
   - CRANETESTKIT_AUTOTEST_SHA
   - CRANETESTKIT_EXECUTABLE_SHA256

--- a/.github/ci/README.md
+++ b/.github/ci/README.md
@@ -2,27 +2,30 @@
 
 `.github/workflows/build.yaml` is the trusted dispatcher for the K3s system
 suite. Pull requests use `pull_request_target` only to authorize and resolve
-immutable revisions on a GitHub-hosted runner. The hosted job never checks out
-or executes pull-request code. A privileged job is dispatched only when all of
-the following are true:
+immutable revisions on a GitHub-hosted runner. The hosted job executes only
+trusted controls from `master`; after authorization, it checks out candidate
+workflow files for static inspection but never executes candidate code. A
+privileged job is dispatched only when all of the following are true:
 
 - the workflow was loaded from `master`;
 - the pull request is from this repository, not a fork;
 - `github.triggering_actor` currently has `maintain` or `admin` permission;
 - Backend and FrontEnd refs resolve to full commit SHAs.
 
-The current cutover uses the existing repository-scoped runner and selects it
-with the `cranesystemtest` label. This temporary mode does not isolate the
-runner from other workflows in `PKUHPC/CraneSched`: labels route jobs, but do
-not authorize workflows. Keep the runner stopped except for controlled CI runs
-until an organization owner completes the runner-group migration below.
+The privileged job uses the dedicated repository-scoped runner selected by the
+exact `cranesystemtest` label. Repository registration prevents other
+repositories from dispatching to it, but GitHub does not restrict which
+workflow in `PKUHPC/CraneSched` may request a repository runner. This is an
+accepted boundary of the deployment.
 
-The target state is an organization runner group that allows only
-`PKUHPC/CraneSched/.github/workflows/build.yaml@refs/heads/master`. Its runner
-must keep the `cranesystemtest` label and runner name. After migration, restore
-the workflow's `runs-on.group` selector using the
-`CRANESCHED_PRIVILEGED_RUNNER_GROUP` repository variable so the group name is
-not duplicated in source.
+The hosted authorization job applies a compensating routing guard before it
+dispatches `test`: after resolving the exact candidate Backend SHA, it checks
+that only `.github/workflows/build.yaml` contains the exact
+`cranesystemtest` token. The check runs trusted code from `master` and treats
+the candidate workflow files only as data. Protect `.github/workflows/**` and
+`.github/ci/**` through branch protection and required maintainer review
+because this static guard is an accidental-change check, not a GitHub-enforced
+workflow authorization boundary.
 
 ## Repository variables
 
@@ -32,7 +35,6 @@ these repository variables:
 
 | Variable | Contract |
 | --- | --- |
-| `CRANESCHED_PRIVILEGED_RUNNER_GROUP` | Target-state organization runner group; `Default` is only a temporary cutover marker and is not consumed by label-only routing |
 | `CRANETESTKIT_RELEASE_DIR` | Absolute path to a root-owned, recursively read-only AutoTest Git release |
 | `CRANETESTKIT_AUTOTEST_SHA` | Exact 40-character commit deployed at the release path |
 | `CRANETESTKIT_EXECUTABLE_SHA256` | SHA-256 of the prepared `<release>/.venv/bin/crane_testkit` entry point |
@@ -84,21 +86,21 @@ It then renders canonical Jobs from the validated release/profile/runtime and
 uses server-side dry-run to require that approved Jobs pass while forbidden
 nodeName, lifecycle, host-network, image and NFS mutations are denied by
 `crane-testkit-ci-jobs`. This verifies the admission boundary without creating
-resources. Permission or policy drift fails before pull-request code is checked
-out.
+resources. Permission or policy drift fails before pull-request source is
+checked out on the privileged runner.
 
 ## Runner setup
 
-The current migration baseline is the dedicated root-owned Backend service
+The dedicated Backend service is
 `actions.runner.PKUHPC-CraneSched.cranesystemtest`. Root is currently required
 to collect and clean NFS run artifacts written by privileged Pods, so the
-hosted authorization, organization runner-group restriction and Kubernetes
-RBAC checks are mandatory compensating controls. The separate AutoTest service
+hosted authorization, static routing guard and Kubernetes RBAC checks are
+mandatory compensating controls. The separate AutoTest service
 `actions.runner.PKUHPC-CraneSched-AutoTest.cranesystemtest-autotest` must not
-receive the Backend runner group or `cranesystemtest` label. A future non-root
-migration requires an explicit NFS ownership/ACL validation first. The
-preflight accepts a private kubeconfig owned by root or the effective runner
-account. Install Actions Runner `2.327.1` or newer; the pinned
+receive the Backend `cranesystemtest` label. A future non-root migration
+requires an explicit NFS ownership/ACL validation first. The preflight accepts
+a private kubeconfig owned by root or the effective runner account. Install
+Actions Runner `2.327.1` or newer; the pinned
 `upload-artifact@v6` action uses Node.js 24. The following state belongs on
 local SSD:
 
@@ -144,34 +146,26 @@ embedded PAT, then use a short-lived read-only GitHub App or deploy credential
 only during the administrator deployment. CI itself performs no AutoTest Git
 network operation.
 
-## Organization runner-group migration
+## Repository runner boundary
 
-An organization owner must perform this migration before the Backend runner is
-left online between runs:
+Keep the Backend runner registered directly to `PKUHPC/CraneSched`, with
+runner name and custom label both set to `cranesystemtest`. Keep the AutoTest
+maintenance runner registered directly to `PKUHPC/CraneSched-AutoTest`, with
+its distinct `cranesystemtest-autotest` label. Do not give either service the
+other service's label or environment.
 
-1. Create a PKUHPC organization runner group with selected-repository access
-   limited to `PKUHPC/CraneSched` and selected-workflow access limited to
-   `PKUHPC/CraneSched/.github/workflows/build.yaml@refs/heads/master`.
-2. Stop the repository-scoped Backend runner and confirm it is idle, no
-   CraneTestKit Lease is held, and no matching Actions job is queued.
-3. Remove the repository-scoped registration and register the same runner at
-   `https://github.com/PKUHPC` in the new group. Keep runner name and custom
-   label `cranesystemtest`; preserve the verified release hooks and restricted
-   kubeconfig in the service environment. Registration and removal tokens must
-   be short-lived, passed without logging, and never stored on disk.
-4. Set `CRANESCHED_PRIVILEGED_RUNNER_GROUP` to the new group name and restore
-   the workflow selector to:
+Only `build.yaml` may contain the exact Backend label. The hosted routing guard
+scans every `.yaml` and `.yml` file directly under `.github/workflows` at the
+authorized candidate SHA and fails closed on symlinked workflow files, a
+missing `build.yaml`, a missing Backend label, or any exact label occurrence in
+another workflow. Labels with longer names such as
+`cranesystemtest-autotest` are not Backend-label matches.
 
-   ```yaml
-   runs-on:
-     group: ${{ vars.CRANESCHED_PRIVILEGED_RUNNER_GROUP }}
-     labels: cranesystemtest
-   ```
-
-5. Start only the Backend runner, dispatch `build.yaml` from `master`, and
-   verify the `test` job reports the new organization group before leaving the
-   service enabled. The AutoTest maintenance runner remains a separate
-   registration and group.
+This guard catches a candidate workflow that accidentally names the dedicated
+label, but it cannot prevent routing through a generic default self-hosted
+label or a repository variable. Required maintainer review, branch protection,
+the trusted `pull_request_target` dispatcher and the restricted Kubernetes
+identity remain part of the repository-level security boundary.
 
 ## Artifacts and result contract
 

--- a/.github/ci/test_validate_workflow_routing.py
+++ b/.github/ci/test_validate_workflow_routing.py
@@ -1,0 +1,138 @@
+from __future__ import annotations
+
+import importlib.util
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+
+MODULE_PATH = Path(__file__).with_name("validate-workflow-routing.py")
+BUILD_WORKFLOW = Path(__file__).parents[1] / "workflows" / "build.yaml"
+WORKFLOW_PATH = Path(__file__).parents[1] / "workflows" / "build.yaml"
+SPEC = importlib.util.spec_from_file_location(
+    "cranesched_ci_validate_workflow_routing", MODULE_PATH
+)
+assert SPEC is not None and SPEC.loader is not None
+routing = importlib.util.module_from_spec(SPEC)
+sys.modules[SPEC.name] = routing
+SPEC.loader.exec_module(routing)
+
+
+class WorkflowRoutingPolicyTest(unittest.TestCase):
+    def setUp(self) -> None:
+        self.temporary_directory = tempfile.TemporaryDirectory()
+        self.addCleanup(self.temporary_directory.cleanup)
+        self.workflows_dir = Path(self.temporary_directory.name)
+        (self.workflows_dir / "build.yaml").write_text(
+            "jobs:\n  test:\n    runs-on: [self-hosted, cranesystemtest]\n",
+            encoding="utf-8",
+        )
+
+    def test_allows_backend_label_only_in_build_workflow(self) -> None:
+        (self.workflows_dir / "format.yaml").write_text(
+            "jobs:\n  format:\n    runs-on: ubuntu-latest\n",
+            encoding="utf-8",
+        )
+
+        routing.validate_workflow_routing(self.workflows_dir)
+
+    def test_rejects_backend_label_in_another_workflow(self) -> None:
+        (self.workflows_dir / "debug.yml").write_text(
+            "jobs:\n  debug:\n    runs-on: cranesystemtest\n",
+            encoding="utf-8",
+        )
+
+        with self.assertRaisesRegex(
+            routing.RoutingPolicyError, r"debug.yml:3"
+        ):
+            routing.validate_workflow_routing(self.workflows_dir)
+
+    def test_rejects_mixed_case_backend_label_in_another_workflow(self) -> None:
+        (self.workflows_dir / "debug.yml").write_text(
+            "jobs:\n  debug:\n    runs-on: CraneSystemTest\n",
+            encoding="utf-8",
+        )
+
+        with self.assertRaisesRegex(routing.RoutingPolicyError, r"debug.yml:3"):
+            routing.validate_workflow_routing(self.workflows_dir)
+
+    def test_does_not_match_maintenance_runner_label_substring(self) -> None:
+        (self.workflows_dir / "maintenance.yaml").write_text(
+            "jobs:\n  clean:\n"
+            "    runs-on: [self-hosted, cranesystemtest-autotest]\n",
+            encoding="utf-8",
+        )
+
+        routing.validate_workflow_routing(self.workflows_dir)
+
+    def test_does_not_match_dotted_runner_label_suffix(self) -> None:
+        (self.workflows_dir / "debug.yaml").write_text(
+            "jobs:\n  debug:\n    runs-on: cranesystemtest.debug\n",
+            encoding="utf-8",
+        )
+
+        routing.validate_workflow_routing(self.workflows_dir)
+
+    def test_requires_backend_label_in_allowed_workflow(self) -> None:
+        (self.workflows_dir / "build.yaml").write_text(
+            "jobs:\n  test:\n    runs-on: [self-hosted]\n",
+            encoding="utf-8",
+        )
+
+        with self.assertRaisesRegex(
+            routing.RoutingPolicyError, "must route only"
+        ):
+            routing.validate_workflow_routing(self.workflows_dir)
+
+    def test_comment_does_not_satisfy_allowed_job_selector(self) -> None:
+        (self.workflows_dir / "build.yaml").write_text(
+            "jobs:\n  test:\n    # cranesystemtest\n    runs-on: [self-hosted]\n",
+            encoding="utf-8",
+        )
+
+        with self.assertRaisesRegex(routing.RoutingPolicyError, "must route only"):
+            routing.validate_workflow_routing(self.workflows_dir)
+
+    def test_fake_test_mapping_outside_jobs_does_not_satisfy_selector(self) -> None:
+        (self.workflows_dir / "build.yaml").write_text(
+            "env:\n  test:\n    runs-on: [self-hosted, cranesystemtest]\n"
+            "jobs:\n  test:\n    runs-on: [self-hosted]\n",
+            encoding="utf-8",
+        )
+
+        with self.assertRaisesRegex(routing.RoutingPolicyError, "must route only"):
+            routing.validate_workflow_routing(self.workflows_dir)
+
+    def test_rejects_symlinked_workflow(self) -> None:
+        target = self.workflows_dir / "target"
+        target.write_text("jobs: {}\n", encoding="utf-8")
+        (self.workflows_dir / "debug.yaml").symlink_to(target)
+
+        with self.assertRaisesRegex(
+            routing.RoutingPolicyError, "workflow must be a regular file"
+        ):
+            routing.validate_workflow_routing(self.workflows_dir)
+
+    def test_build_workflow_does_not_suppress_python_bytecode(self) -> None:
+        text = BUILD_WORKFLOW.read_text(encoding="utf-8")
+
+        self.assertNotIn("PYTHONDONTWRITEBYTECODE", text)
+
+    def test_candidate_routing_steps_require_successful_authorization(self) -> None:
+        workflow = WORKFLOW_PATH.read_text(encoding="utf-8")
+        condition = "if: steps.authorize.outputs.authorized == 'true'"
+        for step_name in (
+            "Checkout candidate workflow routing",
+            "Validate repository runner routing",
+        ):
+            with self.subTest(step_name=step_name):
+                step = workflow.index(f"- name: {step_name}")
+                next_step = workflow.find("\n      - name:", step + 1)
+                if next_step == -1:
+                    next_step = len(workflow)
+                self.assertIn(condition, workflow[step:next_step])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/.github/ci/validate-workflow-routing.py
+++ b/.github/ci/validate-workflow-routing.py
@@ -1,0 +1,141 @@
+#!/usr/bin/env python3
+"""Keep the privileged repository runner label in its trusted workflow."""
+
+from __future__ import annotations
+
+import argparse
+import re
+import sys
+from pathlib import Path
+
+
+ALLOWED_WORKFLOW = "build.yaml"
+ALLOWED_JOB = "test"
+RUNNER_LABEL = "cranesystemtest"
+_LABEL_CHARACTER = r"A-Za-z0-9_.-"
+_JOB_KEY_RE = re.compile(r"^  ([A-Za-z0-9_-]+):\s*(?:#.*)?$")
+_INLINE_RUNS_ON_RE = re.compile(
+    r"^    runs-on:\s*\[([^\]]+)\]\s*(?:#.*)?$",
+    re.IGNORECASE,
+)
+
+
+class RoutingPolicyError(RuntimeError):
+    pass
+
+
+def _label_pattern(label: str) -> re.Pattern[str]:
+    if not label or label != label.strip():
+        raise ValueError("runner label must be a non-empty trimmed string")
+    return re.compile(
+        rf"(?<![{_LABEL_CHARACTER}]){re.escape(label)}"
+        rf"(?![{_LABEL_CHARACTER}])",
+        re.IGNORECASE,
+    )
+
+
+def _validate_allowed_job_selector(path: Path, runner_label: str) -> None:
+    lines = path.read_text(encoding="utf-8").splitlines()
+    jobs_headers = [index for index, line in enumerate(lines) if line == "jobs:"]
+    if len(jobs_headers) != 1:
+        raise RoutingPolicyError(f"{ALLOWED_WORKFLOW} must have one canonical jobs section")
+    jobs_start = jobs_headers[0] + 1
+    jobs_end = len(lines)
+    for index in range(jobs_start, len(lines)):
+        line = lines[index]
+        if line and not line[0].isspace() and not line.startswith("#"):
+            jobs_end = index
+            break
+
+    job_start: int | None = None
+    job_end = jobs_end
+    for index in range(jobs_start, jobs_end):
+        line = lines[index]
+        match = _JOB_KEY_RE.fullmatch(line)
+        if match is None:
+            continue
+        if job_start is None and match.group(1) == ALLOWED_JOB:
+            job_start = index + 1
+            continue
+        if job_start is not None:
+            job_end = index
+            break
+    if job_start is None:
+        raise RoutingPolicyError(f"allowed job is missing: {ALLOWED_JOB}")
+
+    selectors = [
+        match.group(1)
+        for line in lines[job_start:job_end]
+        if (match := _INLINE_RUNS_ON_RE.fullmatch(line)) is not None
+    ]
+    if len(selectors) != 1:
+        raise RoutingPolicyError(
+            f"{ALLOWED_WORKFLOW}:{ALLOWED_JOB} must have one inline runs-on selector"
+        )
+    labels = [item.strip().strip("'\"").casefold() for item in selectors[0].split(",")]
+    if labels != ["self-hosted", runner_label.casefold()]:
+        raise RoutingPolicyError(
+            f"{ALLOWED_WORKFLOW}:{ALLOWED_JOB} must route only to "
+            f"[self-hosted, {runner_label}]"
+        )
+
+
+def validate_workflow_routing(
+    workflows_dir: Path,
+    *,
+    allowed_workflow: str = ALLOWED_WORKFLOW,
+    runner_label: str = RUNNER_LABEL,
+) -> None:
+    if not workflows_dir.is_dir() or workflows_dir.is_symlink():
+        raise RoutingPolicyError("workflow directory must be a regular directory")
+    if Path(allowed_workflow).name != allowed_workflow:
+        raise RoutingPolicyError("allowed workflow must be a filename")
+
+    pattern = _label_pattern(runner_label)
+    workflow_paths = sorted(
+        path
+        for path in workflows_dir.iterdir()
+        if path.suffix in {".yaml", ".yml"}
+    )
+    allowed_path = workflows_dir / allowed_workflow
+    if allowed_path not in workflow_paths:
+        raise RoutingPolicyError(f"allowed workflow is missing: {allowed_workflow}")
+
+    violations: list[str] = []
+    for path in workflow_paths:
+        if path.is_symlink() or not path.is_file():
+            raise RoutingPolicyError(f"workflow must be a regular file: {path.name}")
+        text = path.read_text(encoding="utf-8")
+        for line_number, line in enumerate(text.splitlines(), start=1):
+            if pattern.search(line) is None:
+                continue
+            if path != allowed_path:
+                violations.append(f"{path.name}:{line_number}")
+
+    if violations:
+        locations = ", ".join(violations)
+        raise RoutingPolicyError(
+            f"runner label {runner_label!r} is restricted to {allowed_workflow}; "
+            f"found in {locations}"
+        )
+    _validate_allowed_job_selector(allowed_path, runner_label)
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--workflows-dir", required=True, type=Path)
+    args = parser.parse_args(argv)
+    try:
+        validate_workflow_routing(args.workflows_dir)
+    except (OSError, UnicodeError, RoutingPolicyError, ValueError) as exc:
+        print(f"workflow routing validation failed: {exc}", file=sys.stderr)
+        return 1
+    print(
+        f"workflow routing validated: {RUNNER_LABEL} is restricted to "
+        f"{ALLOWED_WORKFLOW}"
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -93,6 +93,24 @@ jobs:
           FRONTEND_REPOSITORY: PKUHPC/CraneSched-FrontEnd
         run: /usr/bin/python3 -I trusted-ci/.github/ci/authorize.py
 
+      - name: Checkout candidate workflow routing
+        if: steps.authorize.outputs.authorized == 'true'
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
+        with:
+          ref: ${{ steps.authorize.outputs.backend_sha }}
+          path: candidate-routing
+          sparse-checkout: .github/workflows
+          persist-credentials: false
+          clean: true
+          set-safe-directory: false
+
+      - name: Validate repository runner routing
+        if: steps.authorize.outputs.authorized == 'true'
+        run: >-
+          /usr/bin/python3 -I
+          trusted-ci/.github/ci/validate-workflow-routing.py
+          --workflows-dir candidate-routing/.github/workflows
+
   test:
     name: test
     needs: authorize
@@ -102,7 +120,6 @@ jobs:
     permissions:
       contents: read
     env:
-      PYTHONDONTWRITEBYTECODE: "1"
       PYTHONNOUSERSITE: "1"
       PYTHONPATH: ""
       CRANETESTKIT_RELEASE_DIR: ${{ vars.CRANETESTKIT_RELEASE_DIR }}


### PR DESCRIPTION
## Summary

- keep K3s CI on the existing repository-scoped `cranesystemtest` runner
- inspect candidate workflow files on the hosted authorization job before self-hosted dispatch
- require the canonical `jobs.test.runs-on: [self-hosted, cranesystemtest]` selector and reject the label in other workflows
- remove the unused organization runner-group variable and document the accepted repository-level boundary
- rely on the existing narrow bytecode validation instead of suppressing `.pyc` generation

## Why

The deployment intentionally keeps repository-level runners. Labels route jobs but do not provide workflow-level authorization, so the hosted guard catches accidental candidate workflow drift before the privileged job is dispatched while the existing same-repository, maintainer, trusted-master and fork checks remain authoritative.

## Validation

- 59 Backend CI Python tests passed
- current repository workflow routing guard passed
- actionlint v1.7.7 passed
- `git diff --check` passed

The self-hosted runner remains stopped until the matching post-merge AutoTest release and image bundle are deployed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added validation to ensure privileged runner routing is restricted to the approved workflow and configuration.
  - Added authorization checks before routing-related workflow steps can run.

- **Documentation**
  - Clarified privileged CI security boundaries, runner setup requirements, and workflow routing rules.
  - Removed documentation for the retired privileged runner-group variable.

- **Tests**
  - Added coverage for valid and invalid runner labels, workflow selectors, symlinks, comments, and authorization conditions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->