### PR TITLE
fix(ci): allow request workflow to write PR comments

### DIFF
--- a/.github/ci/test_validate_workflow_routing.py
+++ b/.github/ci/test_validate_workflow_routing.py
@@ -238,9 +238,10 @@ class WorkflowRoutingPolicyTest(unittest.TestCase):
         self.assertIn("  issue_comment:\n", workflow)
         self.assertIn("      - created\n", workflow)
         self.assertIn("  contents: read\n", workflow)
-        self.assertIn("  pull-requests: read\n", workflow)
-        self.assertIn("  issues: write\n", workflow)
         self.assertIn("  actions: read\n", workflow)
+        self.assertIn("  issues: write\n", workflow)
+        self.assertIn("  pull-requests: write\n", workflow)
+        self.assertNotIn("  pull-requests: read\n", workflow)
         self.assertIn(
             "  group: request-fork-ci-${{ github.event.issue.number }}\n", workflow
         )

--- a/.github/workflows/request-ci.yaml
+++ b/.github/workflows/request-ci.yaml
@@ -7,9 +7,9 @@ on:
 
 permissions:
   contents: read
-  pull-requests: read
-  issues: write
   actions: read
+  issues: write
+  pull-requests: write
 
 concurrency:
   group: request-fork-ci-${{ github.event.issue.number }}


### PR DESCRIPTION
The fork CI request workflow currently receives HTTP 403 while creating its bot attestation comment. Grant pull-requests: write in addition to the existing issues: write permission and lock the permission contract in tests.

Validation: 133 CI unit tests, workflow routing validator, YAML parse, Ruff, actionlint, and git diff --check.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated automated workflow permissions to support writing pull request updates.
  * Refined validation checks to confirm the workflow uses the intended access levels.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->