### PR TITLE
fix(ci): validate stale PR routing without workflow writes

### DIFF
--- a/.github/ci/README.md
+++ b/.github/ci/README.md
@@ -3,7 +3,7 @@
 `.github/workflows/build.yaml` is the trusted dispatcher for the K3s system
 suite. Pull requests use `pull_request_target` only to authorize and resolve
 immutable revisions on a GitHub-hosted runner. The hosted job executes only
-trusted controls from `master`; after authorization, it checks out candidate
+trusted controls from `master`; after authorization, it checks out proposed-merge
 workflow files for static inspection but never executes candidate code. A
 privileged job is dispatched only when all of the following are true:
 
@@ -19,13 +19,19 @@ workflow in `PKUHPC/CraneSched` may request a repository runner. This is an
 accepted boundary of the deployment.
 
 The hosted authorization job applies a compensating routing guard before it
-dispatches `test`: after resolving the exact candidate Backend SHA, it checks
-that only `.github/workflows/build.yaml` contains the exact
+dispatches `test`. For a pull request, it resolves the exact PR head SHA for
+the build, then obtains GitHub's proposed merge commit only for this static
+routing check. The merge commit must have exactly the event's base and head
+commits as parents, in that order; a stale or conflicting snapshot fails
+closed. It checks that only `.github/workflows/build.yaml` contains the exact
 `cranesystemtest` token. The check runs trusted code from `master` and treats
-the candidate workflow files only as data. Protect `.github/workflows/**` and
-`.github/ci/**` through branch protection and required maintainer review
-because this static guard is an accidental-change check, not a GitHub-enforced
-workflow authorization boundary.
+the proposed workflow files only as data. The privileged job still builds and
+tests the PR head SHA, not the temporary merge commit. Protect
+`.github/workflows/**` and `.github/ci/**` through branch protection and
+required maintainer review because this static guard is an accidental-change
+check, not a GitHub-enforced workflow authorization boundary.
+The sanitized artifact manifest and summary retain the base, head, and routing
+SHAs so reviewers can distinguish tested source from the inspected merge tree.
 
 ## Repository variables
 
@@ -156,10 +162,17 @@ other service's label or environment.
 
 Only `build.yaml` may contain the exact Backend label. The hosted routing guard
 scans every `.yaml` and `.yml` file directly under `.github/workflows` at the
-authorized candidate SHA and fails closed on symlinked workflow files, a
+authorized proposed-merge SHA and fails closed on symlinked workflow files, a
 missing `build.yaml`, a missing Backend label, or any exact label occurrence in
-another workflow. Labels with longer names such as
+another workflow. The checkout also verifies the merge commit's HEAD and
+parent SHAs before scanning. Labels with longer names such as
 `cranesystemtest-autotest` are not Backend-label matches.
+
+The Clang Format check is intentionally read-only. It checks the exact PR head
+on a hosted runner, never pushes a formatting commit, and uploads a short-lived
+binary patch when formatting changes are required. Same-repository and fork
+pull requests have the same behavior; a contributor applies the patch and
+pushes a normal commit, which then triggers the normal PR events.
 
 This guard catches a candidate workflow that accidentally names the dedicated
 label, but it cannot prevent routing through a generic default self-hosted

--- a/.github/ci/authorize.py
+++ b/.github/ci/authorize.py
@@ -7,6 +7,7 @@ import json
 import os
 import re
 import sys
+import time
 import urllib.error
 import urllib.parse
 import urllib.request
@@ -30,6 +31,11 @@ class DispatchContext:
     triggering_actor: str
     event_sha: str
     frontend_repository: str
+    pr_number: str = ""
+    pr_base_repository: str = ""
+    pr_base_ref: str = ""
+    pr_base_sha: str = ""
+    pr_merge_sha: str = ""
     pr_head_repository: str = ""
     pr_head_ref: str = ""
     pr_head_sha: str = ""
@@ -39,6 +45,31 @@ class DispatchContext:
 
 PermissionLookup = Callable[[str, str], dict[str, object]]
 CommitResolver = Callable[[str, str], Optional[str]]
+
+
+@dataclass(frozen=True)
+class PullRequestSnapshot:
+    """The immutable PR fields used to bind a proposed merge result."""
+
+    number: int
+    state: str
+    draft: bool
+    base_repository: str
+    base_ref: str
+    base_sha: str
+    head_repository: str
+    head_ref: str
+    head_sha: str
+    merge_commit_sha: str
+    mergeable: bool | None
+
+
+PullRequestLookup = Callable[[str, int], PullRequestSnapshot]
+MergeRefResolver = Callable[[str, int], Optional[str]]
+CommitParentsResolver = Callable[[str, str], Optional[tuple[str, ...]]]
+Sleeper = Callable[[float], None]
+
+_MERGE_RETRY_DELAYS = (0.5, 1.0, 2.0, 4.0, 8.0)
 
 
 def _has_maintain_permission(value: dict[str, object]) -> bool:
@@ -71,10 +102,134 @@ def _required_commit(
     return revision
 
 
+def _required_pr_number(value: str) -> int:
+    if re.fullmatch(r"[1-9][0-9]*", value) is None:
+        raise AuthorizationError("pull request number is invalid")
+    return int(value)
+
+
+def _validate_pr_event(context: DispatchContext) -> int:
+    if context.pr_head_repository != context.repository:
+        raise AuthorizationError(
+            "fork pull requests cannot dispatch the self-hosted runner"
+        )
+    if context.pr_base_repository != context.repository:
+        raise AuthorizationError("pull request base repository is unexpected")
+    if context.pr_base_ref != "master":
+        raise AuthorizationError("pull request base branch is not master")
+    if not SHA_RE.fullmatch(context.pr_base_sha):
+        raise AuthorizationError("pull request base is not a full commit SHA")
+    if context.event_sha != context.pr_base_sha:
+        raise AuthorizationError(
+            "trusted workflow revision does not match the pull request base"
+        )
+    if not SHA_RE.fullmatch(context.pr_head_sha):
+        raise AuthorizationError("pull request head is not a full commit SHA")
+    if not context.pr_head_ref or any(
+        character in context.pr_head_ref for character in "\r\n"
+    ):
+        raise AuthorizationError("pull request head ref is invalid")
+    if context.pr_merge_sha and not SHA_RE.fullmatch(context.pr_merge_sha):
+        raise AuthorizationError("event proposed merge is not a full commit SHA")
+    return _required_pr_number(context.pr_number)
+
+
+def _validate_pr_snapshot(
+    context: DispatchContext, number: int, snapshot: PullRequestSnapshot
+) -> None:
+    if snapshot.number != number:
+        raise AuthorizationError("GitHub returned an unexpected pull request")
+    if snapshot.state != "open":
+        raise AuthorizationError("pull request is no longer open")
+    if snapshot.draft:
+        raise AuthorizationError("draft pull requests cannot dispatch tests")
+    if (
+        snapshot.base_repository != context.pr_base_repository
+        or snapshot.base_ref != context.pr_base_ref
+        or snapshot.base_sha != context.pr_base_sha
+        or snapshot.head_repository != context.pr_head_repository
+        or snapshot.head_ref != context.pr_head_ref
+        or snapshot.head_sha != context.pr_head_sha
+    ):
+        raise AuthorizationError(
+            "pull request changed after this workflow event; wait for the new run"
+        )
+
+
+def _resolve_pr_merge(
+    context: DispatchContext,
+    number: int,
+    pull_request_lookup: PullRequestLookup,
+    merge_ref_resolver: MergeRefResolver,
+    commit_parents_resolver: CommitParentsResolver,
+    *,
+    sleeper: Sleeper,
+    retry_delays: tuple[float, ...] = _MERGE_RETRY_DELAYS,
+) -> str:
+    attempts = len(retry_delays) + 1
+    pending_reason = "GitHub has not computed the proposed merge"
+
+    for attempt in range(attempts):
+        snapshot = pull_request_lookup(context.repository, number)
+        _validate_pr_snapshot(context, number, snapshot)
+        if snapshot.mergeable is False:
+            raise AuthorizationError("pull request has no mergeable proposed result")
+
+        merge_sha = snapshot.merge_commit_sha
+        if snapshot.mergeable is not True or not SHA_RE.fullmatch(merge_sha):
+            pending_reason = "GitHub has not computed the proposed merge"
+        elif context.pr_merge_sha and context.pr_merge_sha != merge_sha:
+            raise AuthorizationError(
+                "event proposed merge does not match the current pull request"
+            )
+        else:
+            merge_ref_sha = merge_ref_resolver(context.repository, number)
+            if merge_ref_sha != merge_sha:
+                pending_reason = "the pull request merge ref is not synchronized"
+            else:
+                parents = commit_parents_resolver(context.repository, merge_sha)
+                if parents is None:
+                    pending_reason = "the proposed merge commit is not available"
+                elif parents != (context.pr_base_sha, context.pr_head_sha):
+                    raise AuthorizationError(
+                        "proposed merge parents do not match the event base and head"
+                    )
+                else:
+                    final_snapshot = pull_request_lookup(context.repository, number)
+                    _validate_pr_snapshot(context, number, final_snapshot)
+                    final_ref_sha = merge_ref_resolver(context.repository, number)
+                    if (
+                        final_snapshot.mergeable is True
+                        and final_snapshot.merge_commit_sha == merge_sha
+                        and final_ref_sha == merge_sha
+                    ):
+                        return merge_sha
+                    if final_snapshot.mergeable is False:
+                        raise AuthorizationError(
+                            "pull request has no mergeable proposed result"
+                        )
+                    pending_reason = (
+                        "the proposed merge changed during authorization"
+                    )
+
+        if attempt < len(retry_delays):
+            sleeper(retry_delays[attempt])
+
+    raise AuthorizationError(
+        f"unable to resolve a stable proposed merge: {pending_reason}"
+    )
+
+
 def authorize_dispatch(
     context: DispatchContext,
     permission_lookup: PermissionLookup,
     commit_resolver: CommitResolver,
+    pull_request_lookup: PullRequestLookup | None = None,
+    merge_ref_resolver: MergeRefResolver | None = None,
+    commit_parents_resolver: CommitParentsResolver | None = None,
+    *,
+    sleeper: Sleeper = time.sleep,
+    retry_delays: tuple[float, ...] = _MERGE_RETRY_DELAYS,
 ) -> dict[str, str]:
     expected_workflow_ref = (
         f"{context.repository}/.github/workflows/build.yaml@refs/heads/master"
@@ -86,13 +241,33 @@ def authorize_dispatch(
     if not SHA_RE.fullmatch(context.event_sha):
         raise AuthorizationError("trusted workflow ref is not a full commit SHA")
 
+    pr_base_sha = ""
+    pr_head_sha = ""
+    pr_merge_sha = ""
     if context.event_name == "pull_request_target":
-        if context.pr_head_repository != context.repository:
-            raise AuthorizationError(
-                "fork pull requests cannot dispatch the self-hosted runner"
-            )
+        pr_number = _validate_pr_event(context)
         _require_maintainer(context, permission_lookup)
+        if (
+            pull_request_lookup is None
+            or merge_ref_resolver is None
+            or commit_parents_resolver is None
+        ):
+            raise AuthorizationError(
+                "pull request merge validation is unavailable"
+            )
         backend_sha = context.pr_head_sha
+        routing_sha = _resolve_pr_merge(
+            context,
+            pr_number,
+            pull_request_lookup,
+            merge_ref_resolver,
+            commit_parents_resolver,
+            sleeper=sleeper,
+            retry_delays=retry_delays,
+        )
+        pr_base_sha = context.pr_base_sha
+        pr_head_sha = context.pr_head_sha
+        pr_merge_sha = routing_sha
         frontend_ref = context.pr_head_ref
         frontend_sha = commit_resolver(context.frontend_repository, frontend_ref)
         if frontend_sha is None:
@@ -118,8 +293,10 @@ def authorize_dispatch(
             frontend_ref,
             "FrontEnd",
         )
+        routing_sha = backend_sha
     elif context.event_name in {"push", "schedule"}:
         backend_sha = context.event_sha
+        routing_sha = backend_sha
         frontend_ref = "master"
         frontend_sha = _required_commit(
             commit_resolver,
@@ -137,6 +314,11 @@ def authorize_dispatch(
     )
     if verified_backend != backend_sha:
         raise AuthorizationError("Backend commit verification failed")
+    verified_routing = _required_commit(
+        commit_resolver, context.repository, routing_sha, "Routing"
+    )
+    if verified_routing != routing_sha:
+        raise AuthorizationError("Routing commit verification failed")
     if not SHA_RE.fullmatch(frontend_sha):
         raise AuthorizationError("FrontEnd ref did not resolve to a full commit SHA")
     if any(character in frontend_ref for character in "\r\n"):
@@ -145,6 +327,10 @@ def authorize_dispatch(
     return {
         "authorized": "true",
         "backend_sha": backend_sha,
+        "routing_sha": routing_sha,
+        "pr_base_sha": pr_base_sha,
+        "pr_head_sha": pr_head_sha,
+        "pr_merge_sha": pr_merge_sha,
         "frontend_ref": frontend_ref,
         "frontend_sha": frontend_sha,
         "workflow_sha": context.event_sha,
@@ -205,6 +391,92 @@ class GitHubApi:
         revision = value.get("sha")
         return revision if isinstance(revision, str) else None
 
+    def pull_request(self, repository: str, number: int) -> PullRequestSnapshot:
+        value = self._get(f"repos/{repository}/pulls/{number}")
+        assert value is not None
+        base = value.get("base")
+        head = value.get("head")
+        if not isinstance(base, dict) or not isinstance(head, dict):
+            raise AuthorizationError("GitHub pull request response is malformed")
+        base_repository = base.get("repo")
+        head_repository = head.get("repo")
+        if not isinstance(base_repository, dict) or not isinstance(
+            head_repository, dict
+        ):
+            raise AuthorizationError("GitHub pull request response is malformed")
+
+        actual_number = value.get("number")
+        state = value.get("state")
+        draft = value.get("draft")
+        mergeable = value.get("mergeable")
+        merge_commit_sha = value.get("merge_commit_sha")
+        fields = (
+            base_repository.get("full_name"),
+            base.get("ref"),
+            base.get("sha"),
+            head_repository.get("full_name"),
+            head.get("ref"),
+            head.get("sha"),
+        )
+        if (
+            not isinstance(actual_number, int)
+            or isinstance(actual_number, bool)
+            or not isinstance(state, str)
+            or not isinstance(draft, bool)
+            or mergeable is not None
+            and not isinstance(mergeable, bool)
+            or merge_commit_sha is not None
+            and not isinstance(merge_commit_sha, str)
+            or any(not isinstance(field, str) for field in fields)
+        ):
+            raise AuthorizationError("GitHub pull request response is malformed")
+
+        return PullRequestSnapshot(
+            number=actual_number,
+            state=state,
+            draft=draft,
+            base_repository=fields[0],
+            base_ref=fields[1],
+            base_sha=fields[2],
+            head_repository=fields[3],
+            head_ref=fields[4],
+            head_sha=fields[5],
+            merge_commit_sha=merge_commit_sha or "",
+            mergeable=mergeable,
+        )
+
+    def merge_ref(self, repository: str, number: int) -> str | None:
+        value = self._get(
+            f"repos/{repository}/git/ref/pull/{number}/merge",
+            missing_statuses=frozenset({404, 409, 422}),
+        )
+        if value is None:
+            return None
+        target = value.get("object")
+        if not isinstance(target, dict) or not isinstance(target.get("sha"), str):
+            raise AuthorizationError("GitHub merge ref response is malformed")
+        return target["sha"]
+
+    def commit_parents(
+        self, repository: str, revision: str
+    ) -> tuple[str, ...] | None:
+        encoded_revision = urllib.parse.quote(revision, safe="")
+        value = self._get(
+            f"repos/{repository}/git/commits/{encoded_revision}",
+            missing_statuses=frozenset({404, 422}),
+        )
+        if value is None:
+            return None
+        parents = value.get("parents")
+        if not isinstance(parents, list):
+            raise AuthorizationError("GitHub commit response is malformed")
+        revisions: list[str] = []
+        for parent in parents:
+            if not isinstance(parent, dict) or not isinstance(parent.get("sha"), str):
+                raise AuthorizationError("GitHub commit response is malformed")
+            revisions.append(parent["sha"])
+        return tuple(revisions)
+
 
 def _context_from_environment() -> DispatchContext:
     return DispatchContext(
@@ -216,6 +488,11 @@ def _context_from_environment() -> DispatchContext:
         frontend_repository=os.environ.get(
             "FRONTEND_REPOSITORY", "PKUHPC/CraneSched-FrontEnd"
         ),
+        pr_number=os.environ.get("PR_NUMBER", ""),
+        pr_base_repository=os.environ.get("PR_BASE_REPOSITORY", ""),
+        pr_base_ref=os.environ.get("PR_BASE_REF", ""),
+        pr_base_sha=os.environ.get("PR_BASE_SHA", ""),
+        pr_merge_sha=os.environ.get("PR_MERGE_SHA", ""),
         pr_head_repository=os.environ.get("PR_HEAD_REPOSITORY", ""),
         pr_head_ref=os.environ.get("PR_HEAD_REF", ""),
         pr_head_sha=os.environ.get("PR_HEAD_SHA", ""),
@@ -229,11 +506,22 @@ def main() -> int:
     with output_path.open("a", encoding="utf-8") as output:
         output.write("authorized=false\n")
     api = GitHubApi(os.environ.get("GH_TOKEN", ""))
-    result = authorize_dispatch(_context_from_environment(), api.permission, api.commit)
+    result = authorize_dispatch(
+        _context_from_environment(),
+        api.permission,
+        api.commit,
+        api.pull_request,
+        api.merge_ref,
+        api.commit_parents,
+    )
     with output_path.open("a", encoding="utf-8") as output:
         for name in (
             "authorized",
             "backend_sha",
+            "routing_sha",
+            "pr_base_sha",
+            "pr_head_sha",
+            "pr_merge_sha",
             "frontend_ref",
             "frontend_sha",
             "workflow_sha",

--- a/.github/ci/collect-cranetestkit-artifacts.py
+++ b/.github/ci/collect-cranetestkit-artifacts.py
@@ -62,6 +62,13 @@ REDACTIONS = (
 ANSI_ESCAPE = re.compile(r"\x1b\[[0-?]*[ -/]*[@-~]")
 UNSAFE_CONTROLS = re.compile(r"[\x00-\x08\x0b\x0c\x0e-\x1f\x7f]")
 BIDI_CONTROLS = re.compile(r"[\u202a-\u202e\u2066-\u2069]")
+FULL_SHA = re.compile(r"^[0-9a-f]{40}$")
+
+
+def _full_sha(value: str) -> str:
+    if FULL_SHA.fullmatch(value) is None:
+        raise argparse.ArgumentTypeError("revision must be a full lowercase commit SHA")
+    return value
 
 
 def _sha256(path: Path) -> str:
@@ -587,6 +594,9 @@ def _write_summary(
     build_cache_hit: str | None = None,
     build_duration_seconds: float | None = None,
     execute_exit_code: int | None = None,
+    routing_sha: str | None = None,
+    pr_base_sha: str | None = None,
+    pr_head_sha: str | None = None,
 ) -> int | None:
     result = _read_run_json(run_root, Path("result.json"))
     state = _read_run_json(run_root, Path("state.json"))
@@ -886,6 +896,13 @@ def _write_summary(
         ("Started", result.get("started_at", "unavailable")),
         ("Finished", result.get("finished_at", "unavailable")),
     ]
+    if routing_sha is not None:
+        provenance_rows.insert(4, ("Workflow routing SHA", routing_sha))
+    if pr_head_sha is not None:
+        provenance_rows[4:4] = [
+            ("PR base SHA", pr_base_sha or "unavailable"),
+            ("PR head SHA", pr_head_sha),
+        ]
     lines.extend(["<details>", "<summary>Provenance</summary>", ""])
     _append_table(lines, ("Field", "Value"), provenance_rows)
     lines.extend(["", "</details>", ""])
@@ -909,7 +926,12 @@ def main() -> int:
     parser.add_argument("--build-cache-hit", choices=("true", "false"))
     parser.add_argument("--build-duration-seconds", type=float)
     parser.add_argument("--execute-exit-code", type=int, choices=(0, 1, 2))
+    parser.add_argument("--routing-sha", type=_full_sha)
+    parser.add_argument("--pr-base-sha", type=_full_sha)
+    parser.add_argument("--pr-head-sha", type=_full_sha)
     args = parser.parse_args()
+    if (args.pr_base_sha is None) != (args.pr_head_sha is None):
+        parser.error("PR base and head SHAs must be provided together")
 
     destination = args.destination.absolute()
     if destination.is_symlink():
@@ -929,6 +951,9 @@ def main() -> int:
         build_cache_hit=args.build_cache_hit,
         build_duration_seconds=args.build_duration_seconds,
         execute_exit_code=args.execute_exit_code,
+        routing_sha=args.routing_sha,
+        pr_base_sha=args.pr_base_sha,
+        pr_head_sha=args.pr_head_sha,
     )
     include_failure_logs = args.include_logs or summary_exit_code != 0
     if run_root.exists() and not run_root.is_symlink() and run_root.is_dir():
@@ -1001,6 +1026,11 @@ def main() -> int:
         "check_exit_code": (
             summary_exit_code if summary_exit_code in {0, 1, 2} else 2
         ),
+        "revision_routing": {
+            "routing_sha": args.routing_sha,
+            "pr_base_sha": args.pr_base_sha,
+            "pr_head_sha": args.pr_head_sha,
+        },
         "files": entries,
     }
     (destination / "artifact-manifest.json").write_text(

--- a/.github/ci/test_authorize.py
+++ b/.github/ci/test_authorize.py
@@ -20,6 +20,7 @@ SPEC.loader.exec_module(authorize)
 BACKEND_SHA = "a" * 40
 FRONTEND_SHA = "b" * 40
 WORKFLOW_SHA = "c" * 40
+MERGE_SHA = "d" * 40
 
 
 def _context(**overrides):
@@ -32,6 +33,11 @@ def _context(**overrides):
         "triggering_actor": "maintainer",
         "event_sha": WORKFLOW_SHA,
         "frontend_repository": "PKUHPC/CraneSched-FrontEnd",
+        "pr_number": "935",
+        "pr_base_repository": "PKUHPC/CraneSched",
+        "pr_base_ref": "master",
+        "pr_base_sha": WORKFLOW_SHA,
+        "pr_merge_sha": MERGE_SHA,
         "pr_head_repository": "PKUHPC/CraneSched",
         "pr_head_ref": "feature/test",
         "pr_head_sha": BACKEND_SHA,
@@ -41,21 +47,180 @@ def _context(**overrides):
 
 
 def _resolver(repository: str, ref: str) -> str | None:
-    if repository == "PKUHPC/CraneSched" and ref in {BACKEND_SHA, "master"}:
-        return BACKEND_SHA
+    if repository == "PKUHPC/CraneSched" and ref in {
+        BACKEND_SHA,
+        MERGE_SHA,
+        WORKFLOW_SHA,
+        "master",
+    }:
+        return BACKEND_SHA if ref == "master" else ref
     if repository == "PKUHPC/CraneSched-FrontEnd" and ref in {"feature/test", "master"}:
         return FRONTEND_SHA
     return None
 
 
+def _snapshot(**overrides) -> authorize.PullRequestSnapshot:
+    values = {
+        "number": 935,
+        "state": "open",
+        "draft": False,
+        "base_repository": "PKUHPC/CraneSched",
+        "base_ref": "master",
+        "base_sha": WORKFLOW_SHA,
+        "head_repository": "PKUHPC/CraneSched",
+        "head_ref": "feature/test",
+        "head_sha": BACKEND_SHA,
+        "merge_commit_sha": MERGE_SHA,
+        "mergeable": True,
+    }
+    values.update(overrides)
+    return authorize.PullRequestSnapshot(**values)
+
+
+def _pull_request(_repository: str, _number: int) -> authorize.PullRequestSnapshot:
+    return _snapshot()
+
+
+def _merge_ref(_repository: str, _number: int) -> str:
+    return MERGE_SHA
+
+
+def _commit_parents(_repository: str, _revision: str) -> tuple[str, ...]:
+    return (WORKFLOW_SHA, BACKEND_SHA)
+
+
+def _authorize(
+    context: authorize.DispatchContext | None = None,
+    *,
+    permission: str = "maintain",
+    resolver=_resolver,
+    pull_request_lookup=_pull_request,
+    merge_ref_resolver=_merge_ref,
+    commit_parents_resolver=_commit_parents,
+    retry_delays: tuple[float, ...] = (),
+) -> dict[str, str]:
+    return authorize.authorize_dispatch(
+        context or _context(),
+        lambda _repo, _actor: {"permission": permission},
+        resolver,
+        pull_request_lookup,
+        merge_ref_resolver,
+        commit_parents_resolver,
+        sleeper=lambda _delay: None,
+        retry_delays=retry_delays,
+    )
+
+
 class AuthorizationPolicyTest(unittest.TestCase):
     def test_same_repository_maintainer_pr_is_authorized(self) -> None:
-        result = authorize.authorize_dispatch(
-            _context(), lambda _repo, _actor: {"permission": "maintain"}, _resolver
-        )
+        result = _authorize()
         self.assertEqual(result["backend_sha"], BACKEND_SHA)
+        self.assertEqual(result["routing_sha"], MERGE_SHA)
+        self.assertEqual(result["pr_base_sha"], WORKFLOW_SHA)
+        self.assertEqual(result["pr_head_sha"], BACKEND_SHA)
+        self.assertEqual(result["pr_merge_sha"], MERGE_SHA)
         self.assertEqual(result["frontend_sha"], FRONTEND_SHA)
         self.assertEqual(result["workflow_sha"], WORKFLOW_SHA)
+
+    def test_missing_event_merge_sha_uses_verified_current_merge(self) -> None:
+        result = _authorize(_context(pr_merge_sha=""))
+
+        self.assertEqual(result["routing_sha"], MERGE_SHA)
+        self.assertEqual(result["pr_merge_sha"], MERGE_SHA)
+
+    def test_waits_for_github_to_compute_mergeability(self) -> None:
+        snapshots = iter(
+            [
+                _snapshot(mergeable=None, merge_commit_sha=""),
+                _snapshot(),
+                _snapshot(),
+            ]
+        )
+        delays: list[float] = []
+
+        result = authorize.authorize_dispatch(
+            _context(pr_merge_sha=""),
+            lambda _repo, _actor: {"permission": "admin"},
+            _resolver,
+            lambda _repo, _number: next(snapshots),
+            _merge_ref,
+            _commit_parents,
+            sleeper=delays.append,
+            retry_delays=(0.25,),
+        )
+
+        self.assertEqual(result["routing_sha"], MERGE_SHA)
+        self.assertEqual(delays, [0.25])
+
+    def test_mergeability_polling_is_bounded(self) -> None:
+        calls = 0
+
+        def pending(_repository: str, _number: int):
+            nonlocal calls
+            calls += 1
+            return _snapshot(mergeable=None, merge_commit_sha="")
+
+        with self.assertRaisesRegex(
+            authorize.AuthorizationError, "unable to resolve a stable proposed merge"
+        ):
+            _authorize(
+                _context(pr_merge_sha=""),
+                pull_request_lookup=pending,
+                retry_delays=(0.0, 0.0),
+            )
+
+        self.assertEqual(calls, 3)
+
+    def test_event_base_must_match_trusted_workflow_revision(self) -> None:
+        with self.assertRaisesRegex(
+            authorize.AuthorizationError, "trusted workflow revision"
+        ):
+            _authorize(_context(pr_base_sha="e" * 40))
+
+    def test_current_pr_snapshot_must_match_event(self) -> None:
+        with self.assertRaisesRegex(authorize.AuthorizationError, "changed"):
+            _authorize(
+                pull_request_lookup=lambda _repo, _number: _snapshot(
+                    head_sha="e" * 40
+                )
+            )
+
+    def test_unmergeable_pr_is_rejected(self) -> None:
+        with self.assertRaisesRegex(authorize.AuthorizationError, "no mergeable"):
+            _authorize(
+                pull_request_lookup=lambda _repo, _number: _snapshot(
+                    mergeable=False, merge_commit_sha=""
+                )
+            )
+
+    def test_event_merge_must_match_current_merge(self) -> None:
+        with self.assertRaisesRegex(authorize.AuthorizationError, "event proposed merge"):
+            _authorize(_context(pr_merge_sha="e" * 40))
+
+    def test_merge_ref_must_match_current_merge(self) -> None:
+        with self.assertRaisesRegex(authorize.AuthorizationError, "merge ref"):
+            _authorize(merge_ref_resolver=lambda _repo, _number: "e" * 40)
+
+    def test_merge_parents_are_exactly_base_then_head(self) -> None:
+        for parents in (
+            (BACKEND_SHA, WORKFLOW_SHA),
+            (WORKFLOW_SHA,),
+            (WORKFLOW_SHA, BACKEND_SHA, "e" * 40),
+        ):
+            with self.subTest(parents=parents), self.assertRaisesRegex(
+                authorize.AuthorizationError, "parents"
+            ):
+                _authorize(
+                    commit_parents_resolver=lambda _repo, _sha, value=parents: value
+                )
+
+    def test_second_snapshot_detects_authorization_race(self) -> None:
+        snapshots = iter([_snapshot(), _snapshot(head_sha="e" * 40)])
+
+        with self.assertRaisesRegex(authorize.AuthorizationError, "changed"):
+            _authorize(
+                pull_request_lookup=lambda _repo, _number: next(snapshots)
+            )
 
     def test_fork_is_rejected_before_permission_lookup(self) -> None:
         def unexpected_permission(_repo, _actor):
@@ -66,13 +231,14 @@ class AuthorizationPolicyTest(unittest.TestCase):
                 _context(pr_head_repository="external/fork"),
                 unexpected_permission,
                 _resolver,
+                _pull_request,
+                _merge_ref,
+                _commit_parents,
             )
 
     def test_non_maintainer_is_rejected(self) -> None:
         with self.assertRaisesRegex(authorize.AuthorizationError, "maintain or admin"):
-            authorize.authorize_dispatch(
-                _context(), lambda _repo, _actor: {"permission": "write"}, _resolver
-            )
+            _authorize(permission="write")
 
     def test_push_and_schedule_lock_backend_to_trusted_workflow_sha(self) -> None:
         def unexpected_permission(_repo, _actor):
@@ -93,6 +259,8 @@ class AuthorizationPolicyTest(unittest.TestCase):
                     resolver,
                 )
                 self.assertEqual(result["backend_sha"], WORKFLOW_SHA)
+                self.assertEqual(result["routing_sha"], WORKFLOW_SHA)
+                self.assertEqual(result["pr_base_sha"], "")
                 self.assertEqual(result["workflow_sha"], WORKFLOW_SHA)
 
     def test_non_default_workflow_ref_is_rejected(self) -> None:
@@ -105,6 +273,9 @@ class AuthorizationPolicyTest(unittest.TestCase):
                 ),
                 lambda _repo, _actor: {"permission": "admin"},
                 _resolver,
+                _pull_request,
+                _merge_ref,
+                _commit_parents,
             )
 
     def test_manual_dispatch_also_requires_maintainer(self) -> None:
@@ -117,16 +288,22 @@ class AuthorizationPolicyTest(unittest.TestCase):
 
     def test_missing_matching_frontend_branch_falls_back_to_master(self) -> None:
         def resolver(repository: str, ref: str) -> str | None:
-            if repository == "PKUHPC/CraneSched" and ref == BACKEND_SHA:
-                return BACKEND_SHA
+            if repository == "PKUHPC/CraneSched" and ref in {
+                BACKEND_SHA,
+                MERGE_SHA,
+            }:
+                return ref
             if repository == "PKUHPC/CraneSched-FrontEnd" and ref == "master":
                 return FRONTEND_SHA
             return None
 
-        result = authorize.authorize_dispatch(
+        result = _authorize(
             _context(pr_head_ref="backend-only-branch"),
-            lambda _repo, _actor: {"permission": "admin"},
-            resolver,
+            permission="admin",
+            resolver=resolver,
+            pull_request_lookup=lambda _repo, _number: _snapshot(
+                head_ref="backend-only-branch"
+            ),
         )
         self.assertEqual(result["frontend_ref"], "master")
         self.assertEqual(result["frontend_sha"], FRONTEND_SHA)
@@ -161,6 +338,79 @@ class GitHubApiTest(unittest.TestCase):
             side_effect=self._http_error(422),
         ), self.assertRaisesRegex(authorize.AuthorizationError, "HTTP 422"):
             api.permission("PKUHPC/CraneSched", "maintainer")
+
+    def test_pull_request_response_is_parsed_into_snapshot(self) -> None:
+        api = authorize.GitHubApi("test-token")
+        response = {
+            "number": 935,
+            "state": "open",
+            "draft": False,
+            "mergeable": True,
+            "merge_commit_sha": MERGE_SHA,
+            "base": {
+                "ref": "master",
+                "sha": WORKFLOW_SHA,
+                "repo": {"full_name": "PKUHPC/CraneSched"},
+            },
+            "head": {
+                "ref": "feature/test",
+                "sha": BACKEND_SHA,
+                "repo": {"full_name": "PKUHPC/CraneSched"},
+            },
+        }
+
+        with mock.patch.object(api, "_get", return_value=response):
+            snapshot = api.pull_request("PKUHPC/CraneSched", 935)
+
+        self.assertEqual(snapshot, _snapshot())
+
+    def test_pull_request_allows_pending_merge_fields(self) -> None:
+        api = authorize.GitHubApi("test-token")
+        response = {
+            "number": 935,
+            "state": "open",
+            "draft": False,
+            "mergeable": None,
+            "merge_commit_sha": None,
+            "base": {
+                "ref": "master",
+                "sha": WORKFLOW_SHA,
+                "repo": {"full_name": "PKUHPC/CraneSched"},
+            },
+            "head": {
+                "ref": "feature/test",
+                "sha": BACKEND_SHA,
+                "repo": {"full_name": "PKUHPC/CraneSched"},
+            },
+        }
+
+        with mock.patch.object(api, "_get", return_value=response):
+            snapshot = api.pull_request("PKUHPC/CraneSched", 935)
+
+        self.assertIsNone(snapshot.mergeable)
+        self.assertEqual(snapshot.merge_commit_sha, "")
+
+    def test_merge_ref_and_commit_parents_are_parsed(self) -> None:
+        api = authorize.GitHubApi("test-token")
+        with mock.patch.object(
+            api, "_get", return_value={"object": {"sha": MERGE_SHA}}
+        ) as get:
+            self.assertEqual(api.merge_ref("PKUHPC/CraneSched", 935), MERGE_SHA)
+        self.assertEqual(
+            get.call_args.args[0],
+            "repos/PKUHPC/CraneSched/git/ref/pull/935/merge",
+        )
+        with mock.patch.object(
+            api,
+            "_get",
+            return_value={
+                "parents": [{"sha": WORKFLOW_SHA}, {"sha": BACKEND_SHA}]
+            },
+        ):
+            self.assertEqual(
+                api.commit_parents("PKUHPC/CraneSched", MERGE_SHA),
+                (WORKFLOW_SHA, BACKEND_SHA),
+            )
 
 
 if __name__ == "__main__":

--- a/.github/ci/test_collect_cranetestkit_artifacts.py
+++ b/.github/ci/test_collect_cranetestkit_artifacts.py
@@ -29,6 +29,9 @@ class ArtifactCollectionTest(unittest.TestCase):
         cache_hit: str | None = None,
         build_duration: float | None = None,
         execute_exit_code: int | None = None,
+        routing_sha: str | None = None,
+        pr_base_sha: str | None = None,
+        pr_head_sha: str | None = None,
     ) -> None:
         command = [
             sys.executable,
@@ -48,6 +51,12 @@ class ArtifactCollectionTest(unittest.TestCase):
             command.extend(("--build-duration-seconds", str(build_duration)))
         if execute_exit_code is not None:
             command.extend(("--execute-exit-code", str(execute_exit_code)))
+        if routing_sha is not None:
+            command.extend(("--routing-sha", routing_sha))
+        if pr_base_sha is not None:
+            command.extend(("--pr-base-sha", pr_base_sha))
+        if pr_head_sha is not None:
+            command.extend(("--pr-head-sha", pr_head_sha))
         subprocess.run(command, check=True)
 
     @staticmethod
@@ -311,6 +320,47 @@ class ArtifactCollectionTest(unittest.TestCase):
             )
             self.assertEqual(manifest["check_exit_code"], 0)
             self.assertFalse(manifest["failure_logs_included"])
+
+    def test_revision_routing_is_preserved_in_summary_and_manifest(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary:
+            root = Path(temporary)
+            cases = [self._case("1.0.0.1", "passed", 1.0)]
+            run_root = self._run(
+                root,
+                cases,
+                exit_code=0,
+                shards=[cases],
+                workers={"wrl02": [0]},
+            )
+            self._checkpoint(run_root, "wrl02", 0, 0, cases, exit_code=0)
+            destination = root / "artifact"
+            routing_sha = "d" * 40
+            base_sha = "e" * 40
+            head_sha = "f" * 40
+
+            self._collect(
+                run_root,
+                destination,
+                routing_sha=routing_sha,
+                pr_base_sha=base_sha,
+                pr_head_sha=head_sha,
+            )
+
+            summary = (destination / "summary.md").read_text(encoding="utf-8")
+            self.assertIn(f"`{routing_sha}`", summary)
+            self.assertIn(f"`{base_sha}`", summary)
+            self.assertIn(f"`{head_sha}`", summary)
+            manifest = json.loads(
+                (destination / "artifact-manifest.json").read_text(encoding="utf-8")
+            )
+            self.assertEqual(
+                manifest["revision_routing"],
+                {
+                    "routing_sha": routing_sha,
+                    "pr_base_sha": base_sha,
+                    "pr_head_sha": head_sha,
+                },
+            )
 
     def test_exit_one_summary_reports_failed_and_error_cases(self) -> None:
         with tempfile.TemporaryDirectory() as temporary:

--- a/.github/ci/test_format_workflow.py
+++ b/.github/ci/test_format_workflow.py
@@ -1,0 +1,99 @@
+from __future__ import annotations
+
+import re
+import unittest
+from pathlib import Path
+
+
+WORKFLOW = Path(__file__).parents[1] / "workflows" / "format.yaml"
+
+
+class FormatWorkflowContractTest(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls) -> None:
+        cls.workflow = WORKFLOW.read_text(encoding="utf-8")
+
+    def test_keeps_pull_request_triggers_and_paths(self) -> None:
+        for event_type in ("opened", "synchronize", "reopened", "ready_for_review"):
+            self.assertRegex(self.workflow, rf"(?m)^      - {event_type}$")
+        for path in (
+            "'.clang-format*'",
+            "'.github/workflows/**'",
+            "'dependencies/**'",
+            "'CMakeModule/**'",
+            "'protos/**'",
+            "'src/**'",
+            "'test/**'",
+            "'CMakeLists.txt'",
+            "'VERSION'",
+        ):
+            self.assertIn(f"      - {path}", self.workflow)
+
+    def test_uses_read_only_permissions_and_no_git_write_path(self) -> None:
+        self.assertRegex(self.workflow, r"(?m)^permissions:\n  contents: read$")
+        self.assertNotIn("contents: write", self.workflow)
+        self.assertNotIn("secrets.", self.workflow)
+        self.assertNotIn("GITHUB_TOKEN", self.workflow)
+        self.assertNotIn("self-hosted", self.workflow)
+        for command in ("git add", "git commit", "git config", "git push", "git checkout"):
+            self.assertNotIn(command, self.workflow)
+
+    def test_checks_exact_pull_request_head_without_persisting_credentials(self) -> None:
+        checkout = self._step("Checkout pull request head")
+        self.assertIn(
+            "uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5",
+            checkout,
+        )
+        self.assertIn(
+            "repository: ${{ github.event.pull_request.head.repo.full_name }}", checkout
+        )
+        self.assertIn("ref: ${{ github.event.pull_request.head.sha }}", checkout)
+        self.assertIn("fetch-depth: 1", checkout)
+        self.assertIn("persist-credentials: false", checkout)
+
+    def test_format_step_is_local_only_and_produces_a_patch(self) -> None:
+        step = self._step("Check clang-format and prepare patch")
+        self.assertIn("continue-on-error: true", step)
+        self.assertIn("--dry-run --Werror", step)
+        self.assertIn("-print0", step)
+        self.assertIn("clang-format-20 -i", step)
+        self.assertIn("git diff --binary -- src protos > format.patch", step)
+        self.assertIn("changed=true", step)
+
+    def test_uploads_patch_for_both_repository_origins(self) -> None:
+        step = self._step("Upload format patch")
+        self.assertIn(
+            "uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6",
+            step,
+        )
+        self.assertIn("if: always() && steps.format.outputs.changed == 'true'", step)
+        self.assertNotIn("head.repo.full_name != github.repository", step)
+        self.assertIn("if-no-files-found: error", step)
+        self.assertIn("retention-days: 3", step)
+
+    def test_failure_gate_runs_after_artifact_upload(self) -> None:
+        upload_start = self.workflow.index("- name: Upload format patch")
+        gate_start = self.workflow.index("- name: Fail when formatting is required")
+        self.assertLess(upload_start, gate_start)
+        gate = self.workflow[gate_start:]
+        self.assertIn("steps.format.outputs.changed == 'true'", gate)
+        self.assertIn("steps.format.outcome == 'failure'", gate)
+        self.assertRegex(gate, r"(?m)^          exit 1$")
+
+    def test_keeps_required_check_identity_and_serializes_pr_runs(self) -> None:
+        self.assertIn("name: Clang Format Check", self.workflow)
+        self.assertRegex(self.workflow, r"(?m)^  format:\s*$")
+        self.assertIn("group: clang-format-pr-${{ github.event.pull_request.number }}", self.workflow)
+        self.assertIn("cancel-in-progress: true", self.workflow)
+
+    def _step(self, name: str) -> str:
+        match = re.search(
+            rf"(?ms)^      - name: {re.escape(name)}\n(.*?)(?=^      - name:|\Z)",
+            self.workflow,
+        )
+        self.assertIsNotNone(match, f"workflow step not found: {name}")
+        return match.group(0) if match else ""
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/.github/ci/test_validate_workflow_routing.py
+++ b/.github/ci/test_validate_workflow_routing.py
@@ -123,7 +123,8 @@ class WorkflowRoutingPolicyTest(unittest.TestCase):
         workflow = WORKFLOW_PATH.read_text(encoding="utf-8")
         condition = "if: steps.authorize.outputs.authorized == 'true'"
         for step_name in (
-            "Checkout candidate workflow routing",
+            "Checkout proposed merge workflow routing",
+            "Verify proposed merge routing revision",
             "Validate repository runner routing",
         ):
             with self.subTest(step_name=step_name):
@@ -132,6 +133,51 @@ class WorkflowRoutingPolicyTest(unittest.TestCase):
                 if next_step == -1:
                     next_step = len(workflow)
                 self.assertIn(condition, workflow[step:next_step])
+
+    def test_candidate_checkout_uses_routing_output_and_parent_guard(self) -> None:
+        workflow = WORKFLOW_PATH.read_text(encoding="utf-8")
+        checkout = workflow.index("- name: Checkout proposed merge workflow routing")
+        checkout_end = workflow.find("\n      - name:", checkout + 1)
+        if checkout_end == -1:
+            checkout_end = len(workflow)
+        checkout_block = workflow[checkout:checkout_end]
+        self.assertIn("ref: ${{ steps.authorize.outputs.routing_sha }}", checkout_block)
+        self.assertIn("fetch-depth: 2", checkout_block)
+
+        verify = workflow.index("- name: Verify proposed merge routing revision")
+        verify_end = workflow.find("\n      - name:", verify + 1)
+        if verify_end == -1:
+            verify_end = len(workflow)
+        verify_block = workflow[verify:verify_end]
+        self.assertIn("git -C candidate-routing rev-parse HEAD", verify_block)
+        self.assertIn("git -C candidate-routing rev-list --parents", verify_block)
+        self.assertIn("PR_BASE_SHA", verify_block)
+        self.assertIn("PR_HEAD_SHA", verify_block)
+
+    def test_pr_build_still_uses_backend_head_output(self) -> None:
+        workflow = WORKFLOW_PATH.read_text(encoding="utf-8")
+        self.assertIn(
+            "ref: ${{ needs.authorize.outputs.backend_sha }}",
+            workflow,
+        )
+
+    def test_stale_head_is_not_used_as_routing_input(self) -> None:
+        stale_head = self.workflows_dir / "stale-head"
+        merged_tree = self.workflows_dir / "merged-tree"
+        stale_head.mkdir()
+        merged_tree.mkdir()
+        (stale_head / "build.yaml").write_text(
+            "jobs:\n  test:\n    runs-on: [self-hosted, CraneSched]\n",
+            encoding="utf-8",
+        )
+        (merged_tree / "build.yaml").write_text(
+            "jobs:\n  test:\n    runs-on: [self-hosted, cranesystemtest]\n",
+            encoding="utf-8",
+        )
+
+        with self.assertRaises(routing.RoutingPolicyError):
+            routing.validate_workflow_routing(stale_head)
+        routing.validate_workflow_routing(merged_tree)
 
 
 if __name__ == "__main__":

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -62,6 +62,10 @@ jobs:
     outputs:
       authorized: ${{ steps.authorize.outputs.authorized }}
       backend_sha: ${{ steps.authorize.outputs.backend_sha }}
+      routing_sha: ${{ steps.authorize.outputs.routing_sha }}
+      pr_base_sha: ${{ steps.authorize.outputs.pr_base_sha }}
+      pr_head_sha: ${{ steps.authorize.outputs.pr_head_sha }}
+      pr_merge_sha: ${{ steps.authorize.outputs.pr_merge_sha }}
       frontend_ref: ${{ steps.authorize.outputs.frontend_ref }}
       frontend_sha: ${{ steps.authorize.outputs.frontend_sha }}
       workflow_sha: ${{ steps.authorize.outputs.workflow_sha }}
@@ -85,6 +89,11 @@ jobs:
           WORKFLOW_REF: ${{ github.workflow_ref }}
           TRIGGERING_ACTOR: ${{ github.triggering_actor }}
           EVENT_SHA: ${{ github.sha }}
+          PR_NUMBER: ${{ github.event.pull_request.number || '' }}
+          PR_BASE_REPOSITORY: ${{ github.event.pull_request.base.repo.full_name || '' }}
+          PR_BASE_REF: ${{ github.event.pull_request.base.ref || '' }}
+          PR_BASE_SHA: ${{ github.event.pull_request.base.sha || '' }}
+          PR_MERGE_SHA: ${{ github.event.pull_request.merge_commit_sha || '' }}
           PR_HEAD_REPOSITORY: ${{ github.event.pull_request.head.repo.full_name || '' }}
           PR_HEAD_REF: ${{ github.event.pull_request.head.ref || '' }}
           PR_HEAD_SHA: ${{ github.event.pull_request.head.sha || '' }}
@@ -93,16 +102,35 @@ jobs:
           FRONTEND_REPOSITORY: PKUHPC/CraneSched-FrontEnd
         run: /usr/bin/python3 -I trusted-ci/.github/ci/authorize.py
 
-      - name: Checkout candidate workflow routing
+      - name: Checkout proposed merge workflow routing
         if: steps.authorize.outputs.authorized == 'true'
         uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
         with:
-          ref: ${{ steps.authorize.outputs.backend_sha }}
+          ref: ${{ steps.authorize.outputs.routing_sha }}
           path: candidate-routing
+          fetch-depth: 2
           sparse-checkout: .github/workflows
           persist-credentials: false
           clean: true
           set-safe-directory: false
+
+      - name: Verify proposed merge routing revision
+        if: steps.authorize.outputs.authorized == 'true'
+        env:
+          ROUTING_SHA: ${{ steps.authorize.outputs.routing_sha }}
+          PR_BASE_SHA: ${{ steps.authorize.outputs.pr_base_sha }}
+          PR_HEAD_SHA: ${{ steps.authorize.outputs.pr_head_sha }}
+        run: |
+          set -euo pipefail
+          actual="$(git -C candidate-routing rev-parse HEAD)"
+          [[ "$actual" == "$ROUTING_SHA" ]]
+          if [[ -n "$PR_BASE_SHA" || -n "$PR_HEAD_SHA" ]]; then
+            [[ -n "$PR_BASE_SHA" && -n "$PR_HEAD_SHA" ]]
+            read -r -a commit_fields <<< "$(git -C candidate-routing rev-list --parents -n 1 HEAD)"
+            [[ "${#commit_fields[@]}" -eq 3 ]]
+            [[ "${commit_fields[1]}" == "$PR_BASE_SHA" ]]
+            [[ "${commit_fields[2]}" == "$PR_HEAD_SHA" ]]
+          fi
 
       - name: Validate repository runner routing
         if: steps.authorize.outputs.authorized == 'true'
@@ -136,6 +164,10 @@ jobs:
       CRANETESTKIT_CCACHE_DIR: ${{ vars.CRANETESTKIT_CCACHE_DIR }}
       CRANETESTKIT_FETCHCONTENT_DIR: ${{ vars.CRANETESTKIT_FETCHCONTENT_DIR }}
       BACKEND_SHA: ${{ needs.authorize.outputs.backend_sha }}
+      ROUTING_SHA: ${{ needs.authorize.outputs.routing_sha }}
+      PR_BASE_SHA: ${{ needs.authorize.outputs.pr_base_sha }}
+      PR_HEAD_SHA: ${{ needs.authorize.outputs.pr_head_sha }}
+      PR_MERGE_SHA: ${{ needs.authorize.outputs.pr_merge_sha }}
       FRONTEND_SHA: ${{ needs.authorize.outputs.frontend_sha }}
       FRONTEND_REF: ${{ needs.authorize.outputs.frontend_ref }}
     defaults:
@@ -162,6 +194,20 @@ jobs:
             echo "Trusted CI control checkout resolved to an unexpected commit." >&2
             exit 2
           fi
+
+      - name: Record revision routing provenance
+        run: |
+          {
+            echo "### CI revision routing"
+            echo "- Backend test SHA: \`$BACKEND_SHA\`"
+            if [[ -n "$PR_HEAD_SHA" ]]; then
+              echo "- PR base SHA: \`$PR_BASE_SHA\`"
+              echo "- PR head SHA: \`$PR_HEAD_SHA\`"
+              echo "- Proposed merge routing SHA: \`$ROUTING_SHA\`"
+            else
+              echo "- Workflow routing SHA: \`$ROUTING_SHA\`"
+            fi
+          } >> "$GITHUB_STEP_SUMMARY"
 
       - name: Validate deployment variables
         env:
@@ -393,6 +439,10 @@ jobs:
           fi
           if [[ "$BUILD_DURATION_SECONDS" =~ ^[0-9]+([.][0-9]+)?$ ]]; then
             arguments+=(--build-duration-seconds "$BUILD_DURATION_SECONDS")
+          fi
+          arguments+=(--routing-sha "$ROUTING_SHA")
+          if [[ -n "$PR_HEAD_SHA" ]]; then
+            arguments+=(--pr-base-sha "$PR_BASE_SHA" --pr-head-sha "$PR_HEAD_SHA")
           fi
           /usr/bin/python3 -I trusted-ci/.github/ci/collect-cranetestkit-artifacts.py "${arguments[@]}"
           check_exit_code="$(

--- a/.github/workflows/format.yaml
+++ b/.github/workflows/format.yaml
@@ -20,77 +20,139 @@ on:
       - 'CMakeLists.txt'
       - 'VERSION'
 
+permissions:
+  contents: read
+
+concurrency:
+  group: clang-format-pr-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
 jobs:
   format:
     if: github.event_name == 'pull_request' && github.event.pull_request.draft == false
     runs-on: ubuntu-latest
 
     steps:
-      - name: Checkout repository
-        uses: actions/checkout@v5
+      - name: Checkout pull request head
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
         with:
-          fetch-depth: 0
-          token: ${{ secrets.GITHUB_TOKEN }}
+          repository: ${{ github.event.pull_request.head.repo.full_name }}
+          ref: ${{ github.event.pull_request.head.sha }}
+          fetch-depth: 1
+          persist-credentials: false
 
-      - name: Switch to current branch
-        if: github.event.pull_request.head.repo.full_name == github.repository
-        run: |
-          echo "Switching to branch: ${GITHUB_HEAD_REF}"
-          git checkout "${GITHUB_HEAD_REF}"
-
-      - name: Set up Git identity
-        run: |
-          git config --global user.name "github-actions[bot]"
-          git config --global user.email "github-actions[bot]@users.noreply.github.com"
       - name: Install latest Clang-Format
         run: |
+          set -euo pipefail
           sudo apt-get install -y wget lsb-release
           sudo wget -O /tmp/llvm.sh https://apt.llvm.org/llvm.sh
           sudo bash /tmp/llvm.sh 20
           sudo apt update
           sudo apt-get install clang-format-20
 
-      - name: Run clang-format and apply changes
+      - name: Check clang-format and prepare patch
+        id: format
+        continue-on-error: true
+        shell: bash
         run: |
-          find src -type f \( -name "*.cpp" -o -name "*.h" \) | while read -r file; do
-            clang-format-20 -i --style=file "$file"
-          done
-          find protos -type f -name "*.proto" | while read -r file; do
-            clang-format-20 -i --style=file:.clang-format-proto "$file"
-          done
+          set -euo pipefail
 
-          if ! git diff --quiet; then
-            echo "FORMATED=true" >> $GITHUB_ENV
-          else
-            echo "No formatting changes were necessary."
+          mapfile -d '' -t cpp_files < <(
+            find src -type f \( -name '*.cpp' -o -name '*.h' \) -print0
+          )
+          mapfile -d '' -t proto_files < <(
+            find protos -type f -name '*.proto' -print0
+          )
+
+          cpp_check_status=0
+          proto_check_status=0
+          if ((${#cpp_files[@]})); then
+            if clang-format-20 --dry-run --Werror --style=file "${cpp_files[@]}"; then
+              cpp_check_status=0
+            else
+              cpp_check_status=$?
+            fi
+          fi
+          if ((${#proto_files[@]})); then
+            if clang-format-20 --dry-run --Werror --style=file:.clang-format-proto \
+              "${proto_files[@]}"; then
+              proto_check_status=0
+            else
+              proto_check_status=$?
+            fi
           fi
 
-      - name: Commit formatting changes
-        if: github.event.pull_request.head.repo.full_name == github.repository && env.FORMATED == 'true'
-        run: |
-          git add .
-          git commit -m "style: auto format with clang-format."
-          git push
-          echo "Commit format."
-
-      - name: Generate diff
-        if: env.FORMATED == 'true'
-        run: |
-          if ! git diff --quiet; then
-            git diff  > format.patch
-          else
-            echo "No formatting changes were necessary."
+          if ((cpp_check_status == 0 && proto_check_status == 0)); then
+            echo 'changed=false' >> "$GITHUB_OUTPUT"
+            echo 'All files are formatted.'
+            exit 0
           fi
 
-      - name: Upload diff
-        if: github.event.pull_request.head.repo.full_name != github.repository && env.FORMATED == 'true'
-        uses: actions/upload-artifact@v6
+          cpp_format_status=0
+          proto_format_status=0
+          if ((cpp_check_status != 0 && ${#cpp_files[@]})); then
+            if clang-format-20 -i --style=file "${cpp_files[@]}"; then
+              cpp_format_status=0
+            else
+              cpp_format_status=$?
+            fi
+          fi
+          if ((proto_check_status != 0 && ${#proto_files[@]})); then
+            if clang-format-20 -i --style=file:.clang-format-proto "${proto_files[@]}"; then
+              proto_format_status=0
+            else
+              proto_format_status=$?
+            fi
+          fi
+
+          if ((cpp_format_status != 0 || proto_format_status != 0)); then
+            echo 'changed=false' >> "$GITHUB_OUTPUT"
+            echo '::error::clang-format could not produce a formatting patch.'
+            exit 1
+          fi
+
+          if git diff --quiet -- src protos; then
+            echo 'changed=false' >> "$GITHUB_OUTPUT"
+            echo '::error::clang-format reported an error without changing source files.'
+            exit 1
+          fi
+
+          git diff --binary -- src protos > format.patch
+          if [[ ! -s format.patch ]]; then
+            echo 'changed=false' >> "$GITHUB_OUTPUT"
+            echo '::error::clang-format produced an empty patch.'
+            exit 1
+          fi
+
+          echo 'changed=true' >> "$GITHUB_OUTPUT"
+          {
+            echo '### Clang format check failed'
+            echo
+            echo 'The checkout was not modified remotely. Download `format-diff` and run:'
+            echo
+            echo '```bash'
+            echo 'git apply format.patch'
+            echo '```'
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Upload format patch
+        if: always() && steps.format.outputs.changed == 'true'
+        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6
         with:
           name: format-diff
           path: format.patch
+          if-no-files-found: error
+          retention-days: 3
 
-      - name: Alert on formated for forked repo
-        if: github.event.pull_request.head.repo.full_name != github.repository && env.FORMATED == 'true'
+      - name: Fail when formatting is required
+        if: always() && (steps.format.outputs.changed == 'true' || steps.format.outcome == 'failure')
+        env:
+          FORMAT_CHANGED: ${{ steps.format.outputs.changed }}
+          FORMAT_OUTCOME: ${{ steps.format.outcome }}
         run: |
-          echo "Please download the patch and apply to format your code."
+          if [[ "$FORMAT_CHANGED" == 'true' ]]; then
+            echo 'Formatting changes are required; see the format-diff artifact.'
+          else
+            echo "clang-format check failed before a patch could be prepared (outcome: $FORMAT_OUTCOME)."
+          fi
           exit 1


### PR DESCRIPTION
## Summary

- validate privileged runner routing against GitHub's exact proposed merge tree while continuing to build and test the PR head SHA
- fail closed on stale PR snapshots, unresolved mergeability, merge-ref drift, or unexpected merge parents
- make the Clang Format check read-only and upload an applicable patch instead of pushing a bot commit
- retain PR base, head, and workflow-routing SHAs in the sanitized CI summary and artifact manifest

## Root cause

The trusted dispatcher previously inspected `.github/workflows` at the raw PR head. A code-only branch created before the runner-policy migration therefore carried an old `build.yaml` and was rejected even though the proposed merge tree inherited the current trusted workflow from `master`.

The format workflow also pushed fixes with `GITHUB_TOKEN`. That created a new bot-authored head without a corresponding privileged `pull_request_target` run, so the final PR head could lack the K3s `test` check.

## Security boundary

The hosted job still executes only controls from `master`. For PRs it verifies the current API snapshot, `refs/pull/<number>/merge`, and the exact `[base, head]` merge parents before treating the sparse workflow checkout as data. Forks and non-maintainers remain unable to dispatch `cranesystemtest`; only `build.yaml:test` may use the dedicated label. The actual Backend build remains pinned to the PR head SHA.

The format workflow now has only `contents: read`, checks the exact head SHA on `ubuntu-latest`, persists no credentials, and never commits or pushes.

## Validation

- `83` CI policy/artifact unit tests passed
- Ruff passed for all modified Python files
- actionlint `v1.7.12` passed for `build.yaml` and `format.yaml`
- YAML parsing and `git diff --check` passed
- live GitHub API authorization smoke test resolved and verified PR #935's proposed merge
- recovery run `29755496139` passed on `cranesystemtest`: `459/459`, exit code `0`, complete coverage, system execute `655.26s`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added stronger pull request validation to ensure CI tests the correct proposed merge revision.
  * Added revision provenance details to workflow summaries and collected artifacts for easier review.
  * Formatting checks now provide a downloadable patch when changes are required.

* **Bug Fixes**
  * Improved safeguards against stale, conflicting, symlinked, or incorrectly routed workflow revisions.
  * Formatting checks now use read-only permissions and reliably fail when formatting changes are needed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->