### PR TITLE
ci: validate repository runner PR dispatch

### DIFF
--- a/.github/ci/README.md
+++ b/.github/ci/README.md
@@ -1,5 +1,7 @@
 # CraneTestKit privileged CI contract
 
+<!-- PR-only canary marker for repository runner dispatch validation. -->
+
 `.github/workflows/build.yaml` is the trusted dispatcher for the K3s system
 suite. Pull requests use `pull_request_target` only to authorize and resolve
 immutable revisions on a GitHub-hosted runner. The hosted job executes only


### PR DESCRIPTION
## Purpose

This canary PR adds one PR-only documentation comment under `.github/ci/` so
the production workflow path filter is exercised. It exists only to validate
the repository-level runner dispatch after #932 and will not be merged.

## Acceptance

- The trusted hosted authorization job accepts this same-repository,
  non-draft maintainer PR.
- Candidate workflow routing validation passes.
- Only the `cranesystemtest` Backend runner receives the self-hosted `test`
  job.
- The K3s aggregate completes with full coverage and exit code 0.

The PR will be closed without merging after the checks finish.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a canary marker to the CI documentation to support repository-runner validation.
  * No changes were made to existing CI behavior or contractual guidance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->