### PR TITLE
fix(ci): tolerate stale reopened PR routing hints

### DIFF
--- a/.github/ci/README.md
+++ b/.github/ci/README.md
@@ -23,7 +23,14 @@ dispatches `test`. For a pull request, it resolves the exact PR head SHA for
 the build, then obtains GitHub's proposed merge commit only for this static
 routing check. The merge commit must have exactly the event's base and head
 commits as parents, in that order; a stale or conflicting snapshot fails
-closed. It checks that only `.github/workflows/build.yaml` contains the exact
+closed. GitHub can retain stale base and proposed-merge SHAs in a `reopened`
+event payload after `master` advances, so those payload values are syntax
+checked but are not authorization inputs. The trusted base is the
+`pull_request_target` workflow SHA; the current PR API base and the proposed
+merge's first parent must both equal it. The current API head and second parent
+must equal the event head, while the API merge SHA and merge ref must agree.
+These current values are checked twice with bounded retries before dispatch.
+It checks that only `.github/workflows/build.yaml` contains the exact
 `cranesystemtest` token. The check runs trusted code from `master` and treats
 the proposed workflow files only as data. The privileged job still builds and
 tests the PR head SHA, not the temporary merge commit. Protect

--- a/.github/ci/authorize.py
+++ b/.github/ci/authorize.py
@@ -62,6 +62,7 @@ class PullRequestSnapshot:
     head_sha: str
     merge_commit_sha: str
     mergeable: bool | None
+    mergeable_state: str
 
 
 PullRequestLookup = Callable[[str, int], PullRequestSnapshot]
@@ -119,10 +120,6 @@ def _validate_pr_event(context: DispatchContext) -> int:
         raise AuthorizationError("pull request base branch is not master")
     if not SHA_RE.fullmatch(context.pr_base_sha):
         raise AuthorizationError("pull request base is not a full commit SHA")
-    if context.event_sha != context.pr_base_sha:
-        raise AuthorizationError(
-            "trusted workflow revision does not match the pull request base"
-        )
     if not SHA_RE.fullmatch(context.pr_head_sha):
         raise AuthorizationError("pull request head is not a full commit SHA")
     if not context.pr_head_ref or any(
@@ -146,7 +143,6 @@ def _validate_pr_snapshot(
     if (
         snapshot.base_repository != context.pr_base_repository
         or snapshot.base_ref != context.pr_base_ref
-        or snapshot.base_sha != context.pr_base_sha
         or snapshot.head_repository != context.pr_head_repository
         or snapshot.head_ref != context.pr_head_ref
         or snapshot.head_sha != context.pr_head_sha
@@ -172,17 +168,19 @@ def _resolve_pr_merge(
     for attempt in range(attempts):
         snapshot = pull_request_lookup(context.repository, number)
         _validate_pr_snapshot(context, number, snapshot)
-        if snapshot.mergeable is False:
-            raise AuthorizationError("pull request has no mergeable proposed result")
-
-        merge_sha = snapshot.merge_commit_sha
-        if snapshot.mergeable is not True or not SHA_RE.fullmatch(merge_sha):
-            pending_reason = "GitHub has not computed the proposed merge"
-        elif context.pr_merge_sha and context.pr_merge_sha != merge_sha:
-            raise AuthorizationError(
-                "event proposed merge does not match the current pull request"
+        if snapshot.base_sha != context.event_sha:
+            pending_reason = (
+                "the current pull request base has not converged to the trusted "
+                "workflow revision"
             )
+        elif snapshot.mergeable is False:
+            raise AuthorizationError("pull request has no mergeable proposed result")
+        elif snapshot.mergeable is not True or not SHA_RE.fullmatch(
+            snapshot.merge_commit_sha
+        ):
+            pending_reason = "GitHub has not computed the proposed merge"
         else:
+            merge_sha = snapshot.merge_commit_sha
             merge_ref_sha = merge_ref_resolver(context.repository, number)
             if merge_ref_sha != merge_sha:
                 pending_reason = "the pull request merge ref is not synchronized"
@@ -190,27 +188,37 @@ def _resolve_pr_merge(
                 parents = commit_parents_resolver(context.repository, merge_sha)
                 if parents is None:
                     pending_reason = "the proposed merge commit is not available"
-                elif parents != (context.pr_base_sha, context.pr_head_sha):
+                elif parents != (context.event_sha, context.pr_head_sha):
                     raise AuthorizationError(
-                        "proposed merge parents do not match the event base and head"
+                        "proposed merge parents do not match the trusted base and "
+                        "event head"
                     )
                 else:
                     final_snapshot = pull_request_lookup(context.repository, number)
                     _validate_pr_snapshot(context, number, final_snapshot)
-                    final_ref_sha = merge_ref_resolver(context.repository, number)
-                    if (
-                        final_snapshot.mergeable is True
-                        and final_snapshot.merge_commit_sha == merge_sha
-                        and final_ref_sha == merge_sha
-                    ):
-                        return merge_sha
-                    if final_snapshot.mergeable is False:
+                    if final_snapshot.base_sha != context.event_sha:
+                        raise AuthorizationError(
+                            "pull request base changed during authorization; wait for "
+                            "the new run"
+                        )
+                    elif final_snapshot.mergeable is False:
                         raise AuthorizationError(
                             "pull request has no mergeable proposed result"
                         )
-                    pending_reason = (
-                        "the proposed merge changed during authorization"
-                    )
+                    elif (
+                        final_snapshot.mergeable is True
+                        and final_snapshot.merge_commit_sha == merge_sha
+                    ):
+                        final_ref_sha = merge_ref_resolver(context.repository, number)
+                        if final_ref_sha == merge_sha:
+                            return merge_sha
+                        pending_reason = (
+                            "the pull request merge ref changed during authorization"
+                        )
+                    else:
+                        pending_reason = (
+                            "the proposed merge changed during authorization"
+                        )
 
         if attempt < len(retry_delays):
             sleeper(retry_delays[attempt])
@@ -265,7 +273,7 @@ def authorize_dispatch(
             sleeper=sleeper,
             retry_delays=retry_delays,
         )
-        pr_base_sha = context.pr_base_sha
+        pr_base_sha = context.event_sha
         pr_head_sha = context.pr_head_sha
         pr_merge_sha = routing_sha
         frontend_ref = context.pr_head_ref
@@ -409,6 +417,7 @@ class GitHubApi:
         state = value.get("state")
         draft = value.get("draft")
         mergeable = value.get("mergeable")
+        mergeable_state = value.get("mergeable_state")
         merge_commit_sha = value.get("merge_commit_sha")
         fields = (
             base_repository.get("full_name"),
@@ -423,10 +432,12 @@ class GitHubApi:
             or isinstance(actual_number, bool)
             or not isinstance(state, str)
             or not isinstance(draft, bool)
-            or mergeable is not None
-            and not isinstance(mergeable, bool)
-            or merge_commit_sha is not None
-            and not isinstance(merge_commit_sha, str)
+            or (mergeable is not None and not isinstance(mergeable, bool))
+            or not isinstance(mergeable_state, str)
+            or (
+                merge_commit_sha is not None
+                and not isinstance(merge_commit_sha, str)
+            )
             or any(not isinstance(field, str) for field in fields)
         ):
             raise AuthorizationError("GitHub pull request response is malformed")
@@ -443,6 +454,7 @@ class GitHubApi:
             head_sha=fields[5],
             merge_commit_sha=merge_commit_sha or "",
             mergeable=mergeable,
+            mergeable_state=mergeable_state,
         )
 
     def merge_ref(self, repository: str, number: int) -> str | None:

--- a/.github/ci/test_authorize.py
+++ b/.github/ci/test_authorize.py
@@ -72,6 +72,7 @@ def _snapshot(**overrides) -> authorize.PullRequestSnapshot:
         "head_sha": BACKEND_SHA,
         "merge_commit_sha": MERGE_SHA,
         "mergeable": True,
+        "mergeable_state": "blocked",
     }
     values.update(overrides)
     return authorize.PullRequestSnapshot(**values)
@@ -128,6 +129,61 @@ class AuthorizationPolicyTest(unittest.TestCase):
         self.assertEqual(result["routing_sha"], MERGE_SHA)
         self.assertEqual(result["pr_merge_sha"], MERGE_SHA)
 
+    def test_stale_event_base_and_merge_hints_use_current_api_snapshot(self) -> None:
+        result = _authorize(
+            _context(pr_base_sha="e" * 40, pr_merge_sha="f" * 40)
+        )
+
+        self.assertEqual(result["backend_sha"], BACKEND_SHA)
+        self.assertEqual(result["routing_sha"], MERGE_SHA)
+        self.assertEqual(result["pr_base_sha"], WORKFLOW_SHA)
+        self.assertEqual(result["pr_head_sha"], BACKEND_SHA)
+        self.assertEqual(result["pr_merge_sha"], MERGE_SHA)
+
+    def test_waits_for_api_base_to_converge_to_trusted_workflow(self) -> None:
+        snapshots = iter(
+            [
+                _snapshot(base_sha="e" * 40),
+                _snapshot(),
+                _snapshot(),
+            ]
+        )
+        delays: list[float] = []
+
+        result = authorize.authorize_dispatch(
+            _context(pr_base_sha="e" * 40, pr_merge_sha="f" * 40),
+            lambda _repo, _actor: {"permission": "admin"},
+            _resolver,
+            lambda _repo, _number: next(snapshots),
+            _merge_ref,
+            _commit_parents,
+            sleeper=delays.append,
+            retry_delays=(0.25,),
+        )
+
+        self.assertEqual(result["pr_base_sha"], WORKFLOW_SHA)
+        self.assertEqual(result["routing_sha"], MERGE_SHA)
+        self.assertEqual(delays, [0.25])
+
+    def test_api_base_convergence_is_bounded(self) -> None:
+        calls = 0
+
+        def stale_base(_repository: str, _number: int):
+            nonlocal calls
+            calls += 1
+            return _snapshot(base_sha="e" * 40)
+
+        with self.assertRaisesRegex(
+            authorize.AuthorizationError, "base has not converged"
+        ):
+            _authorize(
+                _context(pr_base_sha="e" * 40, pr_merge_sha="f" * 40),
+                pull_request_lookup=stale_base,
+                retry_delays=(0.0, 0.0),
+            )
+
+        self.assertEqual(calls, 3)
+
     def test_waits_for_github_to_compute_mergeability(self) -> None:
         snapshots = iter(
             [
@@ -171,11 +227,12 @@ class AuthorizationPolicyTest(unittest.TestCase):
 
         self.assertEqual(calls, 3)
 
-    def test_event_base_must_match_trusted_workflow_revision(self) -> None:
-        with self.assertRaisesRegex(
-            authorize.AuthorizationError, "trusted workflow revision"
-        ):
-            _authorize(_context(pr_base_sha="e" * 40))
+    def test_event_base_and_merge_hints_must_be_full_shas(self) -> None:
+        for field in ("pr_base_sha", "pr_merge_sha"):
+            with self.subTest(field=field), self.assertRaisesRegex(
+                authorize.AuthorizationError, "full commit SHA"
+            ):
+                _authorize(_context(**{field: "invalid"}))
 
     def test_current_pr_snapshot_must_match_event(self) -> None:
         with self.assertRaisesRegex(authorize.AuthorizationError, "changed"):
@@ -192,10 +249,6 @@ class AuthorizationPolicyTest(unittest.TestCase):
                     mergeable=False, merge_commit_sha=""
                 )
             )
-
-    def test_event_merge_must_match_current_merge(self) -> None:
-        with self.assertRaisesRegex(authorize.AuthorizationError, "event proposed merge"):
-            _authorize(_context(pr_merge_sha="e" * 40))
 
     def test_merge_ref_must_match_current_merge(self) -> None:
         with self.assertRaisesRegex(authorize.AuthorizationError, "merge ref"):
@@ -221,6 +274,23 @@ class AuthorizationPolicyTest(unittest.TestCase):
             _authorize(
                 pull_request_lookup=lambda _repo, _number: next(snapshots)
             )
+
+    def test_second_snapshot_detects_base_drift(self) -> None:
+        snapshots = iter([_snapshot(), _snapshot(base_sha="e" * 40)])
+
+        with self.assertRaisesRegex(authorize.AuthorizationError, "base changed"):
+            _authorize(
+                pull_request_lookup=lambda _repo, _number: next(snapshots)
+            )
+
+    def test_mergeable_blocked_pr_is_authorized(self) -> None:
+        result = _authorize(
+            pull_request_lookup=lambda _repo, _number: _snapshot(
+                mergeable=True, mergeable_state="blocked"
+            )
+        )
+
+        self.assertEqual(result["routing_sha"], MERGE_SHA)
 
     def test_fork_is_rejected_before_permission_lookup(self) -> None:
         def unexpected_permission(_repo, _actor):
@@ -339,6 +409,15 @@ class GitHubApiTest(unittest.TestCase):
         ), self.assertRaisesRegex(authorize.AuthorizationError, "HTTP 422"):
             api.permission("PKUHPC/CraneSched", "maintainer")
 
+    def test_api_timeout_fails_closed(self) -> None:
+        api = authorize.GitHubApi("test-token")
+        with mock.patch.object(
+            authorize.urllib.request,
+            "urlopen",
+            side_effect=TimeoutError,
+        ), self.assertRaisesRegex(authorize.AuthorizationError, "request failed"):
+            api.permission("PKUHPC/CraneSched", "maintainer")
+
     def test_pull_request_response_is_parsed_into_snapshot(self) -> None:
         api = authorize.GitHubApi("test-token")
         response = {
@@ -346,6 +425,7 @@ class GitHubApiTest(unittest.TestCase):
             "state": "open",
             "draft": False,
             "mergeable": True,
+            "mergeable_state": "blocked",
             "merge_commit_sha": MERGE_SHA,
             "base": {
                 "ref": "master",
@@ -371,6 +451,7 @@ class GitHubApiTest(unittest.TestCase):
             "state": "open",
             "draft": False,
             "mergeable": None,
+            "mergeable_state": "unknown",
             "merge_commit_sha": None,
             "base": {
                 "ref": "master",
@@ -388,6 +469,7 @@ class GitHubApiTest(unittest.TestCase):
             snapshot = api.pull_request("PKUHPC/CraneSched", 935)
 
         self.assertIsNone(snapshot.mergeable)
+        self.assertEqual(snapshot.mergeable_state, "unknown")
         self.assertEqual(snapshot.merge_commit_sha, "")
 
     def test_merge_ref_and_commit_parents_are_parsed(self) -> None:


### PR DESCRIPTION
## Summary

- tolerate stale `pull_request_target` base and proposed-merge hints after `master` advances
- bind authorization to the trusted workflow SHA, the current PR API snapshot, the current merge ref, and exact merge parents
- preserve PR-head builds and record the authoritative base/routing SHAs
- add regression coverage for API convergence, stale hints, blocked mergeability, timeouts, and base races

## Root cause

After PR #936 merged, reopening PR #935 emitted `EVENT_SHA=3798c050...` but
the event payload still contained the previous `PR_BASE_SHA=40407bdf...` and
old proposed merge SHA. The dispatcher rejected the event before querying the
current PR API, so no K3s job was created. The current API and merge ref were
valid and had parents `[3798c050..., 57fa8f98...]`.

## Fix

The event base and merge fields are now syntax-checked hints only. The trusted
`EVENT_SHA` must converge with the current API base and proposed merge first
parent; the event head must match the current API head and second parent. The
API merge SHA and `refs/pull/<number>/merge` are checked twice with bounded
retries. Stale snapshots, conflicts, or races remain fail-closed.

## Validation

- 88 CI unit tests passed
- Ruff, actionlint 1.7.12, YAML parsing, and `git diff --check` passed
- live API smoke test reproduced the stale #935 event fields and authorized
  using current base `3798c050...` and routing `f0b36e65...`
- no runner, K3s, AutoTest, FrontEnd, or branch-protection changes

The failed canary `29759838846` stopped in hosted authorization and created no
K3s job or Lease. It is retained as the regression fixture; a fresh canary
after this PR merges must verify the full pull-request target path.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved pull request authorization reliability by validating current base, merge, and workflow revisions.
  - Added bounded retries to handle temporary synchronization delays.
  - Authorization now fails safely when GitHub API requests time out or data is inconsistent.
  - Improved handling of blocked and pending mergeability states.

- **Documentation**
  - Clarified trusted revision checks, stale event data handling, and authorization validation requirements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->