### PR TITLE
fix(ci): allow maintainers to request fork CI

### DIFF
--- a/.github/ci/README.md
+++ b/.github/ci/README.md
@@ -10,8 +10,9 @@ privileged job is dispatched only when all of the following are true:
 - the workflow was loaded from `master`;
 - a same-repository pull request was triggered by a user whose current
   permission is `maintain` or `admin`; or
-- a fork pull request author recorded an exact-head `/request-ci` request and
-  a current `maintain` or `admin` user reran that same workflow run;
+- a fork pull request author or current `maintain`/`admin` user recorded an
+  exact-head `/request-ci` request and a current `maintain` or `admin` user
+  reran that same workflow run;
 - Backend and FrontEnd refs resolve to full commit SHAs.
 
 The privileged job uses the dedicated repository-scoped runner selected by the
@@ -23,21 +24,23 @@ accepted boundary of the deployment.
 ## Fork pull request approval
 
 The first `pull_request_target` run for a fork always fails in the hosted
-authorization job and never queues `cranesystemtest`. The fork author can then
-comment exactly `/request-ci`. The hosted-only `request-ci.yaml` workflow
-requires an open, non-draft fork PR targeting `master`, binds the request to
-the current head repository, ref and SHA, and verifies that attempt 1 of the
-latest matching `build.yaml` run failed authorization without assigning or
-starting `system-test`.
+authorization job and never queues `cranesystemtest`. The fork author or a
+current `maintain`/`admin` user can then comment exactly `/request-ci`. The
+hosted-only `request-ci.yaml` workflow requires an open, non-draft fork PR
+targeting `master`, verifies a non-author requester's current permission, binds
+the request to the current head repository, ref and SHA, and verifies that
+attempt 1 of the latest matching `build.yaml` run failed authorization without
+assigning or starting `system-test`.
 
 The bot reply records a canonical hidden attestation containing the PR number,
 head SHA, original request comment ID and workflow run ID. A maintainer approves
 that exact request by following the reply and selecting **Re-run all jobs**.
-Every rerun checks the maintainer's current permission, rereads the original
-request comment, resolves the current PR and proposed merge, and rejects any
-run, head, base, comment or merge drift. A new head requires a new
-`/request-ci` comment. A maintainer may rerun the same attested run again after
-an infrastructure failure; all checks execute again.
+Every rerun checks the rerun actor's current permission and, for a request made
+by someone other than the PR author, the requester's current permission. It
+rereads the original request comment, resolves the current PR and proposed
+merge, and rejects any run, head, base, comment, permission or merge drift. A
+new head requires a new `/request-ci` comment. A maintainer may rerun the same
+attested run again after an infrastructure failure; all checks execute again.
 
 The request workflow has only hosted-runner access and read-only repository and
 Actions permissions plus permission to create or update its issue comment. It

--- a/.github/ci/authorize.py
+++ b/.github/ci/authorize.py
@@ -225,9 +225,10 @@ def _validate_fork_request(
     )
     if run_attempt == 1:
         raise AuthorizationError(
-            "fork pull requests require approval: the pull request author must "
-            "comment exactly `/request-ci`, then a maintainer must use `Re-run all "
-            "jobs` on the workflow run linked by github-actions[bot]"
+            "fork pull requests require approval: the pull request author or a "
+            "maintain/admin user must comment exactly `/request-ci`, then a "
+            "maintainer must use `Re-run all jobs` on the workflow run linked by "
+            "github-actions[bot]"
         )
 
     if (
@@ -278,9 +279,16 @@ def _validate_fork_request(
         raise AuthorizationError("GitHub returned an unexpected request comment")
     if request.body != "/request-ci":
         raise AuthorizationError("the original `/request-ci` comment was edited")
-    if request.author_login != snapshot.author_login:
+    if request.author_type != "User":
         raise AuthorizationError(
-            "the original `/request-ci` comment was not created by the PR author"
+            "the original `/request-ci` comment was not created by a user"
+        )
+    if request.author_login != snapshot.author_login and not _has_maintain_permission(
+        permission_lookup(context.repository, request.author_login)
+    ):
+        raise AuthorizationError(
+            "the original `/request-ci` comment was not created by the PR author "
+            "or a current maintain/admin user"
         )
 
 

--- a/.github/ci/request_ci.py
+++ b/.github/ci/request_ci.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""Record a fork author's request for a maintainer-approved CI rerun."""
+"""Record an authorized request for a maintainer-approved fork CI rerun."""
 
 from __future__ import annotations
 
@@ -119,6 +119,8 @@ class RequestResult:
 
 
 class RequestCiApi(Protocol):
+    def permission(self, repository: str, actor: str) -> dict[str, object]: ...
+
     def pull_request(self, repository: str, number: int) -> PullRequestSnapshot: ...
 
     def workflow_runs(
@@ -377,7 +379,7 @@ def validate_initial_jobs(values: list[dict[str, object]]) -> None:
         raise RequestCiError("privileged workflow job started executing steps")
 
 
-def _validate_pr(snapshot: PullRequestSnapshot, number: int, commenter: str) -> None:
+def _validate_pr(snapshot: PullRequestSnapshot, number: int) -> None:
     if snapshot.number != number:
         raise RequestCiError("GitHub returned an unexpected pull request")
     if snapshot.state != "open":
@@ -388,8 +390,6 @@ def _validate_pr(snapshot: PullRequestSnapshot, number: int, commenter: str) -> 
         raise RequestCiError("pull request does not target PKUHPC/CraneSched:master")
     if snapshot.head_repository == snapshot.base_repository:
         raise RequestCiError("same-repository pull requests do not use /request-ci")
-    if snapshot.author != commenter:
-        raise RequestCiError("only the pull request author may request CI")
     if SHA_RE.fullmatch(snapshot.base_sha) is None:
         raise RequestCiError("pull request base SHA is invalid")
     if SHA_RE.fullmatch(snapshot.head_sha) is None:
@@ -398,7 +398,34 @@ def _validate_pr(snapshot: PullRequestSnapshot, number: int, commenter: str) -> 
         raise RequestCiError("pull request head ref is invalid")
 
 
-def _event_request(event: object, repository: str) -> tuple[int, int, str] | None:
+def _has_maintain_permission(value: dict[str, object]) -> bool:
+    if value.get("permission") in {"maintain", "admin"}:
+        return True
+    user = value.get("user")
+    permissions = user.get("permissions") if isinstance(user, dict) else None
+    return isinstance(permissions, dict) and (
+        permissions.get("maintain") is True or permissions.get("admin") is True
+    )
+
+
+def _validate_requester(
+    snapshot: PullRequestSnapshot,
+    repository: str,
+    commenter: str,
+    commenter_type: str,
+    api: RequestCiApi,
+) -> None:
+    if commenter_type != "User":
+        raise RequestCiError("only a user may request CI")
+    if commenter == snapshot.author:
+        return
+    if not _has_maintain_permission(api.permission(repository, commenter)):
+        raise RequestCiError(
+            "only the pull request author or a maintain/admin user may request CI"
+        )
+
+
+def _event_request(event: object, repository: str) -> tuple[int, int, str, str] | None:
     root = _mapping(event, "issue_comment event")
     if root.get("action") != "created":
         return None
@@ -415,7 +442,8 @@ def _event_request(event: object, repository: str) -> tuple[int, int, str] | Non
     comment_id = _positive_int(comment.get("id"), "request comment ID")
     user = _mapping(comment.get("user"), "request comment author")
     commenter = _required_string(user.get("login"), "request comment author login")
-    return number, comment_id, commenter
+    commenter_type = _required_string(user.get("type"), "request comment author type")
+    return number, comment_id, commenter, commenter_type
 
 
 def handle_request(
@@ -426,10 +454,11 @@ def handle_request(
     request = _event_request(event, repository)
     if request is None:
         return None
-    number, request_comment_id, commenter = request
+    number, request_comment_id, commenter, commenter_type = request
 
     snapshot = api.pull_request(repository, number)
-    _validate_pr(snapshot, number, commenter)
+    _validate_pr(snapshot, number)
+    _validate_requester(snapshot, repository, commenter, commenter_type, api)
     run = select_workflow_run(
         api.workflow_runs(repository, snapshot.head_sha), snapshot
     )
@@ -450,9 +479,10 @@ def handle_request(
         raise RequestCiError("multiple bot attestations exist for the current head")
 
     final_snapshot = api.pull_request(repository, number)
-    _validate_pr(final_snapshot, number, commenter)
+    _validate_pr(final_snapshot, number)
     if final_snapshot != snapshot:
         raise RequestCiError("pull request changed while recording the CI request")
+    _validate_requester(final_snapshot, repository, commenter, commenter_type, api)
 
     attestation = Attestation(
         pr_number=number,
@@ -575,6 +605,12 @@ class GitHubApi:
             if len(current) < 100:
                 return values
         raise RequestCiError("GitHub API pagination exceeded the safety limit")
+
+    def permission(self, repository: str, actor: str) -> dict[str, object]:
+        encoded_actor = urllib.parse.quote(actor, safe="")
+        return self._object(
+            "GET", f"repos/{repository}/collaborators/{encoded_actor}/permission"
+        )
 
     def pull_request(self, repository: str, number: int) -> PullRequestSnapshot:
         value = self._object("GET", f"repos/{repository}/pulls/{number}")

--- a/.github/ci/test_authorize.py
+++ b/.github/ci/test_authorize.py
@@ -164,6 +164,7 @@ def _authorize(
     context: authorize.DispatchContext | None = None,
     *,
     permission: str = "maintain",
+    actor_permissions: dict[str, str] | None = None,
     resolver=_resolver,
     pull_request_lookup=_pull_request,
     merge_ref_resolver=_merge_ref,
@@ -172,9 +173,12 @@ def _authorize(
     issue_comment_lookup=None,
     retry_delays: tuple[float, ...] = (),
 ) -> dict[str, str]:
+    resolved_context = context or _context()
+    permissions = {resolved_context.triggering_actor: permission}
+    permissions.update(actor_permissions or {})
     return authorize.authorize_dispatch(
-        context or _context(),
-        lambda _repo, _actor: {"permission": permission},
+        resolved_context,
+        lambda _repo, actor: {"permission": permissions.get(actor, "none")},
         resolver,
         pull_request_lookup,
         merge_ref_resolver,
@@ -431,11 +435,51 @@ class AuthorizationPolicyTest(unittest.TestCase):
         self.assertEqual(result["routing_sha"], MERGE_SHA)
         self.assertEqual(result["pr_head_sha"], FORK_HEAD_SHA)
 
+    def test_maintainer_request_allows_a_different_maintainer_to_rerun(self) -> None:
+        result = _authorize(
+            _fork_context(triggering_actor="rerun-maintainer"),
+            permission="admin",
+            actor_permissions={"request-maintainer": "maintain"},
+            pull_request_lookup=_fork_pull_request,
+            commit_parents_resolver=_fork_commit_parents,
+            issue_comments_lookup=lambda _repo, _number: (_attestation_comment(),),
+            issue_comment_lookup=lambda _repo, _number, _comment_id: (
+                _request_comment(author_login="request-maintainer")
+            ),
+        )
+
+        self.assertEqual(result["backend_sha"], FORK_HEAD_SHA)
+
+    def test_non_author_requester_must_still_have_maintain_permission(self) -> None:
+        for permission in ("write", "triage", "read", "none"):
+            with (
+                self.subTest(permission=permission),
+                self.assertRaisesRegex(
+                    authorize.AuthorizationError, "current maintain/admin"
+                ),
+            ):
+                _authorize(
+                    _fork_context(),
+                    actor_permissions={"requester": permission},
+                    pull_request_lookup=_fork_pull_request,
+                    commit_parents_resolver=_fork_commit_parents,
+                    issue_comments_lookup=lambda _repo, _number: (
+                        _attestation_comment(),
+                    ),
+                    issue_comment_lookup=lambda _repo, _number, _comment_id: (
+                        _request_comment(author_login="requester")
+                    ),
+                )
+
     def test_deleted_or_edited_fork_request_is_rejected(self) -> None:
         for request, message in (
             (None, "no longer exists"),
             (_request_comment(body="/request-ci please"), "was edited"),
-            (_request_comment(author_login="someone-else"), "PR author"),
+            (_request_comment(author_type="Bot"), "not created by a user"),
+            (
+                _request_comment(author_login="someone-else"),
+                "PR author or a current maintain/admin",
+            ),
         ):
             with (
                 self.subTest(message=message),

--- a/.github/ci/test_request_ci.py
+++ b/.github/ci/test_request_ci.py
@@ -33,7 +33,7 @@ def _event(**overrides):
         "comment": {
             "id": REQUEST_COMMENT_ID,
             "body": "/request-ci",
-            "user": {"login": "fork-author"},
+            "user": {"login": "fork-author", "type": "User"},
         },
     }
     value.update(overrides)
@@ -130,9 +130,15 @@ class FakeApi:
         self.runs = [_run()]
         self.jobs = _jobs()
         self.comments = []
+        self.permissions = {}
         self.created = []
         self.updated = []
         self.job_requests = []
+        self.permission_requests = []
+
+    def permission(self, repository, actor):
+        self.permission_requests.append((repository, actor))
+        return self.permissions.get(actor, {"permission": "none"})
 
     def pull_request(self, _repository, _number):
         if len(self.snapshots) > 1:
@@ -197,6 +203,100 @@ class RequestProtocolTest(unittest.TestCase):
         self.assertIn(f"`{HEAD_SHA}`", api.created[0][1])
         self.assertIn(f"actions/runs/{RUN_ID}", api.created[0][1])
         self.assertIn("Re-run all jobs", api.created[0][1])
+        self.assertEqual(api.permission_requests, [])
+
+    def test_current_maintainer_or_admin_can_request_ci(self):
+        for permission in ("maintain", "admin"):
+            with self.subTest(permission=permission):
+                api = FakeApi()
+                api.permissions["requester"] = {"permission": permission}
+                event = _event(
+                    comment={
+                        "id": REQUEST_COMMENT_ID,
+                        "body": "/request-ci",
+                        "user": {"login": "requester", "type": "User"},
+                    }
+                )
+
+                result = _handle(api, event)
+
+                self.assertEqual(result.action, "created")
+                self.assertEqual(
+                    api.permission_requests,
+                    [
+                        ("PKUHPC/CraneSched", "requester"),
+                        ("PKUHPC/CraneSched", "requester"),
+                    ],
+                )
+
+    def test_non_author_without_maintain_permission_is_rejected(self):
+        for permission in ("write", "triage", "read", "none"):
+            with self.subTest(permission=permission):
+                api = FakeApi()
+                api.permissions["requester"] = {"permission": permission}
+                event = _event(
+                    comment={
+                        "id": REQUEST_COMMENT_ID,
+                        "body": "/request-ci",
+                        "user": {"login": "requester", "type": "User"},
+                    }
+                )
+
+                with self.assertRaisesRegex(
+                    request_ci.RequestCiError, "author or a maintain/admin"
+                ):
+                    _handle(api, event)
+
+                self.assertEqual(api.created, [])
+
+    def test_non_user_and_permission_lookup_failure_are_rejected(self):
+        api = FakeApi()
+        api.permissions["requester"] = {"permission": "admin"}
+        bot_event = _event(
+            comment={
+                "id": REQUEST_COMMENT_ID,
+                "body": "/request-ci",
+                "user": {"login": "requester", "type": "Bot"},
+            }
+        )
+        with self.assertRaisesRegex(request_ci.RequestCiError, "only a user"):
+            _handle(api, bot_event)
+        self.assertEqual(api.permission_requests, [])
+
+        api = FakeApi()
+        api.permission = mock.Mock(
+            side_effect=request_ci.RequestCiError("GitHub API request failed")
+        )
+        user_event = _event(
+            comment={
+                "id": REQUEST_COMMENT_ID,
+                "body": "/request-ci",
+                "user": {"login": "requester", "type": "User"},
+            }
+        )
+        with self.assertRaisesRegex(request_ci.RequestCiError, "API request failed"):
+            _handle(api, user_event)
+
+    def test_maintainer_permission_revoked_while_recording_is_rejected(self):
+        api = FakeApi()
+        api.permission = mock.Mock(
+            side_effect=[{"permission": "maintain"}, {"permission": "write"}]
+        )
+        event = _event(
+            comment={
+                "id": REQUEST_COMMENT_ID,
+                "body": "/request-ci",
+                "user": {"login": "requester", "type": "User"},
+            }
+        )
+
+        with self.assertRaisesRegex(
+            request_ci.RequestCiError, "author or a maintain/admin"
+        ):
+            _handle(api, event)
+
+        self.assertEqual(api.created, [])
+        self.assertEqual(api.updated, [])
 
     def test_non_created_wrong_command_and_non_pr_comments_are_ignored(self):
         cases = [
@@ -205,7 +305,7 @@ class RequestProtocolTest(unittest.TestCase):
                 comment={
                     "id": 1,
                     "body": "/request-ci ",
-                    "user": {"login": "fork-author"},
+                    "user": {"login": "fork-author", "type": "User"},
                 }
             ),
             _event(issue={"number": PR_NUMBER}),
@@ -225,14 +325,16 @@ class RequestProtocolTest(unittest.TestCase):
                 _event(repository={"full_name": "attacker/CraneSched"}),
             )
 
-    def test_pr_must_be_open_ready_fork_targeting_master_and_requested_by_author(self):
+    def test_pr_must_be_open_ready_fork_targeting_master_and_requested_by_authorized_user(
+        self,
+    ):
         cases = [
             (_snapshot(state="closed"), "not open"),
             (_snapshot(draft=True), "draft"),
             (_snapshot(base_ref="release"), "does not target"),
             (_snapshot(base_repository="other/repo"), "does not target"),
             (_snapshot(head_repository="PKUHPC/CraneSched"), "same-repository"),
-            (_snapshot(author="someone-else"), "only the pull request author"),
+            (_snapshot(author="someone-else"), "author or a maintain/admin"),
         ]
         for snapshot, message in cases:
             with (
@@ -544,6 +646,18 @@ class GitHubApiValidationTest(unittest.TestCase):
             self.assertRaisesRegex(request_ci.RequestCiError, "HTTP status"),
         ):
             self.api._request("GET", "repos/PKUHPC/CraneSched")
+
+    def test_permission_lookup_encodes_actor_and_returns_exact_response(self):
+        response = {"permission": "maintain"}
+        with mock.patch.object(self.api, "_object", return_value=response) as get:
+            self.assertEqual(
+                self.api.permission("PKUHPC/CraneSched", "maintainer/name"),
+                response,
+            )
+        get.assert_called_once_with(
+            "GET",
+            "repos/PKUHPC/CraneSched/collaborators/maintainer%2Fname/permission",
+        )
 
     def test_run_and_job_counts_cannot_be_boolean_or_truncated(self):
         for method, response in (


### PR DESCRIPTION
## Summary

- allow a fork PR author or a current `maintain`/`admin` user to comment `/request-ci`
- revalidate a non-author requester's permission when recording the request and again when authorizing the rerun
- keep the rerun actor's independent `maintain`/`admin` requirement and update the documented approval contract

## Security boundary

`write`, `triage`, ordinary third-party, and non-user requesters remain rejected. Permission lookup errors fail closed. The attestation stays bound to the exact PR, head SHA, request comment ID, and original workflow run.

## Validation

- 140 `.github/ci/test_*.py` tests passed
- Ruff check and format check passed for all changed Python files
- actionlint passed
- workflow YAML parsing passed
- repository runner routing validation passed
- `git diff --check` passed

After merge, the real `issue_comment` token path will be validated on fork PR #933 by having a maintainer comment `/request-ci` and then rerun the linked workflow.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Fork pull request CI requests can now be submitted by the pull request author or an authorized maintainer.
  * Added clearer approval and rerun workflows for privileged CI jobs.
* **Bug Fixes**
  * Improved validation of request authors, permissions, comments, workflow runs, and commit changes.
  * Added safeguards against edited, deleted, outdated, or unauthorized CI requests.
* **Documentation**
  * Clarified `/request-ci` requirements, rerun permissions, and handling of infrastructure failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->