### PR TITLE
ci: add /request-ci approval for fork tests

### DIFF
--- a/.github/ci/README.md
+++ b/.github/ci/README.md
@@ -8,8 +8,10 @@ workflow files for static inspection but never executes candidate code. A
 privileged job is dispatched only when all of the following are true:
 
 - the workflow was loaded from `master`;
-- the pull request is from this repository, not a fork;
-- `github.triggering_actor` currently has `maintain` or `admin` permission;
+- a same-repository pull request was triggered by a user whose current
+  permission is `maintain` or `admin`; or
+- a fork pull request author recorded an exact-head `/request-ci` request and
+  a current `maintain` or `admin` user reran that same workflow run;
 - Backend and FrontEnd refs resolve to full commit SHAs.
 
 The privileged job uses the dedicated repository-scoped runner selected by the
@@ -17,6 +19,31 @@ exact `cranesystemtest` label. Repository registration prevents other
 repositories from dispatching to it, but GitHub does not restrict which
 workflow in `PKUHPC/CraneSched` may request a repository runner. This is an
 accepted boundary of the deployment.
+
+## Fork pull request approval
+
+The first `pull_request_target` run for a fork always fails in the hosted
+authorization job and never queues `cranesystemtest`. The fork author can then
+comment exactly `/request-ci`. The hosted-only `request-ci.yaml` workflow
+requires an open, non-draft fork PR targeting `master`, binds the request to
+the current head repository, ref and SHA, and verifies that attempt 1 of the
+latest matching `build.yaml` run failed authorization without assigning or
+starting `system-test`.
+
+The bot reply records a canonical hidden attestation containing the PR number,
+head SHA, original request comment ID and workflow run ID. A maintainer approves
+that exact request by following the reply and selecting **Re-run all jobs**.
+Every rerun checks the maintainer's current permission, rereads the original
+request comment, resolves the current PR and proposed merge, and rejects any
+run, head, base, comment or merge drift. A new head requires a new
+`/request-ci` comment. A maintainer may rerun the same attested run again after
+an infrastructure failure; all checks execute again.
+
+The request workflow has only hosted-runner access and read-only repository and
+Actions permissions plus permission to create or update its issue comment. It
+checks out only the exact default-branch SHA and never checks out or executes PR
+code. Fork authors can request a run but cannot approve or dispatch the
+self-hosted job themselves.
 
 The hosted authorization job applies a compensating routing guard before it
 dispatches `test`. For a pull request, it resolves the exact PR head SHA for
@@ -30,10 +57,13 @@ checked but are not authorization inputs. The trusted base is the
 merge's first parent must both equal it. The current API head and second parent
 must equal the event head, while the API merge SHA and merge ref must agree.
 These current values are checked twice with bounded retries before dispatch.
-It checks that only `.github/workflows/build.yaml` contains the exact
-`cranesystemtest` token. The check runs trusted code from `master` and treats
-the proposed workflow files only as data. The privileged job still builds and
-tests the PR head SHA, not the temporary merge commit. Protect
+It requires `.github/workflows/build.yaml:test` to use exactly
+`[self-hosted, cranesystemtest]` and every other workflow job to use the fixed
+`ubuntu-latest` hosted runner. Expressions, matrix-selected runners, other
+self-hosted labels and job-level reusable workflows are rejected. The check
+runs trusted code from `master` and treats the proposed workflow files only as
+data. The privileged job still builds and tests the PR head SHA, not the
+temporary merge commit. Protect
 `.github/workflows/**` and `.github/ci/**` through branch protection and
 required maintainer review because this static guard is an accidental-change
 check, not a GitHub-enforced workflow authorization boundary.
@@ -167,13 +197,13 @@ maintenance runner registered directly to `PKUHPC/CraneSched-AutoTest`, with
 its distinct `cranesystemtest-autotest` label. Do not give either service the
 other service's label or environment.
 
-Only `build.yaml` may contain the exact Backend label. The hosted routing guard
-scans every `.yaml` and `.yml` file directly under `.github/workflows` at the
-authorized proposed-merge SHA and fails closed on symlinked workflow files, a
-missing `build.yaml`, a missing Backend label, or any exact label occurrence in
-another workflow. The checkout also verifies the merge commit's HEAD and
-parent SHAs before scanning. Labels with longer names such as
-`cranesystemtest-autotest` are not Backend-label matches.
+Only the `test` job in `build.yaml` may select the Backend runner. The hosted
+routing guard scans every `.yaml` and `.yml` file directly under
+`.github/workflows` at the authorized proposed-merge SHA and fails closed on
+symlinked or noncanonical workflows, a missing privileged job, any other
+self-hosted route, dynamic runner selection, or job-level reusable workflows.
+The checkout also verifies the merge commit's HEAD and parent SHAs before
+scanning.
 
 The Clang Format check is intentionally read-only. It checks the exact PR head
 on a hosted runner, never pushes a formatting commit, and uploads a short-lived
@@ -181,11 +211,9 @@ binary patch when formatting changes are required. Same-repository and fork
 pull requests have the same behavior; a contributor applies the patch and
 pushes a normal commit, which then triggers the normal PR events.
 
-This guard catches a candidate workflow that accidentally names the dedicated
-label, but it cannot prevent routing through a generic default self-hosted
-label or a repository variable. Required maintainer review, branch protection,
-the trusted `pull_request_target` dispatcher and the restricted Kubernetes
-identity remain part of the repository-level security boundary.
+Required maintainer review, branch protection, the trusted
+`pull_request_target` dispatcher and the restricted Kubernetes identity remain
+part of the repository-level security boundary.
 
 ## Artifacts and result contract
 
@@ -216,13 +244,13 @@ CraneTestKit exit codes remain authoritative:
 - `1`: complete coverage with test failures or errors;
 - `2`: infrastructure error or incomplete coverage.
 
-The workflow replaces the serial implementation in
-`.github/workflows/build.yaml` in place, and the privileged job keeps both the
-job ID and display name `test`. It therefore takes over the existing required
-check context `test`; do not delete or rename that context during cutover.
-Verify the first production run before making any additional branch-protection
-change, and remove only separately named obsolete contexts that an administrator
-has confirmed actually exist.
+The privileged job keeps YAML job ID `test` but uses display name
+`system-test`. A hosted `final-test` job uses display name `test`, always runs,
+and succeeds only when authorization and the complete K3s system job both
+succeed. This preserves the existing required check context `test` while making
+an unapproved fork, failed authorization or skipped system job explicitly fail
+instead of appearing as a skipped required check. Do not delete or rename that
+context during cutover.
 
 If two consecutive production runs return infrastructure exit code `2`,
 disable this workflow and restore the previous serial workflow from Git

--- a/.github/ci/authorize.py
+++ b/.github/ci/authorize.py
@@ -17,6 +17,17 @@ from typing import Callable, Optional
 
 
 SHA_RE = re.compile(r"^[0-9a-f]{40}$")
+_REQUEST_MARKER_PREFIX = "<!-- cranesched-ci-request:"
+_REQUEST_MARKER_RE = re.compile(
+    r"^<!-- cranesched-ci-request:(\{[^\r\n]*\}) -->$", re.MULTILINE
+)
+_REQUEST_MARKER_KEYS = {
+    "head_sha",
+    "pr_number",
+    "request_comment_id",
+    "run_id",
+    "schema",
+}
 
 
 class AuthorizationError(RuntimeError):
@@ -39,6 +50,8 @@ class DispatchContext:
     pr_head_repository: str = ""
     pr_head_ref: str = ""
     pr_head_sha: str = ""
+    run_id: str = ""
+    run_attempt: str = ""
     manual_backend_ref: str = "master"
     manual_frontend_ref: str = "master"
 
@@ -60,6 +73,7 @@ class PullRequestSnapshot:
     head_repository: str
     head_ref: str
     head_sha: str
+    author_login: str
     merge_commit_sha: str
     mergeable: bool | None
     mergeable_state: str
@@ -68,6 +82,30 @@ class PullRequestSnapshot:
 PullRequestLookup = Callable[[str, int], PullRequestSnapshot]
 MergeRefResolver = Callable[[str, int], Optional[str]]
 CommitParentsResolver = Callable[[str, str], Optional[tuple[str, ...]]]
+
+
+@dataclass(frozen=True)
+class IssueComment:
+    """The comment identity and content needed for a fork CI request."""
+
+    comment_id: int
+    body: str
+    author_login: str
+    author_type: str
+
+
+@dataclass(frozen=True)
+class RequestAttestation:
+    """A canonical request marker emitted by the trusted hosted workflow."""
+
+    pr_number: int
+    head_sha: str
+    request_comment_id: int
+    run_id: int
+
+
+IssueCommentsLookup = Callable[[str, int], tuple[IssueComment, ...]]
+IssueCommentLookup = Callable[[str, int, int], Optional[IssueComment]]
 Sleeper = Callable[[float], None]
 
 _MERGE_RETRY_DELAYS = (0.5, 1.0, 2.0, 4.0, 8.0)
@@ -109,11 +147,50 @@ def _required_pr_number(value: str) -> int:
     return int(value)
 
 
+def _required_positive_integer(value: str, label: str) -> int:
+    if re.fullmatch(r"[1-9][0-9]*", value) is None:
+        raise AuthorizationError(f"{label} is invalid")
+    return int(value)
+
+
+def _parse_request_attestation(body: str) -> RequestAttestation | None:
+    if body.count(_REQUEST_MARKER_PREFIX) != 1:
+        return None
+    matches = _REQUEST_MARKER_RE.findall(body)
+    if len(matches) != 1:
+        return None
+    raw_payload = matches[0]
+    try:
+        payload = json.loads(raw_payload)
+    except json.JSONDecodeError:
+        return None
+    if not isinstance(payload, dict) or set(payload) != _REQUEST_MARKER_KEYS:
+        return None
+    if json.dumps(payload, sort_keys=True, separators=(",", ":")) != raw_payload:
+        return None
+    schema = payload.get("schema")
+    if not isinstance(schema, int) or isinstance(schema, bool) or schema != 1:
+        return None
+    integer_fields = ("pr_number", "request_comment_id", "run_id")
+    if any(
+        not isinstance(payload.get(field), int)
+        or isinstance(payload.get(field), bool)
+        or payload[field] <= 0
+        for field in integer_fields
+    ):
+        return None
+    head_sha = payload.get("head_sha")
+    if not isinstance(head_sha, str) or SHA_RE.fullmatch(head_sha) is None:
+        return None
+    return RequestAttestation(
+        pr_number=payload["pr_number"],
+        head_sha=head_sha,
+        request_comment_id=payload["request_comment_id"],
+        run_id=payload["run_id"],
+    )
+
+
 def _validate_pr_event(context: DispatchContext) -> int:
-    if context.pr_head_repository != context.repository:
-        raise AuthorizationError(
-            "fork pull requests cannot dispatch the self-hosted runner"
-        )
     if context.pr_base_repository != context.repository:
         raise AuthorizationError("pull request base repository is unexpected")
     if context.pr_base_ref != "master":
@@ -126,9 +203,85 @@ def _validate_pr_event(context: DispatchContext) -> int:
         character in context.pr_head_ref for character in "\r\n"
     ):
         raise AuthorizationError("pull request head ref is invalid")
+    if not context.pr_head_repository or any(
+        character in context.pr_head_repository for character in "\r\n"
+    ):
+        raise AuthorizationError("pull request head repository is invalid")
     if context.pr_merge_sha and not SHA_RE.fullmatch(context.pr_merge_sha):
         raise AuthorizationError("event proposed merge is not a full commit SHA")
     return _required_pr_number(context.pr_number)
+
+
+def _validate_fork_request(
+    context: DispatchContext,
+    number: int,
+    permission_lookup: PermissionLookup,
+    pull_request_lookup: PullRequestLookup | None,
+    issue_comments_lookup: IssueCommentsLookup | None,
+    issue_comment_lookup: IssueCommentLookup | None,
+) -> None:
+    run_attempt = _required_positive_integer(
+        context.run_attempt, "workflow run attempt"
+    )
+    if run_attempt == 1:
+        raise AuthorizationError(
+            "fork pull requests require approval: the pull request author must "
+            "comment exactly `/request-ci`, then a maintainer must use `Re-run all "
+            "jobs` on the workflow run linked by github-actions[bot]"
+        )
+
+    if (
+        pull_request_lookup is None
+        or issue_comments_lookup is None
+        or issue_comment_lookup is None
+    ):
+        raise AuthorizationError("fork CI request validation is unavailable")
+
+    run_id = _required_positive_integer(context.run_id, "workflow run ID")
+    _require_maintainer(context, permission_lookup)
+
+    snapshot = pull_request_lookup(context.repository, number)
+    _validate_pr_snapshot(context, number, snapshot)
+
+    attestations: list[RequestAttestation] = []
+    for comment in issue_comments_lookup(context.repository, number):
+        if (
+            comment.author_login != "github-actions[bot]"
+            or comment.author_type != "Bot"
+        ):
+            continue
+        attestation = _parse_request_attestation(comment.body)
+        if (
+            attestation is not None
+            and attestation.pr_number == number
+            and attestation.head_sha == context.pr_head_sha
+            and attestation.run_id == run_id
+        ):
+            attestations.append(attestation)
+
+    if not attestations:
+        raise AuthorizationError(
+            "no valid `/request-ci` attestation matches this workflow run and PR head"
+        )
+    if len(attestations) != 1:
+        raise AuthorizationError(
+            "multiple `/request-ci` attestations match this workflow run and PR head"
+        )
+
+    attestation = attestations[0]
+    request = issue_comment_lookup(
+        context.repository, number, attestation.request_comment_id
+    )
+    if request is None:
+        raise AuthorizationError("the original `/request-ci` comment no longer exists")
+    if request.comment_id != attestation.request_comment_id:
+        raise AuthorizationError("GitHub returned an unexpected request comment")
+    if request.body != "/request-ci":
+        raise AuthorizationError("the original `/request-ci` comment was edited")
+    if request.author_login != snapshot.author_login:
+        raise AuthorizationError(
+            "the original `/request-ci` comment was not created by the PR author"
+        )
 
 
 def _validate_pr_snapshot(
@@ -235,6 +388,8 @@ def authorize_dispatch(
     pull_request_lookup: PullRequestLookup | None = None,
     merge_ref_resolver: MergeRefResolver | None = None,
     commit_parents_resolver: CommitParentsResolver | None = None,
+    issue_comments_lookup: IssueCommentsLookup | None = None,
+    issue_comment_lookup: IssueCommentLookup | None = None,
     *,
     sleeper: Sleeper = time.sleep,
     retry_delays: tuple[float, ...] = _MERGE_RETRY_DELAYS,
@@ -254,15 +409,23 @@ def authorize_dispatch(
     pr_merge_sha = ""
     if context.event_name == "pull_request_target":
         pr_number = _validate_pr_event(context)
-        _require_maintainer(context, permission_lookup)
+        if context.pr_head_repository == context.repository:
+            _require_maintainer(context, permission_lookup)
+        else:
+            _validate_fork_request(
+                context,
+                pr_number,
+                permission_lookup,
+                pull_request_lookup,
+                issue_comments_lookup,
+                issue_comment_lookup,
+            )
         if (
             pull_request_lookup is None
             or merge_ref_resolver is None
             or commit_parents_resolver is None
         ):
-            raise AuthorizationError(
-                "pull request merge validation is unavailable"
-            )
+            raise AuthorizationError("pull request merge validation is unavailable")
         backend_sha = context.pr_head_sha
         routing_sha = _resolve_pr_merge(
             context,
@@ -353,9 +516,9 @@ class GitHubApi:
             )
         self._token = token
 
-    def _get(
+    def _request_json(
         self, path: str, *, missing_statuses: frozenset[int] = frozenset()
-    ) -> dict[str, object] | None:
+    ) -> object | None:
         request = urllib.request.Request(
             f"https://api.github.com/{path}",
             headers={
@@ -376,8 +539,22 @@ class GitHubApi:
             ) from None
         except (urllib.error.URLError, TimeoutError, json.JSONDecodeError) as exc:
             raise AuthorizationError("GitHub API request failed") from exc
+        return value
+
+    def _get(
+        self, path: str, *, missing_statuses: frozenset[int] = frozenset()
+    ) -> dict[str, object] | None:
+        value = self._request_json(path, missing_statuses=missing_statuses)
+        if value is None:
+            return None
         if not isinstance(value, dict):
             raise AuthorizationError("GitHub API returned a non-object response")
+        return value
+
+    def _get_list(self, path: str) -> list[object]:
+        value = self._request_json(path)
+        if not isinstance(value, list):
+            raise AuthorizationError("GitHub API returned a non-array response")
         return value
 
     def permission(self, repository: str, actor: str) -> dict[str, object]:
@@ -404,7 +581,12 @@ class GitHubApi:
         assert value is not None
         base = value.get("base")
         head = value.get("head")
-        if not isinstance(base, dict) or not isinstance(head, dict):
+        user = value.get("user")
+        if (
+            not isinstance(base, dict)
+            or not isinstance(head, dict)
+            or not isinstance(user, dict)
+        ):
             raise AuthorizationError("GitHub pull request response is malformed")
         base_repository = base.get("repo")
         head_repository = head.get("repo")
@@ -426,6 +608,7 @@ class GitHubApi:
             head_repository.get("full_name"),
             head.get("ref"),
             head.get("sha"),
+            user.get("login"),
         )
         if (
             not isinstance(actual_number, int)
@@ -434,10 +617,7 @@ class GitHubApi:
             or not isinstance(draft, bool)
             or (mergeable is not None and not isinstance(mergeable, bool))
             or not isinstance(mergeable_state, str)
-            or (
-                merge_commit_sha is not None
-                and not isinstance(merge_commit_sha, str)
-            )
+            or (merge_commit_sha is not None and not isinstance(merge_commit_sha, str))
             or any(not isinstance(field, str) for field in fields)
         ):
             raise AuthorizationError("GitHub pull request response is malformed")
@@ -452,10 +632,73 @@ class GitHubApi:
             head_repository=fields[3],
             head_ref=fields[4],
             head_sha=fields[5],
+            author_login=fields[6],
             merge_commit_sha=merge_commit_sha or "",
             mergeable=mergeable,
             mergeable_state=mergeable_state,
         )
+
+    @staticmethod
+    def _parse_issue_comment(value: object) -> IssueComment:
+        if not isinstance(value, dict):
+            raise AuthorizationError("GitHub issue comment response is malformed")
+        user = value.get("user")
+        if user is None:
+            author_login = ""
+            author_type = ""
+        elif isinstance(user, dict):
+            author_login = user.get("login")
+            author_type = user.get("type")
+        else:
+            raise AuthorizationError("GitHub issue comment response is malformed")
+        comment_id = value.get("id")
+        body = value.get("body")
+        if (
+            not isinstance(comment_id, int)
+            or isinstance(comment_id, bool)
+            or comment_id <= 0
+            or not isinstance(body, str)
+            or not isinstance(author_login, str)
+            or not isinstance(author_type, str)
+        ):
+            raise AuthorizationError("GitHub issue comment response is malformed")
+        return IssueComment(
+            comment_id=comment_id,
+            body=body,
+            author_login=author_login,
+            author_type=author_type,
+        )
+
+    def issue_comments(self, repository: str, number: int) -> tuple[IssueComment, ...]:
+        comments: list[IssueComment] = []
+        for page in range(1, 11):
+            values = self._get_list(
+                f"repos/{repository}/issues/{number}/comments?per_page=100&page={page}"
+            )
+            comments.extend(self._parse_issue_comment(value) for value in values)
+            if len(values) < 100:
+                return tuple(comments)
+        raise AuthorizationError(
+            "pull request has too many comments to validate `/request-ci` safely"
+        )
+
+    def issue_comment(
+        self, repository: str, number: int, comment_id: int
+    ) -> IssueComment | None:
+        value = self._get(
+            f"repos/{repository}/issues/comments/{comment_id}",
+            missing_statuses=frozenset({404}),
+        )
+        if value is None:
+            return None
+        expected_issue_url = (
+            f"https://api.github.com/repos/{repository}/issues/{number}"
+        )
+        if value.get("issue_url") != expected_issue_url:
+            raise AuthorizationError(
+                "GitHub returned a request comment from an unexpected pull request"
+            )
+        return self._parse_issue_comment(value)
 
     def merge_ref(self, repository: str, number: int) -> str | None:
         value = self._get(
@@ -469,9 +712,7 @@ class GitHubApi:
             raise AuthorizationError("GitHub merge ref response is malformed")
         return target["sha"]
 
-    def commit_parents(
-        self, repository: str, revision: str
-    ) -> tuple[str, ...] | None:
+    def commit_parents(self, repository: str, revision: str) -> tuple[str, ...] | None:
         encoded_revision = urllib.parse.quote(revision, safe="")
         value = self._get(
             f"repos/{repository}/git/commits/{encoded_revision}",
@@ -508,6 +749,8 @@ def _context_from_environment() -> DispatchContext:
         pr_head_repository=os.environ.get("PR_HEAD_REPOSITORY", ""),
         pr_head_ref=os.environ.get("PR_HEAD_REF", ""),
         pr_head_sha=os.environ.get("PR_HEAD_SHA", ""),
+        run_id=os.environ.get("GITHUB_RUN_ID", ""),
+        run_attempt=os.environ.get("GITHUB_RUN_ATTEMPT", ""),
         manual_backend_ref=os.environ.get("MANUAL_BACKEND_REF", "master"),
         manual_frontend_ref=os.environ.get("MANUAL_FRONTEND_REF", "master"),
     )
@@ -525,6 +768,8 @@ def main() -> int:
         api.pull_request,
         api.merge_ref,
         api.commit_parents,
+        api.issue_comments,
+        api.issue_comment,
     )
     with output_path.open("a", encoding="utf-8") as output:
         for name in (

--- a/.github/ci/request_ci.py
+++ b/.github/ci/request_ci.py
@@ -1,0 +1,735 @@
+#!/usr/bin/env python3
+"""Record a fork author's request for a maintainer-approved CI rerun."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import sys
+import urllib.error
+import urllib.parse
+import urllib.request
+from dataclasses import dataclass
+from datetime import datetime
+from pathlib import Path
+from typing import Protocol
+
+
+EXPECTED_REPOSITORY = "PKUHPC/CraneSched"
+EXPECTED_WORKFLOW_NAME = "CraneTestKit K3s CI"
+EXPECTED_WORKFLOW_PATH = ".github/workflows/build.yaml"
+EXPECTED_AUTHORIZE_JOB = "Authorize trusted test dispatch"
+EXPECTED_AUTHORIZE_STEP = "Authorize actor and resolve immutable revisions"
+EXPECTED_SYSTEM_JOB = "system-test"
+REQUEST_COMMAND = "/request-ci"
+MARKER_PREFIX = "<!-- cranesched-ci-request:"
+SHA_RE = re.compile(r"^[0-9a-f]{40}$")
+REF_RE = re.compile(r"^[^\x00-\x20\x7f]+(?: [^\x00-\x1f\x7f]+)*$")
+MARKER_RE = re.compile(r"^<!-- cranesched-ci-request:(\{[^\r\n]*\}) -->$", re.MULTILINE)
+_MAX_PAGES = 10
+
+
+class RequestCiError(RuntimeError):
+    pass
+
+
+def _positive_int(value: object, label: str) -> int:
+    if not isinstance(value, int) or isinstance(value, bool) or value <= 0:
+        raise RequestCiError(f"{label} is invalid")
+    return value
+
+
+def _required_string(value: object, label: str) -> str:
+    if not isinstance(value, str) or not value:
+        raise RequestCiError(f"{label} is invalid")
+    return value
+
+
+def _mapping(value: object, label: str) -> dict[str, object]:
+    if not isinstance(value, dict) or any(not isinstance(key, str) for key in value):
+        raise RequestCiError(f"{label} is malformed")
+    return value
+
+
+def _list(value: object, label: str) -> list[object]:
+    if not isinstance(value, list):
+        raise RequestCiError(f"{label} is malformed")
+    return value
+
+
+@dataclass(frozen=True)
+class PullRequestSnapshot:
+    number: int
+    state: str
+    draft: bool
+    base_repository: str
+    base_ref: str
+    base_sha: str
+    head_repository: str
+    head_ref: str
+    head_sha: str
+    author: str
+
+
+@dataclass(frozen=True)
+class WorkflowRun:
+    run_id: int
+    created_at: datetime
+    html_url: str
+    head_repository: str
+    head_ref: str
+    head_sha: str
+
+
+@dataclass(frozen=True)
+class Attestation:
+    pr_number: int
+    head_sha: str
+    request_comment_id: int
+    run_id: int
+    schema: int = 1
+
+    def payload(self) -> dict[str, object]:
+        return {
+            "head_sha": self.head_sha,
+            "pr_number": self.pr_number,
+            "request_comment_id": self.request_comment_id,
+            "run_id": self.run_id,
+            "schema": self.schema,
+        }
+
+
+@dataclass(frozen=True)
+class IssueComment:
+    comment_id: int
+    body: str
+    author: str
+    author_type: str
+    issue_url: str = ""
+
+
+@dataclass(frozen=True)
+class RequestResult:
+    action: str
+    comment_id: int
+    head_sha: str
+    run_id: int
+
+
+class RequestCiApi(Protocol):
+    def pull_request(self, repository: str, number: int) -> PullRequestSnapshot: ...
+
+    def workflow_runs(
+        self, repository: str, head_sha: str
+    ) -> list[dict[str, object]]: ...
+
+    def run_jobs(
+        self, repository: str, run_id: int, attempt: int
+    ) -> list[dict[str, object]]: ...
+
+    def issue_comments(self, repository: str, number: int) -> list[IssueComment]: ...
+
+    def create_issue_comment(
+        self, repository: str, number: int, body: str
+    ) -> IssueComment: ...
+
+    def update_issue_comment(
+        self, repository: str, number: int, comment_id: int, body: str
+    ) -> IssueComment: ...
+
+
+def canonical_marker(attestation: Attestation) -> str:
+    _validate_attestation(attestation)
+    encoded = json.dumps(
+        attestation.payload(), sort_keys=True, separators=(",", ":"), ensure_ascii=True
+    )
+    return f"{MARKER_PREFIX}{encoded} -->"
+
+
+def _validate_attestation(attestation: Attestation) -> None:
+    if attestation.schema != 1:
+        raise RequestCiError("CI request attestation schema is unsupported")
+    _positive_int(attestation.pr_number, "attestation pull request number")
+    _positive_int(attestation.request_comment_id, "attestation request comment ID")
+    _positive_int(attestation.run_id, "attestation workflow run ID")
+    if SHA_RE.fullmatch(attestation.head_sha) is None:
+        raise RequestCiError("attestation head SHA is invalid")
+
+
+def parse_marker(body: str) -> Attestation | None:
+    if not isinstance(body, str):
+        raise RequestCiError("bot comment body is malformed")
+    occurrences = body.count(MARKER_PREFIX)
+    if occurrences == 0:
+        return None
+    if occurrences != 1:
+        raise RequestCiError("bot comment contains multiple CI request markers")
+    match = MARKER_RE.search(body)
+    if match is None:
+        raise RequestCiError("bot comment contains a malformed CI request marker")
+    try:
+        value = json.loads(match.group(1))
+    except json.JSONDecodeError as exc:
+        raise RequestCiError("bot comment contains invalid attestation JSON") from exc
+    if not isinstance(value, dict) or set(value) != {
+        "head_sha",
+        "pr_number",
+        "request_comment_id",
+        "run_id",
+        "schema",
+    }:
+        raise RequestCiError("bot comment attestation fields are invalid")
+    attestation = Attestation(
+        pr_number=_positive_int(value["pr_number"], "attestation pull request number"),
+        head_sha=_required_string(value["head_sha"], "attestation head SHA"),
+        request_comment_id=_positive_int(
+            value["request_comment_id"], "attestation request comment ID"
+        ),
+        run_id=_positive_int(value["run_id"], "attestation workflow run ID"),
+        schema=_positive_int(value["schema"], "attestation schema"),
+    )
+    _validate_attestation(attestation)
+    if match.group(0) != canonical_marker(attestation):
+        raise RequestCiError("bot comment attestation is not canonical")
+    return attestation
+
+
+def render_response(attestation: Attestation, run_url: str) -> str:
+    marker = canonical_marker(attestation)
+    expected_url = (
+        f"https://github.com/{EXPECTED_REPOSITORY}/actions/runs/{attestation.run_id}"
+    )
+    if run_url != expected_url:
+        raise RequestCiError("workflow run URL is invalid")
+    return (
+        f"{marker}\n\n"
+        f"CI was requested for fork pull request #{attestation.pr_number} at "
+        f"head `{attestation.head_sha}`.\n\n"
+        f"A maintainer can approve this exact revision by opening "
+        f"[Actions run {attestation.run_id}]({run_url}) and selecting "
+        "**Re-run all jobs**.\n\n"
+        "If the pull request head changes, comment `/request-ci` again."
+    )
+
+
+def _parse_timestamp(value: object) -> datetime:
+    timestamp = _required_string(value, "workflow run creation time")
+    if not timestamp.endswith("Z"):
+        raise RequestCiError("workflow run creation time is invalid")
+    try:
+        parsed = datetime.fromisoformat(f"{timestamp[:-1]}+00:00")
+    except ValueError as exc:
+        raise RequestCiError("workflow run creation time is invalid") from exc
+    return parsed
+
+
+def _repository_name(value: object, label: str) -> str:
+    repository = _mapping(value, label)
+    return _required_string(repository.get("full_name"), f"{label} name")
+
+
+def _candidate_run(
+    value: dict[str, object], snapshot: PullRequestSnapshot
+) -> WorkflowRun:
+    run_id = _positive_int(value.get("id"), "workflow run ID")
+    if value.get("name") != EXPECTED_WORKFLOW_NAME:
+        raise RequestCiError("workflow run name is unexpected")
+    if value.get("path") != EXPECTED_WORKFLOW_PATH:
+        raise RequestCiError("workflow run path is unexpected")
+    if value.get("event") != "pull_request_target":
+        raise RequestCiError("workflow run event is unexpected")
+    _positive_int(value.get("run_attempt"), "workflow run attempt")
+    if value.get("status") != "completed" or value.get("conclusion") != "failure":
+        raise RequestCiError("initial workflow run did not finish as a failure")
+    if (
+        _repository_name(value.get("repository"), "workflow repository")
+        != EXPECTED_REPOSITORY
+    ):
+        raise RequestCiError("workflow run repository is unexpected")
+    head_repository = _repository_name(
+        value.get("head_repository"), "workflow head repository"
+    )
+    head_ref = _required_string(value.get("head_branch"), "workflow head branch")
+    head_sha = _required_string(value.get("head_sha"), "workflow head SHA")
+    if (
+        head_repository != snapshot.head_repository
+        or head_ref != snapshot.head_ref
+        or head_sha != snapshot.head_sha
+    ):
+        raise RequestCiError(
+            "workflow run does not match the current pull request head"
+        )
+    expected_url = f"https://github.com/{EXPECTED_REPOSITORY}/actions/runs/{run_id}"
+    html_url = _required_string(value.get("html_url"), "workflow run URL")
+    if html_url != expected_url:
+        raise RequestCiError("workflow run URL is invalid")
+    return WorkflowRun(
+        run_id=run_id,
+        created_at=_parse_timestamp(value.get("created_at")),
+        html_url=html_url,
+        head_repository=head_repository,
+        head_ref=head_ref,
+        head_sha=head_sha,
+    )
+
+
+def select_workflow_run(
+    values: list[dict[str, object]], snapshot: PullRequestSnapshot
+) -> WorkflowRun:
+    matching: list[dict[str, object]] = []
+    seen_ids: set[int] = set()
+    for value in values:
+        if not isinstance(value, dict):
+            raise RequestCiError("workflow runs response is malformed")
+        run_id = _positive_int(value.get("id"), "workflow run ID")
+        if run_id in seen_ids:
+            raise RequestCiError("workflow runs response contains a duplicate run")
+        seen_ids.add(run_id)
+        if value.get("head_sha") == snapshot.head_sha:
+            matching.append(value)
+    if not matching:
+        raise RequestCiError("no workflow run exists for the current pull request head")
+
+    newest_value = max(
+        matching,
+        key=lambda item: (_parse_timestamp(item.get("created_at")), item["id"]),
+    )
+    return _candidate_run(newest_value, snapshot)
+
+
+def _job_labels(value: object) -> list[str]:
+    labels = _list(value, "workflow job labels")
+    if any(not isinstance(label, str) for label in labels):
+        raise RequestCiError("workflow job labels are malformed")
+    return labels
+
+
+def validate_initial_jobs(values: list[dict[str, object]]) -> None:
+    authorize_jobs: list[dict[str, object]] = []
+    system_jobs: list[dict[str, object]] = []
+    seen_ids: set[int] = set()
+    for value in values:
+        if not isinstance(value, dict):
+            raise RequestCiError("workflow jobs response is malformed")
+        job_id = _positive_int(value.get("id"), "workflow job ID")
+        if job_id in seen_ids:
+            raise RequestCiError("workflow jobs response contains a duplicate job")
+        seen_ids.add(job_id)
+        name = _required_string(value.get("name"), "workflow job name")
+        labels = _job_labels(value.get("labels"))
+        if name == EXPECTED_AUTHORIZE_JOB:
+            authorize_jobs.append(value)
+        if name == EXPECTED_SYSTEM_JOB or labels == ["self-hosted", "cranesystemtest"]:
+            system_jobs.append(value)
+
+    if len(authorize_jobs) != 1:
+        raise RequestCiError("initial workflow must contain exactly one authorize job")
+    authorize_job = authorize_jobs[0]
+    if (
+        authorize_job.get("status") != "completed"
+        or authorize_job.get("conclusion") != "failure"
+        or _job_labels(authorize_job.get("labels")) != ["ubuntu-latest"]
+    ):
+        raise RequestCiError("initial authorize job did not fail on GitHub-hosted")
+    authorize_steps = _list(authorize_job.get("steps"), "initial authorize job steps")
+    policy_steps: list[dict[str, object]] = []
+    for step in authorize_steps:
+        parsed_step = _mapping(step, "initial authorize job step")
+        if parsed_step.get("name") == EXPECTED_AUTHORIZE_STEP:
+            policy_steps.append(parsed_step)
+    if len(policy_steps) != 1 or (
+        policy_steps[0].get("status") != "completed"
+        or policy_steps[0].get("conclusion") != "failure"
+    ):
+        raise RequestCiError("initial authorization policy step did not fail")
+
+    if len(system_jobs) != 1:
+        raise RequestCiError(
+            "initial workflow must contain exactly one system-test job"
+        )
+    system_job = system_jobs[0]
+    if system_job.get("name") != EXPECTED_SYSTEM_JOB:
+        raise RequestCiError("privileged workflow job name is unexpected")
+    if _job_labels(system_job.get("labels")) != [
+        "self-hosted",
+        "cranesystemtest",
+    ]:
+        raise RequestCiError("privileged workflow job labels are unexpected")
+    if (
+        system_job.get("status") != "completed"
+        or system_job.get("conclusion") != "skipped"
+    ):
+        raise RequestCiError("privileged workflow job was not safely skipped")
+    runner_fields = (
+        "runner_id",
+        "runner_name",
+        "runner_group_id",
+        "runner_group_name",
+    )
+    if any(
+        field not in system_job or system_job[field] is not None
+        for field in runner_fields
+    ):
+        raise RequestCiError("privileged workflow job was assigned to a runner")
+    if _list(system_job.get("steps"), "privileged workflow job steps"):
+        raise RequestCiError("privileged workflow job started executing steps")
+
+
+def _validate_pr(snapshot: PullRequestSnapshot, number: int, commenter: str) -> None:
+    if snapshot.number != number:
+        raise RequestCiError("GitHub returned an unexpected pull request")
+    if snapshot.state != "open":
+        raise RequestCiError("pull request is not open")
+    if snapshot.draft:
+        raise RequestCiError("draft pull requests cannot request CI")
+    if snapshot.base_repository != EXPECTED_REPOSITORY or snapshot.base_ref != "master":
+        raise RequestCiError("pull request does not target PKUHPC/CraneSched:master")
+    if snapshot.head_repository == snapshot.base_repository:
+        raise RequestCiError("same-repository pull requests do not use /request-ci")
+    if snapshot.author != commenter:
+        raise RequestCiError("only the pull request author may request CI")
+    if SHA_RE.fullmatch(snapshot.base_sha) is None:
+        raise RequestCiError("pull request base SHA is invalid")
+    if SHA_RE.fullmatch(snapshot.head_sha) is None:
+        raise RequestCiError("pull request head SHA is invalid")
+    if REF_RE.fullmatch(snapshot.head_ref) is None:
+        raise RequestCiError("pull request head ref is invalid")
+
+
+def _event_request(event: object, repository: str) -> tuple[int, int, str] | None:
+    root = _mapping(event, "issue_comment event")
+    if root.get("action") != "created":
+        return None
+    comment = _mapping(root.get("comment"), "issue comment")
+    if comment.get("body") != REQUEST_COMMAND:
+        return None
+    issue = _mapping(root.get("issue"), "issue")
+    if not isinstance(issue.get("pull_request"), dict):
+        return None
+    event_repository = _mapping(root.get("repository"), "event repository")
+    if event_repository.get("full_name") != repository:
+        raise RequestCiError("issue_comment repository does not match the workflow")
+    number = _positive_int(issue.get("number"), "pull request number")
+    comment_id = _positive_int(comment.get("id"), "request comment ID")
+    user = _mapping(comment.get("user"), "request comment author")
+    commenter = _required_string(user.get("login"), "request comment author login")
+    return number, comment_id, commenter
+
+
+def handle_request(
+    event: object, repository: str, api: RequestCiApi
+) -> RequestResult | None:
+    if repository != EXPECTED_REPOSITORY:
+        raise RequestCiError("request workflow repository is unexpected")
+    request = _event_request(event, repository)
+    if request is None:
+        return None
+    number, request_comment_id, commenter = request
+
+    snapshot = api.pull_request(repository, number)
+    _validate_pr(snapshot, number, commenter)
+    run = select_workflow_run(
+        api.workflow_runs(repository, snapshot.head_sha), snapshot
+    )
+    validate_initial_jobs(api.run_jobs(repository, run.run_id, 1))
+
+    existing: list[IssueComment] = []
+    for comment in api.issue_comments(repository, number):
+        if comment.author != "github-actions[bot]" or comment.author_type != "Bot":
+            continue
+        marker = parse_marker(comment.body)
+        if marker is None:
+            continue
+        if marker.pr_number != number:
+            raise RequestCiError("bot attestation belongs to another pull request")
+        if marker.head_sha == snapshot.head_sha:
+            existing.append(comment)
+    if len(existing) > 1:
+        raise RequestCiError("multiple bot attestations exist for the current head")
+
+    final_snapshot = api.pull_request(repository, number)
+    _validate_pr(final_snapshot, number, commenter)
+    if final_snapshot != snapshot:
+        raise RequestCiError("pull request changed while recording the CI request")
+
+    attestation = Attestation(
+        pr_number=number,
+        head_sha=snapshot.head_sha,
+        request_comment_id=request_comment_id,
+        run_id=run.run_id,
+    )
+    body = render_response(attestation, run.html_url)
+    if existing:
+        response = api.update_issue_comment(
+            repository, number, existing[0].comment_id, body
+        )
+        action = "updated"
+        expected_comment_id = existing[0].comment_id
+    else:
+        response = api.create_issue_comment(repository, number, body)
+        action = "created"
+        expected_comment_id = response.comment_id
+    if (
+        response.comment_id != expected_comment_id
+        or response.author != "github-actions[bot]"
+        or response.author_type != "Bot"
+        or response.body != body
+    ):
+        raise RequestCiError("GitHub returned an unexpected bot comment")
+    if parse_marker(response.body) != attestation:
+        raise RequestCiError(
+            "GitHub did not persist the expected CI request attestation"
+        )
+    return RequestResult(
+        action=action,
+        comment_id=response.comment_id,
+        head_sha=snapshot.head_sha,
+        run_id=run.run_id,
+    )
+
+
+class GitHubApi:
+    def __init__(self, token: str, api_url: str = "https://api.github.com") -> None:
+        if not token:
+            raise RequestCiError("GitHub token is unavailable")
+        parsed = urllib.parse.urlsplit(api_url)
+        if (
+            parsed.scheme != "https"
+            or not parsed.netloc
+            or parsed.username is not None
+            or parsed.password is not None
+            or parsed.query
+            or parsed.fragment
+        ):
+            raise RequestCiError("GitHub API URL is invalid")
+        self._token = token
+        self._api_url = api_url.rstrip("/")
+
+    def _request(
+        self,
+        method: str,
+        path: str,
+        *,
+        query: dict[str, str] | None = None,
+        body: dict[str, object] | None = None,
+    ) -> object:
+        url = f"{self._api_url}/{path}"
+        if query:
+            url = f"{url}?{urllib.parse.urlencode(query)}"
+        encoded_body = None
+        headers = {
+            "Accept": "application/vnd.github+json",
+            "Authorization": f"Bearer {self._token}",
+            "User-Agent": "CraneSched-CI-request-handler",
+            "X-GitHub-Api-Version": "2022-11-28",
+        }
+        if body is not None:
+            encoded_body = json.dumps(body, separators=(",", ":")).encode("utf-8")
+            headers["Content-Type"] = "application/json"
+        request = urllib.request.Request(
+            url, data=encoded_body, headers=headers, method=method
+        )
+        try:
+            with urllib.request.urlopen(request, timeout=30) as response:
+                expected_status = {"GET": 200, "POST": 201, "PATCH": 200}.get(method)
+                if expected_status is None or response.status != expected_status:
+                    raise RequestCiError(
+                        "GitHub API returned an unexpected HTTP status"
+                    )
+                value = json.load(response)
+        except urllib.error.HTTPError as exc:
+            raise RequestCiError(
+                f"GitHub API request failed with HTTP {exc.code}"
+            ) from None
+        except (urllib.error.URLError, TimeoutError, json.JSONDecodeError) as exc:
+            raise RequestCiError("GitHub API request failed") from exc
+        return value
+
+    def _object(
+        self,
+        method: str,
+        path: str,
+        *,
+        query: dict[str, str] | None = None,
+        body: dict[str, object] | None = None,
+    ) -> dict[str, object]:
+        return _mapping(
+            self._request(method, path, query=query, body=body),
+            "GitHub API response",
+        )
+
+    def _paginated_list(
+        self, path: str, *, query: dict[str, str] | None = None
+    ) -> list[object]:
+        values: list[object] = []
+        base_query = dict(query or {})
+        for page in range(1, _MAX_PAGES + 1):
+            page_query = {**base_query, "per_page": "100", "page": str(page)}
+            current = _list(
+                self._request("GET", path, query=page_query),
+                "GitHub API list response",
+            )
+            values.extend(current)
+            if len(current) < 100:
+                return values
+        raise RequestCiError("GitHub API pagination exceeded the safety limit")
+
+    def pull_request(self, repository: str, number: int) -> PullRequestSnapshot:
+        value = self._object("GET", f"repos/{repository}/pulls/{number}")
+        base = _mapping(value.get("base"), "pull request base")
+        head = _mapping(value.get("head"), "pull request head")
+        base_repository = _repository_name(
+            base.get("repo"), "pull request base repository"
+        )
+        head_repository = _repository_name(
+            head.get("repo"), "pull request head repository"
+        )
+        user = _mapping(value.get("user"), "pull request author")
+        actual_number = _positive_int(value.get("number"), "pull request number")
+        state = _required_string(value.get("state"), "pull request state")
+        draft = value.get("draft")
+        if not isinstance(draft, bool):
+            raise RequestCiError("pull request draft state is malformed")
+        return PullRequestSnapshot(
+            number=actual_number,
+            state=state,
+            draft=draft,
+            base_repository=base_repository,
+            base_ref=_required_string(base.get("ref"), "pull request base ref"),
+            base_sha=_required_string(base.get("sha"), "pull request base SHA"),
+            head_repository=head_repository,
+            head_ref=_required_string(head.get("ref"), "pull request head ref"),
+            head_sha=_required_string(head.get("sha"), "pull request head SHA"),
+            author=_required_string(user.get("login"), "pull request author login"),
+        )
+
+    def workflow_runs(self, repository: str, head_sha: str) -> list[dict[str, object]]:
+        value = self._object(
+            "GET",
+            f"repos/{repository}/actions/workflows/build.yaml/runs",
+            query={
+                "event": "pull_request_target",
+                "head_sha": head_sha,
+                "per_page": "100",
+            },
+        )
+        total_count = value.get("total_count")
+        if (
+            not isinstance(total_count, int)
+            or isinstance(total_count, bool)
+            or total_count < 0
+        ):
+            raise RequestCiError("workflow runs count is malformed")
+        runs = _list(value.get("workflow_runs"), "workflow runs response")
+        if total_count != len(runs):
+            raise RequestCiError("workflow runs response was unexpectedly truncated")
+        return [_mapping(run, "workflow run") for run in runs]
+
+    def run_jobs(
+        self, repository: str, run_id: int, attempt: int
+    ) -> list[dict[str, object]]:
+        value = self._object(
+            "GET",
+            f"repos/{repository}/actions/runs/{run_id}/attempts/{attempt}/jobs",
+            query={"filter": "all", "per_page": "100"},
+        )
+        total_count = value.get("total_count")
+        jobs = _list(value.get("jobs"), "workflow jobs response")
+        if (
+            not isinstance(total_count, int)
+            or isinstance(total_count, bool)
+            or total_count < 0
+            or total_count != len(jobs)
+        ):
+            raise RequestCiError("workflow jobs response was unexpectedly truncated")
+        return [_mapping(job, "workflow job") for job in jobs]
+
+    def issue_comments(self, repository: str, number: int) -> list[IssueComment]:
+        values = self._paginated_list(f"repos/{repository}/issues/{number}/comments")
+        return [
+            self._issue_comment(_mapping(value, "issue comment"), repository, number)
+            for value in values
+        ]
+
+    def _issue_comment(
+        self, value: dict[str, object], repository: str, number: int
+    ) -> IssueComment:
+        raw_user = value.get("user")
+        if raw_user is None:
+            author = ""
+            author_type = ""
+        else:
+            user = _mapping(raw_user, "issue comment author")
+            author = _required_string(user.get("login"), "issue comment author login")
+            author_type = _required_string(
+                user.get("type"), "issue comment author type"
+            )
+        issue_url = _required_string(value.get("issue_url"), "issue comment URL")
+        expected_issue_url = f"{self._api_url}/repos/{repository}/issues/{number}"
+        if issue_url != expected_issue_url:
+            raise RequestCiError("issue comment belongs to an unexpected issue")
+        return IssueComment(
+            comment_id=_positive_int(value.get("id"), "issue comment ID"),
+            body=_required_string(value.get("body"), "issue comment body"),
+            author=author,
+            author_type=author_type,
+            issue_url=issue_url,
+        )
+
+    def create_issue_comment(
+        self, repository: str, number: int, body: str
+    ) -> IssueComment:
+        value = self._object(
+            "POST", f"repos/{repository}/issues/{number}/comments", body={"body": body}
+        )
+        return self._issue_comment(value, repository, number)
+
+    def update_issue_comment(
+        self, repository: str, number: int, comment_id: int, body: str
+    ) -> IssueComment:
+        value = self._object(
+            "PATCH",
+            f"repos/{repository}/issues/comments/{comment_id}",
+            body={"body": body},
+        )
+        return self._issue_comment(value, repository, number)
+
+
+def _load_event(path: Path) -> object:
+    try:
+        with path.open(encoding="utf-8") as stream:
+            return json.load(stream)
+    except (OSError, json.JSONDecodeError) as exc:
+        raise RequestCiError("unable to read the issue_comment event") from exc
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--event-path", type=Path, required=True)
+    args = parser.parse_args(argv)
+    repository = os.environ.get("GITHUB_REPOSITORY", "")
+    api = GitHubApi(
+        os.environ.get("GITHUB_TOKEN", ""),
+        os.environ.get("GITHUB_API_URL", "https://api.github.com"),
+    )
+    result = handle_request(_load_event(args.event_path), repository, api)
+    if result is None:
+        print(
+            "Ignoring issue comment: it is not an exact /request-ci on a pull request"
+        )
+    else:
+        print(
+            f"{result.action.capitalize()} CI request comment {result.comment_id} "
+            f"for {result.head_sha}; maintainer rerun target is {result.run_id}"
+        )
+    return 0
+
+
+if __name__ == "__main__":
+    try:
+        raise SystemExit(main())
+    except RequestCiError as exc:
+        print(f"CI request failed: {exc}", file=sys.stderr)
+        raise SystemExit(1) from None

--- a/.github/ci/test_authorize.py
+++ b/.github/ci/test_authorize.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import importlib.util
 import io
+import json
 import sys
 import unittest
 import urllib.error
@@ -21,6 +22,11 @@ BACKEND_SHA = "a" * 40
 FRONTEND_SHA = "b" * 40
 WORKFLOW_SHA = "c" * 40
 MERGE_SHA = "d" * 40
+FORK_HEAD_SHA = "e" * 40
+RUN_ID = 29794463501
+REQUEST_COMMENT_ID = 99123
+FORK_REPOSITORY = "external/CraneSched"
+FORK_AUTHOR = "fork-author"
 
 
 def _context(**overrides):
@@ -41,6 +47,8 @@ def _context(**overrides):
         "pr_head_repository": "PKUHPC/CraneSched",
         "pr_head_ref": "feature/test",
         "pr_head_sha": BACKEND_SHA,
+        "run_id": str(RUN_ID),
+        "run_attempt": "1",
     }
     values.update(overrides)
     return authorize.DispatchContext(**values)
@@ -49,6 +57,7 @@ def _context(**overrides):
 def _resolver(repository: str, ref: str) -> str | None:
     if repository == "PKUHPC/CraneSched" and ref in {
         BACKEND_SHA,
+        FORK_HEAD_SHA,
         MERGE_SHA,
         WORKFLOW_SHA,
         "master",
@@ -70,6 +79,7 @@ def _snapshot(**overrides) -> authorize.PullRequestSnapshot:
         "head_repository": "PKUHPC/CraneSched",
         "head_ref": "feature/test",
         "head_sha": BACKEND_SHA,
+        "author_login": "contributor",
         "merge_commit_sha": MERGE_SHA,
         "mergeable": True,
         "mergeable_state": "blocked",
@@ -90,6 +100,66 @@ def _commit_parents(_repository: str, _revision: str) -> tuple[str, ...]:
     return (WORKFLOW_SHA, BACKEND_SHA)
 
 
+def _fork_context(**overrides) -> authorize.DispatchContext:
+    values = {
+        "pr_head_repository": FORK_REPOSITORY,
+        "pr_head_sha": FORK_HEAD_SHA,
+        "run_attempt": "2",
+    }
+    values.update(overrides)
+    return _context(**values)
+
+
+def _fork_snapshot(**overrides) -> authorize.PullRequestSnapshot:
+    values = {
+        "head_repository": FORK_REPOSITORY,
+        "head_sha": FORK_HEAD_SHA,
+        "author_login": FORK_AUTHOR,
+    }
+    values.update(overrides)
+    return _snapshot(**values)
+
+
+def _fork_pull_request(_repository: str, _number: int) -> authorize.PullRequestSnapshot:
+    return _fork_snapshot()
+
+
+def _fork_commit_parents(_repository: str, _revision: str) -> tuple[str, ...]:
+    return (WORKFLOW_SHA, FORK_HEAD_SHA)
+
+
+def _attestation_comment(**overrides) -> authorize.IssueComment:
+    payload = {
+        "head_sha": FORK_HEAD_SHA,
+        "pr_number": 935,
+        "request_comment_id": REQUEST_COMMENT_ID,
+        "run_id": RUN_ID,
+        "schema": 1,
+    }
+    payload.update(overrides)
+    marker = json.dumps(payload, sort_keys=True, separators=(",", ":"))
+    return authorize.IssueComment(
+        comment_id=99200,
+        body=(
+            f"<!-- cranesched-ci-request:{marker} -->\n\n"
+            "A maintainer may now use Re-run all jobs."
+        ),
+        author_login="github-actions[bot]",
+        author_type="Bot",
+    )
+
+
+def _request_comment(**overrides) -> authorize.IssueComment:
+    values = {
+        "comment_id": REQUEST_COMMENT_ID,
+        "body": "/request-ci",
+        "author_login": FORK_AUTHOR,
+        "author_type": "User",
+    }
+    values.update(overrides)
+    return authorize.IssueComment(**values)
+
+
 def _authorize(
     context: authorize.DispatchContext | None = None,
     *,
@@ -98,6 +168,8 @@ def _authorize(
     pull_request_lookup=_pull_request,
     merge_ref_resolver=_merge_ref,
     commit_parents_resolver=_commit_parents,
+    issue_comments_lookup=None,
+    issue_comment_lookup=None,
     retry_delays: tuple[float, ...] = (),
 ) -> dict[str, str]:
     return authorize.authorize_dispatch(
@@ -107,12 +179,25 @@ def _authorize(
         pull_request_lookup,
         merge_ref_resolver,
         commit_parents_resolver,
+        issue_comments_lookup,
+        issue_comment_lookup,
         sleeper=lambda _delay: None,
         retry_delays=retry_delays,
     )
 
 
 class AuthorizationPolicyTest(unittest.TestCase):
+    def test_workflow_run_identity_is_loaded_from_environment(self) -> None:
+        with mock.patch.dict(
+            authorize.os.environ,
+            {"GITHUB_RUN_ID": str(RUN_ID), "GITHUB_RUN_ATTEMPT": "3"},
+            clear=True,
+        ):
+            context = authorize._context_from_environment()
+
+        self.assertEqual(context.run_id, str(RUN_ID))
+        self.assertEqual(context.run_attempt, "3")
+
     def test_same_repository_maintainer_pr_is_authorized(self) -> None:
         result = _authorize()
         self.assertEqual(result["backend_sha"], BACKEND_SHA)
@@ -130,9 +215,7 @@ class AuthorizationPolicyTest(unittest.TestCase):
         self.assertEqual(result["pr_merge_sha"], MERGE_SHA)
 
     def test_stale_event_base_and_merge_hints_use_current_api_snapshot(self) -> None:
-        result = _authorize(
-            _context(pr_base_sha="e" * 40, pr_merge_sha="f" * 40)
-        )
+        result = _authorize(_context(pr_base_sha="e" * 40, pr_merge_sha="f" * 40))
 
         self.assertEqual(result["backend_sha"], BACKEND_SHA)
         self.assertEqual(result["routing_sha"], MERGE_SHA)
@@ -229,17 +312,16 @@ class AuthorizationPolicyTest(unittest.TestCase):
 
     def test_event_base_and_merge_hints_must_be_full_shas(self) -> None:
         for field in ("pr_base_sha", "pr_merge_sha"):
-            with self.subTest(field=field), self.assertRaisesRegex(
-                authorize.AuthorizationError, "full commit SHA"
+            with (
+                self.subTest(field=field),
+                self.assertRaisesRegex(authorize.AuthorizationError, "full commit SHA"),
             ):
                 _authorize(_context(**{field: "invalid"}))
 
     def test_current_pr_snapshot_must_match_event(self) -> None:
         with self.assertRaisesRegex(authorize.AuthorizationError, "changed"):
             _authorize(
-                pull_request_lookup=lambda _repo, _number: _snapshot(
-                    head_sha="e" * 40
-                )
+                pull_request_lookup=lambda _repo, _number: _snapshot(head_sha="e" * 40)
             )
 
     def test_unmergeable_pr_is_rejected(self) -> None:
@@ -260,8 +342,9 @@ class AuthorizationPolicyTest(unittest.TestCase):
             (WORKFLOW_SHA,),
             (WORKFLOW_SHA, BACKEND_SHA, "e" * 40),
         ):
-            with self.subTest(parents=parents), self.assertRaisesRegex(
-                authorize.AuthorizationError, "parents"
+            with (
+                self.subTest(parents=parents),
+                self.assertRaisesRegex(authorize.AuthorizationError, "parents"),
             ):
                 _authorize(
                     commit_parents_resolver=lambda _repo, _sha, value=parents: value
@@ -271,17 +354,13 @@ class AuthorizationPolicyTest(unittest.TestCase):
         snapshots = iter([_snapshot(), _snapshot(head_sha="e" * 40)])
 
         with self.assertRaisesRegex(authorize.AuthorizationError, "changed"):
-            _authorize(
-                pull_request_lookup=lambda _repo, _number: next(snapshots)
-            )
+            _authorize(pull_request_lookup=lambda _repo, _number: next(snapshots))
 
     def test_second_snapshot_detects_base_drift(self) -> None:
         snapshots = iter([_snapshot(), _snapshot(base_sha="e" * 40)])
 
         with self.assertRaisesRegex(authorize.AuthorizationError, "base changed"):
-            _authorize(
-                pull_request_lookup=lambda _repo, _number: next(snapshots)
-            )
+            _authorize(pull_request_lookup=lambda _repo, _number: next(snapshots))
 
     def test_mergeable_blocked_pr_is_authorized(self) -> None:
         result = _authorize(
@@ -292,19 +371,149 @@ class AuthorizationPolicyTest(unittest.TestCase):
 
         self.assertEqual(result["routing_sha"], MERGE_SHA)
 
-    def test_fork_is_rejected_before_permission_lookup(self) -> None:
+    def test_initial_fork_run_requests_comment_before_permission_lookup(self) -> None:
         def unexpected_permission(_repo, _actor):
-            self.fail("permission lookup must not run for a fork")
+            self.fail("permission lookup must not run for an initial fork attempt")
 
-        with self.assertRaisesRegex(authorize.AuthorizationError, "Fork|fork"):
+        with self.assertRaisesRegex(authorize.AuthorizationError, "/request-ci"):
             authorize.authorize_dispatch(
-                _context(pr_head_repository="external/fork"),
+                _fork_context(run_attempt="1"),
                 unexpected_permission,
                 _resolver,
                 _pull_request,
                 _merge_ref,
                 _commit_parents,
             )
+
+    def test_fork_rerun_without_attestation_is_rejected(self) -> None:
+        with self.assertRaisesRegex(authorize.AuthorizationError, "no valid"):
+            _authorize(
+                _fork_context(),
+                pull_request_lookup=_fork_pull_request,
+                commit_parents_resolver=_fork_commit_parents,
+                issue_comments_lookup=lambda _repo, _number: (),
+                issue_comment_lookup=lambda _repo, _number, _comment_id: None,
+            )
+
+    def test_write_only_actor_cannot_approve_fork_rerun(self) -> None:
+        comments_queried = False
+
+        def unexpected_comments(_repo, _number):
+            nonlocal comments_queried
+            comments_queried = True
+            return ()
+
+        with self.assertRaisesRegex(authorize.AuthorizationError, "maintain or admin"):
+            _authorize(
+                _fork_context(),
+                permission="write",
+                pull_request_lookup=_fork_pull_request,
+                commit_parents_resolver=_fork_commit_parents,
+                issue_comments_lookup=unexpected_comments,
+                issue_comment_lookup=lambda _repo, _number, _comment_id: None,
+            )
+
+        self.assertFalse(comments_queried)
+
+    def test_valid_fork_request_allows_maintainer_rerun(self) -> None:
+        result = _authorize(
+            _fork_context(),
+            permission="admin",
+            pull_request_lookup=_fork_pull_request,
+            commit_parents_resolver=_fork_commit_parents,
+            issue_comments_lookup=lambda _repo, _number: (_attestation_comment(),),
+            issue_comment_lookup=lambda _repo, _number, _comment_id: (
+                _request_comment()
+            ),
+        )
+
+        self.assertEqual(result["backend_sha"], FORK_HEAD_SHA)
+        self.assertEqual(result["routing_sha"], MERGE_SHA)
+        self.assertEqual(result["pr_head_sha"], FORK_HEAD_SHA)
+
+    def test_deleted_or_edited_fork_request_is_rejected(self) -> None:
+        for request, message in (
+            (None, "no longer exists"),
+            (_request_comment(body="/request-ci please"), "was edited"),
+            (_request_comment(author_login="someone-else"), "PR author"),
+        ):
+            with (
+                self.subTest(message=message),
+                self.assertRaisesRegex(authorize.AuthorizationError, message),
+            ):
+                _authorize(
+                    _fork_context(),
+                    pull_request_lookup=_fork_pull_request,
+                    commit_parents_resolver=_fork_commit_parents,
+                    issue_comments_lookup=lambda _repo, _number: (
+                        _attestation_comment(),
+                    ),
+                    issue_comment_lookup=(
+                        lambda _repo, _number, _comment_id, value=request: value
+                    ),
+                )
+
+    def test_fork_attestation_is_bound_to_run_and_head(self) -> None:
+        for marker in (
+            _attestation_comment(run_id=RUN_ID + 1),
+            _attestation_comment(head_sha=BACKEND_SHA),
+        ):
+            with (
+                self.subTest(marker=marker),
+                self.assertRaisesRegex(authorize.AuthorizationError, "no valid"),
+            ):
+                _authorize(
+                    _fork_context(),
+                    pull_request_lookup=_fork_pull_request,
+                    commit_parents_resolver=_fork_commit_parents,
+                    issue_comments_lookup=(
+                        lambda _repo, _number, value=marker: (value,)
+                    ),
+                    issue_comment_lookup=lambda _repo, _number, _comment_id: (
+                        _request_comment()
+                    ),
+                )
+
+    def test_fork_attestation_requires_trusted_bot_and_canonical_marker(self) -> None:
+        valid = _attestation_comment()
+        candidates = (
+            authorize.IssueComment(
+                valid.comment_id,
+                valid.body,
+                "fork-author",
+                "User",
+            ),
+            authorize.IssueComment(
+                valid.comment_id,
+                valid.body.replace(",", ", ", 1),
+                "github-actions[bot]",
+                "Bot",
+            ),
+            _attestation_comment(extra="unexpected"),
+            _attestation_comment(schema=1.0),
+            authorize.IssueComment(
+                valid.comment_id,
+                f"{valid.body}\n<!-- cranesched-ci-request:not-json -->",
+                "github-actions[bot]",
+                "Bot",
+            ),
+        )
+        for candidate in candidates:
+            with (
+                self.subTest(candidate=candidate),
+                self.assertRaisesRegex(authorize.AuthorizationError, "no valid"),
+            ):
+                _authorize(
+                    _fork_context(),
+                    pull_request_lookup=_fork_pull_request,
+                    commit_parents_resolver=_fork_commit_parents,
+                    issue_comments_lookup=(
+                        lambda _repo, _number, value=candidate: (value,)
+                    ),
+                    issue_comment_lookup=lambda _repo, _number, _comment_id: (
+                        _request_comment()
+                    ),
+                )
 
     def test_non_maintainer_is_rejected(self) -> None:
         with self.assertRaisesRegex(authorize.AuthorizationError, "maintain or admin"):
@@ -393,29 +602,38 @@ class GitHubApiTest(unittest.TestCase):
     def test_missing_commit_accepts_github_404_and_422_responses(self) -> None:
         api = authorize.GitHubApi("test-token")
         for status in (404, 422):
-            with self.subTest(status=status), mock.patch.object(
-                authorize.urllib.request,
-                "urlopen",
-                side_effect=self._http_error(status),
+            with (
+                self.subTest(status=status),
+                mock.patch.object(
+                    authorize.urllib.request,
+                    "urlopen",
+                    side_effect=self._http_error(status),
+                ),
             ):
                 self.assertIsNone(api.commit("PKUHPC/CraneSched", "missing/ref"))
 
     def test_permission_lookup_keeps_422_fail_closed(self) -> None:
         api = authorize.GitHubApi("test-token")
-        with mock.patch.object(
-            authorize.urllib.request,
-            "urlopen",
-            side_effect=self._http_error(422),
-        ), self.assertRaisesRegex(authorize.AuthorizationError, "HTTP 422"):
+        with (
+            mock.patch.object(
+                authorize.urllib.request,
+                "urlopen",
+                side_effect=self._http_error(422),
+            ),
+            self.assertRaisesRegex(authorize.AuthorizationError, "HTTP 422"),
+        ):
             api.permission("PKUHPC/CraneSched", "maintainer")
 
     def test_api_timeout_fails_closed(self) -> None:
         api = authorize.GitHubApi("test-token")
-        with mock.patch.object(
-            authorize.urllib.request,
-            "urlopen",
-            side_effect=TimeoutError,
-        ), self.assertRaisesRegex(authorize.AuthorizationError, "request failed"):
+        with (
+            mock.patch.object(
+                authorize.urllib.request,
+                "urlopen",
+                side_effect=TimeoutError,
+            ),
+            self.assertRaisesRegex(authorize.AuthorizationError, "request failed"),
+        ):
             api.permission("PKUHPC/CraneSched", "maintainer")
 
     def test_pull_request_response_is_parsed_into_snapshot(self) -> None:
@@ -437,6 +655,7 @@ class GitHubApiTest(unittest.TestCase):
                 "sha": BACKEND_SHA,
                 "repo": {"full_name": "PKUHPC/CraneSched"},
             },
+            "user": {"login": "contributor"},
         }
 
         with mock.patch.object(api, "_get", return_value=response):
@@ -463,6 +682,7 @@ class GitHubApiTest(unittest.TestCase):
                 "sha": BACKEND_SHA,
                 "repo": {"full_name": "PKUHPC/CraneSched"},
             },
+            "user": {"login": "contributor"},
         }
 
         with mock.patch.object(api, "_get", return_value=response):
@@ -471,6 +691,64 @@ class GitHubApiTest(unittest.TestCase):
         self.assertIsNone(snapshot.mergeable)
         self.assertEqual(snapshot.mergeable_state, "unknown")
         self.assertEqual(snapshot.merge_commit_sha, "")
+
+    def test_issue_comments_are_parsed_for_attestation_validation(self) -> None:
+        api = authorize.GitHubApi("test-token")
+        response = {
+            "id": 99200,
+            "body": _attestation_comment().body,
+            "user": {"login": "github-actions[bot]", "type": "Bot"},
+        }
+
+        with mock.patch.object(api, "_get_list", return_value=[response]) as get:
+            comments = api.issue_comments("PKUHPC/CraneSched", 935)
+
+        self.assertEqual(comments, (_attestation_comment(),))
+        self.assertEqual(
+            get.call_args.args[0],
+            "repos/PKUHPC/CraneSched/issues/935/comments?per_page=100&page=1",
+        )
+
+    def test_deleted_comment_author_is_ignored_as_an_untrusted_identity(self) -> None:
+        api = authorize.GitHubApi("test-token")
+        response = {"id": 99201, "body": "old comment", "user": None}
+
+        with mock.patch.object(api, "_get_list", return_value=[response]):
+            comments = api.issue_comments("PKUHPC/CraneSched", 935)
+
+        self.assertEqual(
+            comments,
+            (authorize.IssueComment(99201, "old comment", "", ""),),
+        )
+
+    def test_original_request_comment_is_bound_to_pull_request(self) -> None:
+        api = authorize.GitHubApi("test-token")
+        response = {
+            "id": REQUEST_COMMENT_ID,
+            "body": "/request-ci",
+            "issue_url": "https://api.github.com/repos/PKUHPC/CraneSched/issues/935",
+            "user": {"login": FORK_AUTHOR, "type": "User"},
+        }
+
+        with mock.patch.object(api, "_get", return_value=response):
+            comment = api.issue_comment("PKUHPC/CraneSched", 935, REQUEST_COMMENT_ID)
+        self.assertEqual(comment, _request_comment())
+
+        response["issue_url"] = (
+            "https://api.github.com/repos/PKUHPC/CraneSched/issues/936"
+        )
+        with (
+            mock.patch.object(api, "_get", return_value=response),
+            self.assertRaisesRegex(authorize.AuthorizationError, "unexpected"),
+        ):
+            api.issue_comment("PKUHPC/CraneSched", 935, REQUEST_COMMENT_ID)
+
+    def test_deleted_request_comment_returns_none(self) -> None:
+        api = authorize.GitHubApi("test-token")
+        with mock.patch.object(api, "_get", return_value=None):
+            self.assertIsNone(
+                api.issue_comment("PKUHPC/CraneSched", 935, REQUEST_COMMENT_ID)
+            )
 
     def test_merge_ref_and_commit_parents_are_parsed(self) -> None:
         api = authorize.GitHubApi("test-token")
@@ -485,9 +763,7 @@ class GitHubApiTest(unittest.TestCase):
         with mock.patch.object(
             api,
             "_get",
-            return_value={
-                "parents": [{"sha": WORKFLOW_SHA}, {"sha": BACKEND_SHA}]
-            },
+            return_value={"parents": [{"sha": WORKFLOW_SHA}, {"sha": BACKEND_SHA}]},
         ):
             self.assertEqual(
                 api.commit_parents("PKUHPC/CraneSched", MERGE_SHA),

--- a/.github/ci/test_request_ci.py
+++ b/.github/ci/test_request_ci.py
@@ -1,0 +1,596 @@
+from __future__ import annotations
+
+import importlib.util
+import io
+import json
+import sys
+import unittest
+from pathlib import Path
+from unittest import mock
+
+
+MODULE_PATH = Path(__file__).with_name("request_ci.py")
+SPEC = importlib.util.spec_from_file_location("cranesched_ci_request", MODULE_PATH)
+assert SPEC is not None and SPEC.loader is not None
+request_ci = importlib.util.module_from_spec(SPEC)
+sys.modules[SPEC.name] = request_ci
+SPEC.loader.exec_module(request_ci)
+
+
+BASE_SHA = "a" * 40
+HEAD_SHA = "b" * 40
+OLD_HEAD_SHA = "c" * 40
+RUN_ID = 123456
+REQUEST_COMMENT_ID = 456789
+PR_NUMBER = 933
+
+
+def _event(**overrides):
+    value = {
+        "action": "created",
+        "repository": {"full_name": "PKUHPC/CraneSched"},
+        "issue": {"number": PR_NUMBER, "pull_request": {"url": "ignored"}},
+        "comment": {
+            "id": REQUEST_COMMENT_ID,
+            "body": "/request-ci",
+            "user": {"login": "fork-author"},
+        },
+    }
+    value.update(overrides)
+    return value
+
+
+def _snapshot(**overrides):
+    values = {
+        "number": PR_NUMBER,
+        "state": "open",
+        "draft": False,
+        "base_repository": "PKUHPC/CraneSched",
+        "base_ref": "master",
+        "base_sha": BASE_SHA,
+        "head_repository": "fork-author/CraneSched",
+        "head_ref": "feature/change",
+        "head_sha": HEAD_SHA,
+        "author": "fork-author",
+    }
+    values.update(overrides)
+    return request_ci.PullRequestSnapshot(**values)
+
+
+def _run(**overrides):
+    values = {
+        "id": RUN_ID,
+        "name": "CraneTestKit K3s CI",
+        "path": ".github/workflows/build.yaml",
+        "event": "pull_request_target",
+        "run_attempt": 1,
+        "status": "completed",
+        "conclusion": "failure",
+        "repository": {"full_name": "PKUHPC/CraneSched"},
+        "head_repository": {"full_name": "fork-author/CraneSched"},
+        "head_branch": "feature/change",
+        "head_sha": HEAD_SHA,
+        "html_url": f"https://github.com/PKUHPC/CraneSched/actions/runs/{RUN_ID}",
+        "created_at": "2026-07-22T08:00:00Z",
+    }
+    values.update(overrides)
+    return values
+
+
+def _jobs():
+    return [
+        {
+            "id": 1,
+            "name": "Authorize trusted test dispatch",
+            "status": "completed",
+            "conclusion": "failure",
+            "labels": ["ubuntu-latest"],
+            "runner_id": 99,
+            "runner_name": "GitHub Actions 99",
+            "runner_group_id": 0,
+            "runner_group_name": "GitHub Actions",
+            "steps": [
+                {
+                    "name": "Authorize actor and resolve immutable revisions",
+                    "status": "completed",
+                    "conclusion": "failure",
+                }
+            ],
+        },
+        {
+            "id": 2,
+            "name": "system-test",
+            "status": "completed",
+            "conclusion": "skipped",
+            "labels": ["self-hosted", "cranesystemtest"],
+            "runner_id": None,
+            "runner_name": None,
+            "runner_group_id": None,
+            "runner_group_name": None,
+            "steps": [],
+        },
+        {
+            "id": 3,
+            "name": "test",
+            "status": "completed",
+            "conclusion": "failure",
+            "labels": ["ubuntu-latest"],
+            "runner_id": 100,
+            "runner_name": "GitHub Actions 100",
+            "runner_group_id": 0,
+            "runner_group_name": "GitHub Actions",
+            "steps": [],
+        },
+    ]
+
+
+class FakeApi:
+    def __init__(self):
+        self.snapshots = [_snapshot()]
+        self.runs = [_run()]
+        self.jobs = _jobs()
+        self.comments = []
+        self.created = []
+        self.updated = []
+        self.job_requests = []
+
+    def pull_request(self, _repository, _number):
+        if len(self.snapshots) > 1:
+            return self.snapshots.pop(0)
+        return self.snapshots[0]
+
+    def workflow_runs(self, _repository, _head_sha):
+        return self.runs
+
+    def run_jobs(self, _repository, _run_id, _attempt):
+        self.job_requests.append((_run_id, _attempt))
+        return self.jobs
+
+    def issue_comments(self, _repository, _number):
+        return self.comments
+
+    def create_issue_comment(self, _repository, number, body):
+        self.created.append((number, body))
+        return request_ci.IssueComment(
+            comment_id=900, body=body, author="github-actions[bot]", author_type="Bot"
+        )
+
+    def update_issue_comment(self, _repository, _number, comment_id, body):
+        self.updated.append((comment_id, body))
+        return request_ci.IssueComment(
+            comment_id=comment_id,
+            body=body,
+            author="github-actions[bot]",
+            author_type="Bot",
+        )
+
+
+def _handle(api=None, event=None):
+    return request_ci.handle_request(
+        event if event is not None else _event(),
+        "PKUHPC/CraneSched",
+        api if api is not None else FakeApi(),
+    )
+
+
+class RequestProtocolTest(unittest.TestCase):
+    def test_creates_attestation_for_exact_fork_author_request(self):
+        api = FakeApi()
+
+        result = _handle(api)
+
+        self.assertEqual(result.action, "created")
+        self.assertEqual(result.comment_id, 900)
+        self.assertEqual(result.head_sha, HEAD_SHA)
+        self.assertEqual(result.run_id, RUN_ID)
+        self.assertEqual(len(api.created), 1)
+        marker = request_ci.parse_marker(api.created[0][1])
+        self.assertEqual(
+            marker,
+            request_ci.Attestation(
+                pr_number=PR_NUMBER,
+                head_sha=HEAD_SHA,
+                request_comment_id=REQUEST_COMMENT_ID,
+                run_id=RUN_ID,
+            ),
+        )
+        self.assertIn(f"`{HEAD_SHA}`", api.created[0][1])
+        self.assertIn(f"actions/runs/{RUN_ID}", api.created[0][1])
+        self.assertIn("Re-run all jobs", api.created[0][1])
+
+    def test_non_created_wrong_command_and_non_pr_comments_are_ignored(self):
+        cases = [
+            _event(action="edited"),
+            _event(
+                comment={
+                    "id": 1,
+                    "body": "/request-ci ",
+                    "user": {"login": "fork-author"},
+                }
+            ),
+            _event(issue={"number": PR_NUMBER}),
+        ]
+        for event in cases:
+            with self.subTest(event=event):
+                api = FakeApi()
+                self.assertIsNone(_handle(api, event))
+                self.assertEqual(api.created, [])
+
+    def test_repository_identity_is_fixed(self):
+        with self.assertRaisesRegex(request_ci.RequestCiError, "repository"):
+            request_ci.handle_request(_event(), "other/repository", FakeApi())
+        with self.assertRaisesRegex(request_ci.RequestCiError, "repository"):
+            _handle(
+                FakeApi(),
+                _event(repository={"full_name": "attacker/CraneSched"}),
+            )
+
+    def test_pr_must_be_open_ready_fork_targeting_master_and_requested_by_author(self):
+        cases = [
+            (_snapshot(state="closed"), "not open"),
+            (_snapshot(draft=True), "draft"),
+            (_snapshot(base_ref="release"), "does not target"),
+            (_snapshot(base_repository="other/repo"), "does not target"),
+            (_snapshot(head_repository="PKUHPC/CraneSched"), "same-repository"),
+            (_snapshot(author="someone-else"), "only the pull request author"),
+        ]
+        for snapshot, message in cases:
+            with (
+                self.subTest(snapshot=snapshot),
+                self.assertRaisesRegex(request_ci.RequestCiError, message),
+            ):
+                api = FakeApi()
+                api.snapshots = [snapshot]
+                _handle(api)
+
+    def test_invalid_head_identity_is_rejected(self):
+        for snapshot in (
+            _snapshot(head_sha="not-a-sha"),
+            _snapshot(head_ref="bad\nref"),
+        ):
+            with (
+                self.subTest(snapshot=snapshot),
+                self.assertRaises(request_ci.RequestCiError),
+            ):
+                api = FakeApi()
+                api.snapshots = [snapshot]
+                _handle(api)
+
+    def test_pr_change_during_request_is_rejected_before_comment_write(self):
+        api = FakeApi()
+        api.snapshots = [_snapshot(), _snapshot(head_sha="d" * 40)]
+
+        with self.assertRaisesRegex(request_ci.RequestCiError, "changed"):
+            _handle(api)
+
+        self.assertEqual(api.created, [])
+        self.assertEqual(api.updated, [])
+
+
+class RunSelectionTest(unittest.TestCase):
+    def test_selects_newest_current_head_run(self):
+        api = FakeApi()
+        api.runs = [
+            _run(
+                id=100,
+                html_url="https://github.com/PKUHPC/CraneSched/actions/runs/100",
+                created_at="2026-07-22T07:00:00Z",
+            ),
+            _run(),
+            _run(
+                id=200,
+                head_sha=OLD_HEAD_SHA,
+                html_url="https://github.com/PKUHPC/CraneSched/actions/runs/200",
+                created_at="2026-07-22T09:00:00Z",
+            ),
+        ]
+
+        result = _handle(api)
+
+        self.assertEqual(result.run_id, RUN_ID)
+
+    def test_selects_newest_run_and_always_validates_its_first_attempt(self):
+        api = FakeApi()
+        api.runs = [
+            _run(
+                id=100,
+                html_url="https://github.com/PKUHPC/CraneSched/actions/runs/100",
+                created_at="2026-07-22T07:00:00Z",
+            ),
+            _run(run_attempt=2, created_at="2026-07-22T09:00:00Z"),
+        ]
+
+        result = _handle(api)
+
+        self.assertEqual(result.run_id, RUN_ID)
+        self.assertEqual(api.job_requests, [(RUN_ID, 1)])
+
+    def test_run_must_match_trusted_workflow_and_current_head(self):
+        cases = [
+            (_run(name="Other"), "name"),
+            (_run(path=".github/workflows/other.yaml"), "path"),
+            (_run(event="pull_request"), "event"),
+            (_run(run_attempt=True), "attempt"),
+            (_run(status="queued", conclusion=None), "finish"),
+            (_run(head_repository={"full_name": "other/fork"}), "current"),
+            (_run(head_branch="other"), "current"),
+            (_run(repository={"full_name": "other/repo"}), "repository"),
+        ]
+        for run, message in cases:
+            with (
+                self.subTest(run=run),
+                self.assertRaisesRegex(request_ci.RequestCiError, message),
+            ):
+                api = FakeApi()
+                api.runs = [run]
+                _handle(api)
+
+    def test_no_current_head_run_is_rejected(self):
+        api = FakeApi()
+        api.runs = [_run(head_sha=OLD_HEAD_SHA)]
+        with self.assertRaisesRegex(request_ci.RequestCiError, "no workflow run"):
+            _handle(api)
+
+    def test_duplicate_run_ids_are_rejected(self):
+        api = FakeApi()
+        api.runs = [_run(), _run()]
+        with self.assertRaisesRegex(request_ci.RequestCiError, "duplicate run"):
+            _handle(api)
+
+
+class InitialJobSafetyTest(unittest.TestCase):
+    def test_initial_jobs_match_authorize_failure_and_unassigned_system_job(self):
+        request_ci.validate_initial_jobs(_jobs())
+
+    def test_authorize_must_fail_on_hosted_runner(self):
+        for change in (
+            {"conclusion": "success"},
+            {"labels": ["self-hosted"]},
+        ):
+            jobs = _jobs()
+            jobs[0].update(change)
+            with (
+                self.subTest(change=change),
+                self.assertRaises(request_ci.RequestCiError),
+            ):
+                request_ci.validate_initial_jobs(jobs)
+
+    def test_system_job_must_never_have_reached_a_runner(self):
+        for change in (
+            {"conclusion": "failure"},
+            {"runner_id": 88},
+            {"runner_name": "cranesystemtest"},
+            {"steps": [{"name": "Set up job"}]},
+            {"labels": ["self-hosted", "other"]},
+            {"name": "test"},
+        ):
+            jobs = _jobs()
+            jobs[1].update(change)
+            with (
+                self.subTest(change=change),
+                self.assertRaises(request_ci.RequestCiError),
+            ):
+                request_ci.validate_initial_jobs(jobs)
+
+        jobs = _jobs()
+        del jobs[1]["runner_id"]
+        with self.assertRaises(request_ci.RequestCiError):
+            request_ci.validate_initial_jobs(jobs)
+
+    def test_duplicate_authorize_or_system_jobs_are_rejected(self):
+        for duplicate in (_jobs()[0], _jobs()[1]):
+            jobs = _jobs()
+            duplicate = {**duplicate, "id": 99}
+            jobs.append(duplicate)
+            with (
+                self.subTest(name=duplicate["name"]),
+                self.assertRaises(request_ci.RequestCiError),
+            ):
+                request_ci.validate_initial_jobs(jobs)
+
+
+class AttestationTest(unittest.TestCase):
+    def _attestation(self, **overrides):
+        values = {
+            "pr_number": PR_NUMBER,
+            "head_sha": HEAD_SHA,
+            "request_comment_id": REQUEST_COMMENT_ID,
+            "run_id": RUN_ID,
+        }
+        values.update(overrides)
+        return request_ci.Attestation(**values)
+
+    def test_marker_is_canonical_and_round_trips(self):
+        attestation = self._attestation()
+        marker = request_ci.canonical_marker(attestation)
+        self.assertEqual(
+            marker,
+            '<!-- cranesched-ci-request:{"head_sha":"'
+            + HEAD_SHA
+            + '","pr_number":933,"request_comment_id":456789,'
+            '"run_id":123456,"schema":1} -->',
+        )
+        self.assertEqual(request_ci.parse_marker(marker), attestation)
+
+    def test_marker_rejects_noncanonical_or_forged_payloads(self):
+        payload = self._attestation().payload()
+        cases = [
+            "<!-- cranesched-ci-request:not-json -->",
+            "<!-- cranesched-ci-request:" + json.dumps(payload) + " -->",
+            request_ci.canonical_marker(self._attestation())
+            + "\n"
+            + request_ci.canonical_marker(self._attestation()),
+            request_ci.canonical_marker(self._attestation()).replace(
+                '"schema":1', '"extra":1,"schema":1'
+            ),
+            request_ci.canonical_marker(self._attestation()).replace(
+                HEAD_SHA, HEAD_SHA.upper()
+            ),
+        ]
+        for body in cases:
+            with self.subTest(body=body), self.assertRaises(request_ci.RequestCiError):
+                request_ci.parse_marker(body)
+
+    def test_same_head_updates_single_bot_response_with_new_request(self):
+        api = FakeApi()
+        old = self._attestation(request_comment_id=111)
+        api.comments = [
+            request_ci.IssueComment(
+                comment_id=700,
+                body=request_ci.render_response(
+                    old,
+                    f"https://github.com/PKUHPC/CraneSched/actions/runs/{RUN_ID}",
+                ),
+                author="github-actions[bot]",
+                author_type="Bot",
+            )
+        ]
+
+        result = _handle(api)
+
+        self.assertEqual(result.action, "updated")
+        self.assertEqual(result.comment_id, 700)
+        self.assertEqual(api.created, [])
+        self.assertEqual(len(api.updated), 1)
+        self.assertEqual(
+            request_ci.parse_marker(api.updated[0][1]).request_comment_id,
+            REQUEST_COMMENT_ID,
+        )
+
+    def test_old_head_response_is_not_reused(self):
+        api = FakeApi()
+        old = self._attestation(head_sha=OLD_HEAD_SHA)
+        api.comments = [
+            request_ci.IssueComment(
+                comment_id=700,
+                body=request_ci.render_response(
+                    old,
+                    f"https://github.com/PKUHPC/CraneSched/actions/runs/{RUN_ID}",
+                ),
+                author="github-actions[bot]",
+                author_type="Bot",
+            )
+        ]
+
+        result = _handle(api)
+
+        self.assertEqual(result.action, "created")
+        self.assertEqual(api.updated, [])
+
+    def test_non_bot_forgery_is_ignored(self):
+        api = FakeApi()
+        marker = request_ci.canonical_marker(self._attestation())
+        api.comments = [
+            request_ci.IssueComment(
+                comment_id=700,
+                body=marker,
+                author="attacker",
+                author_type="User",
+            )
+        ]
+        self.assertEqual(_handle(api).action, "created")
+
+    def test_malformed_or_duplicate_bot_attestations_fail_closed(self):
+        good = request_ci.IssueComment(
+            comment_id=700,
+            body=request_ci.canonical_marker(self._attestation()),
+            author="github-actions[bot]",
+            author_type="Bot",
+        )
+        cases = [
+            [
+                request_ci.IssueComment(
+                    comment_id=700,
+                    body="<!-- cranesched-ci-request:bad -->",
+                    author="github-actions[bot]",
+                    author_type="Bot",
+                )
+            ],
+            [good, request_ci.IssueComment(**{**good.__dict__, "comment_id": 701})],
+        ]
+        for comments in cases:
+            with (
+                self.subTest(comments=comments),
+                self.assertRaises(request_ci.RequestCiError),
+            ):
+                api = FakeApi()
+                api.comments = comments
+                _handle(api)
+
+
+class _Response(io.BytesIO):
+    def __init__(self, value, status=200):
+        super().__init__(json.dumps(value).encode("utf-8"))
+        self.status = status
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, _type, _value, _traceback):
+        self.close()
+
+
+class GitHubApiValidationTest(unittest.TestCase):
+    def setUp(self):
+        self.api = request_ci.GitHubApi("test-token")
+
+    def test_http_status_is_exact_for_each_method(self):
+        with (
+            mock.patch.object(
+                request_ci.urllib.request,
+                "urlopen",
+                return_value=_Response({}, status=202),
+            ),
+            self.assertRaisesRegex(request_ci.RequestCiError, "HTTP status"),
+        ):
+            self.api._request("GET", "repos/PKUHPC/CraneSched")
+
+    def test_run_and_job_counts_cannot_be_boolean_or_truncated(self):
+        for method, response in (
+            (
+                lambda: self.api.workflow_runs("PKUHPC/CraneSched", HEAD_SHA),
+                {"total_count": True, "workflow_runs": [{}]},
+            ),
+            (
+                lambda: self.api.run_jobs("PKUHPC/CraneSched", RUN_ID, 1),
+                {"total_count": 2, "jobs": [{}]},
+            ),
+        ):
+            with (
+                self.subTest(response=response),
+                mock.patch.object(self.api, "_object", return_value=response),
+                self.assertRaises(request_ci.RequestCiError),
+            ):
+                method()
+
+    def test_deleted_comment_author_is_ignored_but_issue_binding_is_required(self):
+        value = {
+            "id": 12,
+            "body": "old comment",
+            "user": None,
+            "issue_url": "https://api.github.com/repos/PKUHPC/CraneSched/issues/933",
+        }
+        comment = self.api._issue_comment(value, "PKUHPC/CraneSched", 933)
+        self.assertEqual(comment.author, "")
+        self.assertEqual(comment.author_type, "")
+
+        value["issue_url"] = "https://api.github.com/repos/PKUHPC/CraneSched/issues/934"
+        with self.assertRaisesRegex(request_ci.RequestCiError, "unexpected issue"):
+            self.api._issue_comment(value, "PKUHPC/CraneSched", 933)
+
+    def test_comment_mutation_response_must_include_exact_issue_identity(self):
+        response = {
+            "id": 12,
+            "body": "response",
+            "user": {"login": "github-actions[bot]", "type": "Bot"},
+            "issue_url": "https://api.github.com/repos/PKUHPC/CraneSched/issues/934",
+        }
+        with (
+            mock.patch.object(self.api, "_object", return_value=response),
+            self.assertRaisesRegex(request_ci.RequestCiError, "unexpected issue"),
+        ):
+            self.api.create_issue_comment("PKUHPC/CraneSched", 933, "response")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/.github/ci/test_validate_workflow_routing.py
+++ b/.github/ci/test_validate_workflow_routing.py
@@ -10,6 +10,8 @@ from pathlib import Path
 MODULE_PATH = Path(__file__).with_name("validate-workflow-routing.py")
 BUILD_WORKFLOW = Path(__file__).parents[1] / "workflows" / "build.yaml"
 WORKFLOW_PATH = Path(__file__).parents[1] / "workflows" / "build.yaml"
+WORKFLOWS_DIR = Path(__file__).parents[1] / "workflows"
+REQUEST_WORKFLOW = WORKFLOWS_DIR / "request-ci.yaml"
 SPEC = importlib.util.spec_from_file_location(
     "cranesched_ci_validate_workflow_routing", MODULE_PATH
 )
@@ -43,9 +45,7 @@ class WorkflowRoutingPolicyTest(unittest.TestCase):
             encoding="utf-8",
         )
 
-        with self.assertRaisesRegex(
-            routing.RoutingPolicyError, r"debug.yml:3"
-        ):
+        with self.assertRaisesRegex(routing.RoutingPolicyError, "fixed GitHub-hosted"):
             routing.validate_workflow_routing(self.workflows_dir)
 
     def test_rejects_mixed_case_backend_label_in_another_workflow(self) -> None:
@@ -54,25 +54,72 @@ class WorkflowRoutingPolicyTest(unittest.TestCase):
             encoding="utf-8",
         )
 
-        with self.assertRaisesRegex(routing.RoutingPolicyError, r"debug.yml:3"):
+        with self.assertRaisesRegex(routing.RoutingPolicyError, "fixed GitHub-hosted"):
             routing.validate_workflow_routing(self.workflows_dir)
 
-    def test_does_not_match_maintenance_runner_label_substring(self) -> None:
+    def test_rejects_other_self_hosted_runner(self) -> None:
         (self.workflows_dir / "maintenance.yaml").write_text(
-            "jobs:\n  clean:\n"
-            "    runs-on: [self-hosted, cranesystemtest-autotest]\n",
+            "jobs:\n  clean:\n    runs-on: [self-hosted, cranesystemtest-autotest]\n",
             encoding="utf-8",
         )
 
-        routing.validate_workflow_routing(self.workflows_dir)
+        with self.assertRaisesRegex(routing.RoutingPolicyError, "fixed GitHub-hosted"):
+            routing.validate_workflow_routing(self.workflows_dir)
 
-    def test_does_not_match_dotted_runner_label_suffix(self) -> None:
+    def test_rejects_dotted_runner_label_suffix(self) -> None:
         (self.workflows_dir / "debug.yaml").write_text(
             "jobs:\n  debug:\n    runs-on: cranesystemtest.debug\n",
             encoding="utf-8",
         )
 
-        routing.validate_workflow_routing(self.workflows_dir)
+        with self.assertRaisesRegex(routing.RoutingPolicyError, "fixed GitHub-hosted"):
+            routing.validate_workflow_routing(self.workflows_dir)
+
+    def test_rejects_expression_runner_routing(self) -> None:
+        (self.workflows_dir / "debug.yaml").write_text(
+            "jobs:\n  debug:\n    runs-on: ${{ matrix.runner }}\n",
+            encoding="utf-8",
+        )
+
+        with self.assertRaisesRegex(routing.RoutingPolicyError, "fixed GitHub-hosted"):
+            routing.validate_workflow_routing(self.workflows_dir)
+
+    def test_rejects_quoted_runner_key_escape(self) -> None:
+        (self.workflows_dir / "debug.yaml").write_text(
+            'jobs:\n  debug:\n    runs-on: ubuntu-latest\n    "runs-on": self-hosted\n',
+            encoding="utf-8",
+        )
+
+        with self.assertRaisesRegex(routing.RoutingPolicyError, "non-canonical"):
+            routing.validate_workflow_routing(self.workflows_dir)
+
+    def test_rejects_job_level_reusable_workflow(self) -> None:
+        (self.workflows_dir / "debug.yaml").write_text(
+            "jobs:\n  debug:\n    uses: owner/repo/.github/workflows/job.yaml@main\n",
+            encoding="utf-8",
+        )
+
+        with self.assertRaisesRegex(routing.RoutingPolicyError, "job-level reusable"):
+            routing.validate_workflow_routing(self.workflows_dir)
+
+    def test_rejects_noncanonical_job_indentation(self) -> None:
+        (self.workflows_dir / "debug.yaml").write_text(
+            "jobs:\n   debug:\n      runs-on: self-hosted\n",
+            encoding="utf-8",
+        )
+
+        with self.assertRaisesRegex(routing.RoutingPolicyError, "non-canonical"):
+            routing.validate_workflow_routing(self.workflows_dir)
+
+    def test_rejects_duplicate_top_level_jobs_after_canonical_section(self) -> None:
+        (self.workflows_dir / "debug.yaml").write_text(
+            "jobs:\n  safe:\n    runs-on: ubuntu-latest\n"
+            '"jobs":\n  unsafe:\n    runs-on: self-hosted\n',
+            encoding="utf-8",
+        )
+
+        with self.assertRaisesRegex(routing.RoutingPolicyError, "final top-level"):
+            routing.validate_workflow_routing(self.workflows_dir)
 
     def test_requires_backend_label_in_allowed_workflow(self) -> None:
         (self.workflows_dir / "build.yaml").write_text(
@@ -80,9 +127,7 @@ class WorkflowRoutingPolicyTest(unittest.TestCase):
             encoding="utf-8",
         )
 
-        with self.assertRaisesRegex(
-            routing.RoutingPolicyError, "must route only"
-        ):
+        with self.assertRaisesRegex(routing.RoutingPolicyError, "must route only"):
             routing.validate_workflow_routing(self.workflows_dir)
 
     def test_comment_does_not_satisfy_allowed_job_selector(self) -> None:
@@ -160,6 +205,63 @@ class WorkflowRoutingPolicyTest(unittest.TestCase):
             "ref: ${{ needs.authorize.outputs.backend_sha }}",
             workflow,
         )
+
+    def test_authorization_receives_actions_run_identity(self) -> None:
+        workflow = WORKFLOW_PATH.read_text(encoding="utf-8")
+        self.assertIn("GITHUB_RUN_ID: ${{ github.run_id }}", workflow)
+        self.assertIn("GITHUB_RUN_ATTEMPT: ${{ github.run_attempt }}", workflow)
+        authorize_job = workflow.index("  authorize:\n")
+        privileged_job = workflow.index("  test:\n", authorize_job)
+        self.assertIn("      issues: read\n", workflow[authorize_job:privileged_job])
+
+    def test_final_test_is_hosted_and_never_skipped(self) -> None:
+        workflow = WORKFLOW_PATH.read_text(encoding="utf-8")
+        final_job = workflow.index("  final-test:\n")
+        final_block = workflow[final_job:]
+        self.assertIn("    name: test\n", final_block)
+        self.assertIn("    if: always()\n", final_block)
+        self.assertIn("    runs-on: ubuntu-latest\n", final_block)
+        self.assertIn("      - authorize\n", final_block)
+        self.assertIn("      - test\n", final_block)
+        self.assertIn("needs.authorize.result", final_block)
+        self.assertIn("needs.test.result", final_block)
+        self.assertIn('[[ "$AUTHORIZE_RESULT" != "success" ]]', final_block)
+        self.assertIn('[[ "$SYSTEM_TEST_RESULT" != "success" ]]', final_block)
+        privileged_job = workflow.index("  test:\n")
+        privileged_end = workflow.index("  final-test:\n", privileged_job)
+        privileged_block = workflow[privileged_job:privileged_end]
+        self.assertIn("    name: system-test\n", privileged_block)
+        self.assertIn("    runs-on: [self-hosted, cranesystemtest]\n", privileged_block)
+
+    def test_request_workflow_is_hosted_and_does_not_execute_pr_code(self) -> None:
+        workflow = REQUEST_WORKFLOW.read_text(encoding="utf-8")
+        self.assertIn("  issue_comment:\n", workflow)
+        self.assertIn("      - created\n", workflow)
+        self.assertIn("  contents: read\n", workflow)
+        self.assertIn("  pull-requests: read\n", workflow)
+        self.assertIn("  issues: write\n", workflow)
+        self.assertIn("  actions: read\n", workflow)
+        self.assertIn(
+            "  group: request-fork-ci-${{ github.event.issue.number }}\n", workflow
+        )
+        self.assertIn("  cancel-in-progress: false\n", workflow)
+        self.assertIn(
+            "if: github.event.issue.pull_request && "
+            "github.event.comment.body == '/request-ci'",
+            workflow,
+        )
+        self.assertIn("    runs-on: ubuntu-latest\n", workflow)
+        self.assertIn("ref: ${{ github.sha }}", workflow)
+        self.assertIn("persist-credentials: false", workflow)
+        self.assertIn('[[ "$DEFAULT_BRANCH" == "master" ]]', workflow)
+        self.assertIn("git -C trusted-ci rev-parse HEAD", workflow)
+        self.assertIn("trusted-ci/.github/ci/request_ci.py", workflow)
+        self.assertNotIn("pull_request.head", workflow)
+        self.assertNotIn("secrets.", workflow)
+        self.assertNotIn("self-hosted", workflow)
+
+    def test_repository_workflows_obey_routing_policy(self) -> None:
+        routing.validate_workflow_routing(WORKFLOWS_DIR)
 
     def test_stale_head_is_not_used_as_routing_input(self) -> None:
         stale_head = self.workflows_dir / "stale-head"

--- a/.github/ci/validate-workflow-routing.py
+++ b/.github/ci/validate-workflow-routing.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""Keep the privileged repository runner label in its trusted workflow."""
+"""Keep every workflow job on its approved runner boundary."""
 
 from __future__ import annotations
 
@@ -12,71 +12,112 @@ from pathlib import Path
 ALLOWED_WORKFLOW = "build.yaml"
 ALLOWED_JOB = "test"
 RUNNER_LABEL = "cranesystemtest"
-_LABEL_CHARACTER = r"A-Za-z0-9_.-"
+GITHUB_HOSTED_RUNNER = "ubuntu-latest"
 _JOB_KEY_RE = re.compile(r"^  ([A-Za-z0-9_-]+):\s*(?:#.*)?$")
-_INLINE_RUNS_ON_RE = re.compile(
-    r"^    runs-on:\s*\[([^\]]+)\]\s*(?:#.*)?$",
-    re.IGNORECASE,
-)
+_DIRECT_PROPERTY_RE = re.compile(r"^    ([A-Za-z0-9_-]+):(?:\s*(.*?))?\s*$")
 
 
 class RoutingPolicyError(RuntimeError):
     pass
 
 
-def _label_pattern(label: str) -> re.Pattern[str]:
-    if not label or label != label.strip():
-        raise ValueError("runner label must be a non-empty trimmed string")
-    return re.compile(
-        rf"(?<![{_LABEL_CHARACTER}]){re.escape(label)}"
-        rf"(?![{_LABEL_CHARACTER}])",
-        re.IGNORECASE,
-    )
-
-
-def _validate_allowed_job_selector(path: Path, runner_label: str) -> None:
+def _split_jobs(path: Path) -> dict[str, list[str]]:
     lines = path.read_text(encoding="utf-8").splitlines()
     jobs_headers = [index for index, line in enumerate(lines) if line == "jobs:"]
     if len(jobs_headers) != 1:
-        raise RoutingPolicyError(f"{ALLOWED_WORKFLOW} must have one canonical jobs section")
+        raise RoutingPolicyError(f"{path.name} must have one canonical jobs section")
     jobs_start = jobs_headers[0] + 1
     jobs_end = len(lines)
     for index in range(jobs_start, len(lines)):
         line = lines[index]
         if line and not line[0].isspace() and not line.startswith("#"):
-            jobs_end = index
-            break
+            raise RoutingPolicyError(
+                f"{path.name} jobs must be the final top-level section"
+            )
 
-    job_start: int | None = None
-    job_end = jobs_end
+    starts: list[tuple[str, int]] = []
     for index in range(jobs_start, jobs_end):
         line = lines[index]
         match = _JOB_KEY_RE.fullmatch(line)
+        if match is not None:
+            starts.append((match.group(1), index))
+            continue
+        if not line.strip() or line.lstrip().startswith("#"):
+            continue
+        indentation = len(line) - len(line.lstrip(" "))
+        if indentation < 4:
+            raise RoutingPolicyError(
+                f"{path.name} has a non-canonical job declaration: {line.strip()}"
+            )
+    if not starts:
+        raise RoutingPolicyError(f"{path.name} must declare at least one job")
+    if len({name for name, _ in starts}) != len(starts):
+        raise RoutingPolicyError(f"{path.name} contains a duplicate job declaration")
+
+    jobs: dict[str, list[str]] = {}
+    for offset, (name, start) in enumerate(starts):
+        end = starts[offset + 1][1] if offset + 1 < len(starts) else jobs_end
+        jobs[name] = lines[start + 1 : end]
+    return jobs
+
+
+def _direct_properties(lines: list[str]) -> dict[str, list[str]]:
+    properties: dict[str, list[str]] = {}
+    for line in lines:
+        match = _DIRECT_PROPERTY_RE.fullmatch(line)
         if match is None:
             continue
-        if job_start is None and match.group(1) == ALLOWED_JOB:
-            job_start = index + 1
-            continue
-        if job_start is not None:
-            job_end = index
-            break
-    if job_start is None:
-        raise RoutingPolicyError(f"allowed job is missing: {ALLOWED_JOB}")
+        value = (match.group(2) or "").strip()
+        if " #" in value:
+            value = value.split(" #", 1)[0].rstrip()
+        properties.setdefault(match.group(1).casefold(), []).append(value)
+    return properties
 
-    selectors = [
-        match.group(1)
-        for line in lines[job_start:job_end]
-        if (match := _INLINE_RUNS_ON_RE.fullmatch(line)) is not None
-    ]
+
+def _validate_job_selector(
+    path: Path,
+    job_name: str,
+    lines: list[str],
+    *,
+    privileged: bool,
+    runner_label: str,
+) -> None:
+    for line in lines:
+        if not line.strip() or line.lstrip().startswith("#"):
+            continue
+        indentation = len(line) - len(line.lstrip(" "))
+        if indentation == 4 and _DIRECT_PROPERTY_RE.fullmatch(line) is None:
+            raise RoutingPolicyError(
+                f"{path.name}:{job_name} has a non-canonical job property: "
+                f"{line.strip()}"
+            )
+    properties = _direct_properties(lines)
+    if "uses" in properties:
+        raise RoutingPolicyError(
+            f"{path.name}:{job_name} must not call a job-level reusable workflow"
+        )
+    selectors = properties.get("runs-on", [])
     if len(selectors) != 1:
         raise RoutingPolicyError(
-            f"{ALLOWED_WORKFLOW}:{ALLOWED_JOB} must have one inline runs-on selector"
+            f"{path.name}:{job_name} must have one runs-on selector"
         )
-    labels = [item.strip().strip("'\"").casefold() for item in selectors[0].split(",")]
-    if labels != ["self-hosted", runner_label.casefold()]:
+
+    selector = selectors[0]
+    if privileged:
+        expected = f"[self-hosted, {runner_label}]"
+        if selector.casefold() != expected.casefold():
+            raise RoutingPolicyError(
+                f"{path.name}:{job_name} must route only to {expected}"
+            )
+        return
+
+    unquoted = selector
+    if len(selector) >= 2 and selector[0] == selector[-1] and selector[0] in "'\"":
+        unquoted = selector[1:-1]
+    if unquoted != GITHUB_HOSTED_RUNNER:
         raise RoutingPolicyError(
-            f"{ALLOWED_WORKFLOW}:{ALLOWED_JOB} must route only to "
-            f"[self-hosted, {runner_label}]"
+            f"{path.name}:{job_name} must route to the fixed GitHub-hosted "
+            f"runner {GITHUB_HOSTED_RUNNER}"
         )
 
 
@@ -91,34 +132,28 @@ def validate_workflow_routing(
     if Path(allowed_workflow).name != allowed_workflow:
         raise RoutingPolicyError("allowed workflow must be a filename")
 
-    pattern = _label_pattern(runner_label)
     workflow_paths = sorted(
-        path
-        for path in workflows_dir.iterdir()
-        if path.suffix in {".yaml", ".yml"}
+        path for path in workflows_dir.iterdir() if path.suffix in {".yaml", ".yml"}
     )
     allowed_path = workflows_dir / allowed_workflow
     if allowed_path not in workflow_paths:
         raise RoutingPolicyError(f"allowed workflow is missing: {allowed_workflow}")
 
-    violations: list[str] = []
     for path in workflow_paths:
         if path.is_symlink() or not path.is_file():
             raise RoutingPolicyError(f"workflow must be a regular file: {path.name}")
-        text = path.read_text(encoding="utf-8")
-        for line_number, line in enumerate(text.splitlines(), start=1):
-            if pattern.search(line) is None:
-                continue
-            if path != allowed_path:
-                violations.append(f"{path.name}:{line_number}")
-
-    if violations:
-        locations = ", ".join(violations)
-        raise RoutingPolicyError(
-            f"runner label {runner_label!r} is restricted to {allowed_workflow}; "
-            f"found in {locations}"
-        )
-    _validate_allowed_job_selector(allowed_path, runner_label)
+        jobs = _split_jobs(path)
+        for job_name, lines in jobs.items():
+            privileged = path == allowed_path and job_name == ALLOWED_JOB
+            _validate_job_selector(
+                path,
+                job_name,
+                lines,
+                privileged=privileged,
+                runner_label=runner_label,
+            )
+    if ALLOWED_JOB not in _split_jobs(allowed_path):
+        raise RoutingPolicyError(f"allowed job is missing: {ALLOWED_JOB}")
 
 
 def main(argv: list[str] | None = None) -> int:
@@ -131,8 +166,8 @@ def main(argv: list[str] | None = None) -> int:
         print(f"workflow routing validation failed: {exc}", file=sys.stderr)
         return 1
     print(
-        f"workflow routing validated: {RUNNER_LABEL} is restricted to "
-        f"{ALLOWED_WORKFLOW}"
+        f"workflow routing validated: {ALLOWED_WORKFLOW}:{ALLOWED_JOB} is the "
+        f"only {RUNNER_LABEL} job and every other job uses {GITHUB_HOSTED_RUNNER}"
     )
     return 0
 

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -58,6 +58,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
+      issues: read
       pull-requests: read
     outputs:
       authorized: ${{ steps.authorize.outputs.authorized }}
@@ -88,6 +89,8 @@ jobs:
           REPOSITORY: ${{ github.repository }}
           WORKFLOW_REF: ${{ github.workflow_ref }}
           TRIGGERING_ACTOR: ${{ github.triggering_actor }}
+          GITHUB_RUN_ID: ${{ github.run_id }}
+          GITHUB_RUN_ATTEMPT: ${{ github.run_attempt }}
           EVENT_SHA: ${{ github.sha }}
           PR_NUMBER: ${{ github.event.pull_request.number || '' }}
           PR_BASE_REPOSITORY: ${{ github.event.pull_request.base.repo.full_name || '' }}
@@ -140,7 +143,7 @@ jobs:
           --workflows-dir candidate-routing/.github/workflows
 
   test:
-    name: test
+    name: system-test
     needs: authorize
     if: needs.authorize.outputs.authorized == 'true'
     runs-on: [self-hosted, cranesystemtest]
@@ -481,3 +484,26 @@ jobs:
             2) echo "System tests ended with an infrastructure error." >&2; exit 2 ;;
             *) echo "System tests did not produce a valid aggregate exit code." >&2; exit 2 ;;
           esac
+
+  final-test:
+    name: test
+    needs:
+      - authorize
+      - test
+    if: always()
+    runs-on: ubuntu-latest
+    permissions: {}
+    steps:
+      - name: Enforce required test check
+        env:
+          AUTHORIZE_RESULT: ${{ needs.authorize.result }}
+          SYSTEM_TEST_RESULT: ${{ needs.test.result }}
+        run: |
+          if [[ "$AUTHORIZE_RESULT" != "success" ]]; then
+            echo "Trusted CI authorization did not succeed." >&2
+            exit 1
+          fi
+          if [[ "$SYSTEM_TEST_RESULT" != "success" ]]; then
+            echo "The CraneTestKit system test did not succeed." >&2
+            exit 1
+          fi

--- a/.github/workflows/request-ci.yaml
+++ b/.github/workflows/request-ci.yaml
@@ -1,0 +1,49 @@
+name: Request Fork CI
+
+on:
+  issue_comment:
+    types:
+      - created
+
+permissions:
+  contents: read
+  pull-requests: read
+  issues: write
+  actions: read
+
+concurrency:
+  group: request-fork-ci-${{ github.event.issue.number }}
+  cancel-in-progress: false
+
+jobs:
+  request:
+    name: Record fork CI request
+    if: github.event.issue.pull_request && github.event.comment.body == '/request-ci'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout trusted request policy
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
+        with:
+          ref: ${{ github.sha }}
+          path: trusted-ci
+          sparse-checkout: .github/ci
+          persist-credentials: false
+          clean: true
+          set-safe-directory: false
+
+      - name: Verify trusted request policy revision
+        env:
+          DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}
+          EXPECTED_SHA: ${{ github.sha }}
+        run: |
+          [[ "$DEFAULT_BRANCH" == "master" ]]
+          [[ "$(git -C trusted-ci rev-parse HEAD)" == "$EXPECTED_SHA" ]]
+
+      - name: Record request for maintainer approval
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+          GITHUB_API_URL: ${{ github.api_url }}
+          GITHUB_REPOSITORY: ${{ github.repository }}
+        run: >-
+          /usr/bin/python3 -I trusted-ci/.github/ci/request_ci.py
+          --event-path "$GITHUB_EVENT_PATH"


### PR DESCRIPTION
## Summary

- add a hosted-only `/request-ci` workflow for fork pull request authors
- bind each request to the current fork repository, ref, head SHA, original comment, and exact failed workflow run
- require a current `maintain` or `admin` user to approve by rerunning the bot-linked run
- keep the privileged YAML job ID `test`, rename its display name to `system-test`, and preserve the required `test` context with an always-run hosted finalizer
- harden candidate workflow routing so every job except `build.yaml:test` uses a fixed GitHub-hosted runner

## Security boundary

Fork attempt 1 always fails before permission lookup and never reaches `cranesystemtest`. A rerun must match a canonical `github-actions[bot]` attestation and the original, unchanged `/request-ci` comment from the current PR author. Authorization then repeats the existing live permission, base/head, proposed merge, parent ordering, routing, Backend, and FrontEnd checks.

The request workflow checks out only the exact default-branch SHA, does not execute pull request code, uses no repository secret, and has only the permissions needed to read Actions/PR state and create or update its bot reply.

## Validation

- `.github/ci` unit tests: 133 passed
- Ruff check and format check: passed for all changed Python files
- actionlint v1.7.7: passed for all workflows
- workflow YAML parse and repository routing validation: passed
- live GitHub REST schema checked against run `29794463501`, including exact fork head identity and the unassigned/skipped privileged job fields from attempt 1

## Rollout

After merge, PR #933 needs a new `reopened` event so it receives the new workflow. Do not rerun old run `29794463501`. The PR author then comments exactly `/request-ci`, and a maintainer uses **Re-run all jobs** from the bot-linked run.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a controlled `/request-ci` process for approving and rerunning CI on fork pull requests.
  * Added explicit workflow status reporting so authorization or system-test failures appear as required-check failures.
  * Added stricter CI routing to ensure only the approved privileged job uses the self-hosted runner.

* **Bug Fixes**
  * Prevented stale, modified, duplicated, or mismatched CI approvals from authorizing runs.
  * Added fail-closed handling for invalid workflow configurations and authorization data.

* **Tests**
  * Expanded coverage for fork approvals, workflow routing, attestation validation, and failure scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->