### PR TITLE
fix: install standalone plugin config by default

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -611,6 +611,15 @@ if [ ! -f /etc/crane/database.yaml ]; then
     fi
 fi
 
+if [ ! -f /etc/crane/plugin.yaml ]; then
+    if [ -f /etc/crane/plugin.yaml.sample ]; then
+        cp /etc/crane/plugin.yaml.sample /etc/crane/plugin.yaml
+        chown crane:crane /etc/crane/plugin.yaml
+        chmod 644 /etc/crane/plugin.yaml
+        echo \"Created new configuration file: /etc/crane/plugin.yaml\"
+    fi
+fi
+
 exit 0
 ")
 

--- a/docs/en/command/cacctmgr.md
+++ b/docs/en/command/cacctmgr.md
@@ -29,6 +29,7 @@ cacctmgr <ACTION> <ENTITY> [ID] [OPTIONS]
 
 - **-h, --help**: Display help information
 - **-C, --config string**: Configuration file path (default: `/etc/crane/config.yaml`)
+- **-p, --plugin-config string**: Plugin configuration file path used by `show event` (default: `/etc/crane/plugin.yaml`)
 - **-v, --version**: Display cacctmgr version
 - **-J, --json**: Output in JSON format
 - **-f, --force**: Force operation without confirmation

--- a/docs/en/command/ceff.md
+++ b/docs/en/command/ceff.md
@@ -48,6 +48,7 @@ WARNING: Efficiency statistics may be misleading for RUNNING jobs.
 
 - **-h/--help**: Display help
 - **-C/--config string**: Path to configuration file (default: "/etc/crane/config.yaml")
+- **-p/--plugin-config string**: Path to plugin configuration file (default: "/etc/crane/plugin.yaml")
 - **--json**: Output task information returned by backend in JSON format
 - **-v/--version**: Display ceff version
 

--- a/docs/en/deployment/packaging.md
+++ b/docs/en/deployment/packaging.md
@@ -108,6 +108,7 @@ sudo dpkg -i CraneSched-*-cranectld.deb
 - `/usr/lib/systemd/system/cranectld.service` - Systemd service
 - `/etc/crane/config.yaml.sample` - Configuration template
 - `/etc/crane/database.yaml.sample` - Database configuration template
+- `/etc/crane/plugin.yaml.sample` - Plugin configuration template
 
 #### craned Package
 
@@ -131,6 +132,7 @@ sudo dpkg -i CraneSched-*-craned.deb
 - `/usr/libexec/csupervisor` - Per-step execution supervisor
 - `/usr/lib/systemd/system/craned.service` - Systemd service
 - `/etc/crane/config.yaml.sample` - Configuration template
+- `/etc/crane/plugin.yaml.sample` - Plugin configuration template
 - `/usr/lib64/security/pam_crane.so` - PAM authentication module
 
 #### Post-Installation
@@ -143,7 +145,7 @@ Both packages automatically:
 4. Copy sample configuration files (if not exists)
 5. Set appropriate file ownership and permissions
 
-After installation, configure `/etc/crane/config.yaml` and `/etc/crane/database.yaml` (for cranectld), then start the services:
+After installation, configure `/etc/crane/config.yaml`, `/etc/crane/plugin.yaml`, and `/etc/crane/database.yaml` (for cranectld), then start the services:
 
 For jobs that need to lock a large amount of memory, configure unlimited memlock for `craned.service` on all compute nodes. Create a systemd drop-in before starting `craned`:
 

--- a/docs/zh/command/cacctmgr.md
+++ b/docs/zh/command/cacctmgr.md
@@ -24,6 +24,7 @@ cacctmgr <操作> <实体> [ID] [选项]
 
 - **-h, --help**: 显示帮助信息
 - **-C, --config string**: 配置文件路径（默认：`/etc/crane/config.yaml`）
+- **-p, --plugin-config string**: `show event` 使用的插件配置文件路径（默认：`/etc/crane/plugin.yaml`）
 - **-v, --version**: 显示 cacctmgr 版本
 - **-J, --json**: 以 JSON 格式输出
 - **-f, --force**: 强制执行操作，不需要确认

--- a/docs/zh/command/ceff.md
+++ b/docs/zh/command/ceff.md
@@ -46,6 +46,7 @@ WARNING: Efficiency statistics may be misleading for RUNNING jobs.
 
 - **-h/--help**: 显示帮助
 - **-C/--config string**: 配置文件路径（默认为"/etc/crane/config.yaml"）
+- **-p/--plugin-config string**: 插件配置文件路径（默认为"/etc/crane/plugin.yaml"）
 - **--json**: 以JSON格式输出后端返回的任务信息
 - **-v/--version**: 显示ceff的版本
 

--- a/docs/zh/deployment/packaging.md
+++ b/docs/zh/deployment/packaging.md
@@ -108,6 +108,7 @@ sudo dpkg -i CraneSched-*-cranectld.deb
 - `/usr/lib/systemd/system/cranectld.service` - Systemd 服务
 - `/etc/crane/config.yaml.sample` - 配置模板
 - `/etc/crane/database.yaml.sample` - 数据库配置模板
+- `/etc/crane/plugin.yaml.sample` - 插件配置模板
 
 #### craned 软件包
 
@@ -131,6 +132,7 @@ sudo dpkg -i CraneSched-*-craned.deb
 - `/usr/libexec/csupervisor` - 作业步骤执行守护进程
 - `/usr/lib/systemd/system/craned.service` - Systemd 服务
 - `/etc/crane/config.yaml.sample` - 配置模板
+- `/etc/crane/plugin.yaml.sample` - 插件配置模板
 - `/usr/lib64/security/pam_crane.so` - PAM 身份验证模块
 
 #### 安装后操作
@@ -143,7 +145,7 @@ sudo dpkg -i CraneSched-*-craned.deb
 4. 复制示例配置文件（如果不存在）
 5. 设置适当的文件所有权和权限
 
-安装后，配置 `/etc/crane/config.yaml` 和 `/etc/crane/database.yaml`（用于 cranectld），然后启动服务：
+安装后，配置 `/etc/crane/config.yaml`、`/etc/crane/plugin.yaml` 和 `/etc/crane/database.yaml`（用于 cranectld），然后启动服务：
 
 ```bash
 # 在控制节点上


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `--plugin-config` options to `cacctmgr` and `ceff`, defaulting to `/etc/crane/plugin.yaml`.
  * Installations now automatically create `/etc/crane/plugin.yaml` from the provided sample when needed.
* **Documentation**
  * Updated English and Chinese command references with the new option.
  * Updated packaging instructions to include the sample plugin configuration and post-install setup steps.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->