### PR TITLE
fix: clean up steps after ExecuteSteps RPC failure

### DIFF
--- a/src/CraneCtld/CtldPublicDefs.cpp
+++ b/src/CraneCtld/CtldPublicDefs.cpp
@@ -285,6 +285,15 @@ void StepInCtld::SetPendingFinalExitCode(uint32_t exit_code) {
   this->m_runtime_attr_.set_pending_final_exit_code(exit_code);
 }
 
+bool StepInCtld::SetPendingFinalResultIfUnset(crane::grpc::JobStatus status,
+                                              uint32_t exit_code) {
+  if (PendingFinalStatus().has_value()) return false;
+
+  SetPendingFinalStatus(status);
+  SetPendingFinalExitCode(exit_code);
+  return true;
+}
+
 void StepInCtld::SetStatus(crane::grpc::JobStatus new_status) {
   this->m_status_ = new_status;
   this->m_runtime_attr_.set_status(new_status);
@@ -687,8 +696,7 @@ DaemonStepInCtld::StepStatusChange(crane::grpc::JobStatus new_status,
 
     case crane::grpc::JobStatus::Failed:
     case crane::grpc::JobStatus::Cancelled:
-      this->SetPendingFinalStatus(new_status);
-      this->SetPendingFinalExitCode(exit_code);
+      this->SetPendingFinalResultIfUnset(new_status, exit_code);
       [[fallthrough]];
     case crane::grpc::JobStatus::Completed:
       if (craned_id != kCtldPrologInternalNodeIndex) [[likely]] {
@@ -791,8 +799,7 @@ DaemonStepInCtld::StepStatusChange(crane::grpc::JobStatus new_status,
     }
     // Terminal report: cleanup done on this node.
     if (new_status != crane::grpc::JobStatus::Completed) {
-      this->SetPendingFinalStatus(new_status);
-      this->SetPendingFinalExitCode(exit_code);
+      this->SetPendingFinalResultIfUnset(new_status, exit_code);
     }
 
     if (this->Status() == crane::grpc::JobStatus::Running) {
@@ -1366,8 +1373,7 @@ CommonStepInCtld::StepStatusChange(crane::grpc::JobStatus new_status,
       context->rn_step_raw_ptrs.insert(this);
     } else if (IsFinishedStepStatus(new_status)) {
       if (new_status != crane::grpc::JobStatus::Completed) {
-        this->SetPendingFinalStatus(new_status);
-        this->SetPendingFinalExitCode(exit_code);
+        this->SetPendingFinalResultIfUnset(new_status, exit_code);
       }
       this->NodeConfiguredWithTerminal(craned_id);
       context->rn_step_raw_ptrs.insert(this);
@@ -1460,8 +1466,7 @@ CommonStepInCtld::StepStatusChange(crane::grpc::JobStatus new_status,
         return std::nullopt;
       }
       if (new_status != crane::grpc::JobStatus::Completed) {
-        this->SetPendingFinalStatus(new_status);
-        this->SetPendingFinalExitCode(exit_code);
+        this->SetPendingFinalResultIfUnset(new_status, exit_code);
       }
       if (this->Status() == crane::grpc::JobStatus::Running) {
         // Terminal before CTLD observes Completing means the final result is

--- a/src/CraneCtld/CtldPublicDefs.h
+++ b/src/CraneCtld/CtldPublicDefs.h
@@ -730,6 +730,8 @@ struct StepInCtld {
   }
   void SetPendingFinalExitCode(uint32_t exit_code);
   uint32_t PendingFinalExitCode() const { return m_pending_final_exit_code_; }
+  bool SetPendingFinalResultIfUnset(crane::grpc::JobStatus status,
+                                    uint32_t exit_code);
   void SetStatus(crane::grpc::JobStatus new_status);
   crane::grpc::JobStatus Status() const { return m_status_; }
 

--- a/src/CraneCtld/JobScheduler.cpp
+++ b/src/CraneCtld/JobScheduler.cpp
@@ -5650,6 +5650,7 @@ void JobScheduler::StepStatusChangeAsync(
          .craned_index = craned_index,
          .reason = std::move(reason),
          .timestamp = std::move(timestamp)});
+    m_job_status_change_queue_size_.fetch_add(1, std::memory_order_relaxed);
   }
   m_job_status_change_async_handle_->send();
 }
@@ -5677,6 +5678,7 @@ void JobScheduler::StepCompletingAndStatusChangeAsync(
          .craned_index = craned_index,
          .reason = std::move(terminal_reason),
          .timestamp = std::move(timestamp)});
+    m_job_status_change_queue_size_.fetch_add(2, std::memory_order_relaxed);
   }
   m_job_status_change_async_handle_->send();
 }
@@ -5888,26 +5890,21 @@ void JobScheduler::JobStatusChangeTimerCb_() {
 }
 
 void JobScheduler::JobStatusChangeAsyncCb_() {
-  size_t queue_size;
-  {
-    absl::MutexLock lock(&m_job_status_change_queue_mtx_);
-    queue_size = m_job_status_change_pending_.size() +
-                 m_job_status_change_incoming_.size();
-  }
+  const size_t queue_size =
+      m_job_status_change_queue_size_.load(std::memory_order_relaxed);
   if (queue_size >= g_config.CtldConf.StatusChangeBatchNum)
     m_clean_job_status_change_handle_->send();
 }
 
 void JobScheduler::CleanJobStatusChangeQueueCb_() {
-  size_t incoming_size;
   {
     absl::MutexLock lock(&m_job_status_change_queue_mtx_);
     if (m_job_status_change_pending_.empty())
       m_job_status_change_pending_.swap(m_job_status_change_incoming_);
-    incoming_size = m_job_status_change_incoming_.size();
   }
 
-  const size_t queue_size = m_job_status_change_pending_.size() + incoming_size;
+  const size_t queue_size =
+      m_job_status_change_queue_size_.load(std::memory_order_relaxed);
   const size_t max_drain_per_tick =
       std::max<uint32_t>(1, g_config.CtldConf.StatusChangeMaxDrainPerTick);
   const size_t drain_size =
@@ -5920,7 +5917,14 @@ void JobScheduler::CleanJobStatusChangeQueueCb_() {
     m_job_status_change_pending_.pop_front();
   }
   const size_t actual_size = args.size();
-  if (actual_size == 0) return;
+  const size_t previous_queue_size = m_job_status_change_queue_size_.fetch_sub(
+      actual_size, std::memory_order_relaxed);
+  CRANE_ASSERT(previous_queue_size >= actual_size);
+  if (actual_size == 0) {
+    if (m_job_status_change_queue_size_.load(std::memory_order_relaxed) > 0)
+      m_clean_job_status_change_handle_->send();
+    return;
+  }
   auto begin_time = std::chrono::steady_clock::now();
   auto state_machine_begin = begin_time;
 
@@ -6309,7 +6313,7 @@ void JobScheduler::CleanJobStatusChangeQueueCb_() {
     }
 
     m_rpc_worker_pool_->detach_task([this, craned_id, steps = std::move(steps),
-                                     traceparents = std::move(tp_map)] {
+                                     traceparents = std::move(tp_map)] mutable {
       auto stub = g_craned_keeper->GetCranedStub(craned_id);
       auto now = google::protobuf::util::TimeUtil::GetCurrentTime();
       if (stub && !stub->Invalid()) {
@@ -6324,11 +6328,17 @@ void JobScheduler::CleanJobStatusChangeQueueCb_() {
               "ExecuteSteps RPC failed for [{}] steps on Node {}; "
               "terminating affected steps.",
               util::JobStepsToString(steps), craned_id);
-          HandleExecuteStepsFailure_(craned_id, steps);
+          g_thread_pool->detach_task(
+              [this, craned_id, steps = std::move(steps)] {
+                HandleExecuteStepsFailure_(craned_id, steps);
+              });
         } else if (!failed_steps.value().empty()) {
           CRANE_ERROR("Failed to ExecuteStep for [{}] steps on Node {}",
                       util::JobStepsToString(failed_steps.value()), craned_id);
-          HandleExecuteStepsFailure_(craned_id, failed_steps.value());
+          g_thread_pool->detach_task(
+              [this, craned_id, steps = std::move(failed_steps.value())] {
+                HandleExecuteStepsFailure_(craned_id, steps);
+              });
         }
       } else {
         CRANE_ERROR(
@@ -6700,11 +6710,8 @@ void JobScheduler::CleanJobStatusChangeQueueCb_() {
   CRANE_TRACE("Cleaning {} StepStatusChanges cost {} ms.", actual_size,
               total_elapsed_ms);
 
-  bool has_more = !m_job_status_change_pending_.empty();
-  if (!has_more) {
-    absl::MutexLock lock(&m_job_status_change_queue_mtx_);
-    has_more = !m_job_status_change_incoming_.empty();
-  }
+  const bool has_more =
+      m_job_status_change_queue_size_.load(std::memory_order_relaxed) > 0;
   if (has_more) m_clean_job_status_change_handle_->send();
 }
 

--- a/src/CraneCtld/JobScheduler.cpp
+++ b/src/CraneCtld/JobScheduler.cpp
@@ -5640,13 +5640,17 @@ void JobScheduler::StepStatusChangeAsync(
     job_id_t job_id, step_id_t step_id, const CranedId& craned_index,
     crane::grpc::JobStatus new_status, uint32_t exit_code, std::string reason,
     google::protobuf::Timestamp timestamp) {
-  m_job_status_change_queue_.enqueue({.job_id = job_id,
-                                      .step_id = step_id,
-                                      .exit_code = exit_code,
-                                      .new_status = new_status,
-                                      .craned_index = craned_index,
-                                      .reason = std::move(reason),
-                                      .timestamp = std::move(timestamp)});
+  {
+    absl::MutexLock lock(&m_job_status_change_queue_mtx_);
+    m_job_status_change_incoming_.push_back(
+        {.job_id = job_id,
+         .step_id = step_id,
+         .exit_code = exit_code,
+         .new_status = new_status,
+         .craned_index = craned_index,
+         .reason = std::move(reason),
+         .timestamp = std::move(timestamp)});
+  }
   m_job_status_change_async_handle_->send();
 }
 
@@ -5655,21 +5659,25 @@ void JobScheduler::StepCompletingAndStatusChangeAsync(
     crane::grpc::JobStatus terminal_status, uint32_t exit_code,
     std::string reason, google::protobuf::Timestamp timestamp) {
   std::string terminal_reason = reason;
-  m_job_status_change_queue_.enqueue(
-      {.job_id = job_id,
-       .step_id = step_id,
-       .exit_code = exit_code,
-       .new_status = crane::grpc::JobStatus::Completing,
-       .craned_index = craned_index,
-       .reason = std::move(reason),
-       .timestamp = timestamp});
-  m_job_status_change_queue_.enqueue({.job_id = job_id,
-                                      .step_id = step_id,
-                                      .exit_code = exit_code,
-                                      .new_status = terminal_status,
-                                      .craned_index = craned_index,
-                                      .reason = std::move(terminal_reason),
-                                      .timestamp = std::move(timestamp)});
+  {
+    absl::MutexLock lock(&m_job_status_change_queue_mtx_);
+    m_job_status_change_incoming_.push_back(
+        {.job_id = job_id,
+         .step_id = step_id,
+         .exit_code = exit_code,
+         .new_status = crane::grpc::JobStatus::Completing,
+         .craned_index = craned_index,
+         .reason = std::move(reason),
+         .timestamp = timestamp});
+    m_job_status_change_incoming_.push_back(
+        {.job_id = job_id,
+         .step_id = step_id,
+         .exit_code = exit_code,
+         .new_status = terminal_status,
+         .craned_index = craned_index,
+         .reason = std::move(terminal_reason),
+         .timestamp = std::move(timestamp)});
+  }
   m_job_status_change_async_handle_->send();
 }
 
@@ -5880,32 +5888,46 @@ void JobScheduler::JobStatusChangeTimerCb_() {
 }
 
 void JobScheduler::JobStatusChangeAsyncCb_() {
-  if (m_job_status_change_queue_.size_approx() >=
-      g_config.CtldConf.StatusChangeBatchNum)
+  size_t queue_size;
+  {
+    absl::MutexLock lock(&m_job_status_change_queue_mtx_);
+    queue_size = m_job_status_change_pending_.size() +
+                 m_job_status_change_incoming_.size();
+  }
+  if (queue_size >= g_config.CtldConf.StatusChangeBatchNum)
     m_clean_job_status_change_handle_->send();
 }
 
 void JobScheduler::CleanJobStatusChangeQueueCb_() {
-  size_t approximate_size = m_job_status_change_queue_.size_approx();
+  size_t incoming_size;
+  {
+    absl::MutexLock lock(&m_job_status_change_queue_mtx_);
+    if (m_job_status_change_pending_.empty())
+      m_job_status_change_pending_.swap(m_job_status_change_incoming_);
+    incoming_size = m_job_status_change_incoming_.size();
+  }
+
+  const size_t queue_size = m_job_status_change_pending_.size() + incoming_size;
   const size_t max_drain_per_tick =
       std::max<uint32_t>(1, g_config.CtldConf.StatusChangeMaxDrainPerTick);
-  const size_t drain_size = std::min(approximate_size, max_drain_per_tick);
+  const size_t drain_size =
+      std::min(m_job_status_change_pending_.size(), max_drain_per_tick);
 
   std::vector<JobStatusChangeArg> args;
-  args.resize(drain_size);
-
-  size_t actual_size =
-      m_job_status_change_queue_.try_dequeue_bulk(args.begin(), drain_size);
+  args.reserve(drain_size);
+  for (size_t i = 0; i < drain_size; ++i) {
+    args.emplace_back(std::move(m_job_status_change_pending_.front()));
+    m_job_status_change_pending_.pop_front();
+  }
+  const size_t actual_size = args.size();
   if (actual_size == 0) return;
-  args.resize(actual_size);
   auto begin_time = std::chrono::steady_clock::now();
   auto state_machine_begin = begin_time;
 
   CRANE_TRACE_SCOPE_NAMED(sc_span, "status_change/process");
   sc_span.SetAttribute("crane.dimension", "lifecycle");
   sc_span.SetAttribute("batch_size", static_cast<int64_t>(actual_size));
-  sc_span.SetAttribute("queue_size_approx",
-                       static_cast<int64_t>(approximate_size));
+  sc_span.SetAttribute("queue_size_approx", static_cast<int64_t>(queue_size));
   sc_span.SetAttribute("max_drain_per_tick",
                        static_cast<int64_t>(max_drain_per_tick));
   size_t running_transition_count = 0;
@@ -6678,8 +6700,12 @@ void JobScheduler::CleanJobStatusChangeQueueCb_() {
   CRANE_TRACE("Cleaning {} StepStatusChanges cost {} ms.", actual_size,
               total_elapsed_ms);
 
-  if (m_job_status_change_queue_.size_approx() > 0)
-    m_clean_job_status_change_handle_->send();
+  bool has_more = !m_job_status_change_pending_.empty();
+  if (!has_more) {
+    absl::MutexLock lock(&m_job_status_change_queue_mtx_);
+    has_more = !m_job_status_change_incoming_.empty();
+  }
+  if (has_more) m_clean_job_status_change_handle_->send();
 }
 
 void JobScheduler::QueryJobsInRam(

--- a/src/CraneCtld/JobScheduler.cpp
+++ b/src/CraneCtld/JobScheduler.cpp
@@ -5772,6 +5772,59 @@ void JobScheduler::DispatchTerminateSteps_(
   });
 }
 
+void JobScheduler::HandleExecuteStepsFailure_(
+    const CranedId& failed_craned_id,
+    const std::unordered_map<job_id_t, std::set<step_id_t>>& steps) {
+  std::unordered_map<CranedId,
+                     std::unordered_map<job_id_t, std::set<step_id_t>>>
+      steps_to_terminate;
+  std::unordered_map<job_id_t, std::set<step_id_t>> steps_to_complete;
+
+  {
+    LockGuard running_guard(&m_running_job_map_mtx_);
+    for (const auto& [job_id, step_ids] : steps) {
+      auto job_it = m_running_job_map_.find(job_id);
+      if (job_it == m_running_job_map_.end()) continue;
+
+      JobInCtld* job = job_it->second.get();
+      for (step_id_t step_id : step_ids) {
+        StepInCtld* step = nullptr;
+        if (step_id == kDaemonStepId)
+          step = job->DaemonStep();
+        else
+          step = job->GetStep(step_id);
+        if (step == nullptr ||
+            !step->ExecutionNodes().contains(failed_craned_id) ||
+            (step->Status() != crane::grpc::JobStatus::Running &&
+             step->Status() != crane::grpc::JobStatus::Completing)) {
+          continue;
+        }
+
+        steps_to_complete[job_id].insert(step_id);
+        step->SetPendingFinalResultIfUnset(crane::grpc::JobStatus::Failed,
+                                           ExitCode::EC_RPC_ERR);
+
+        for (const auto& craned_id : step->ExecutionNodes()) {
+          steps_to_terminate[craned_id][job_id].insert(step_id);
+        }
+      }
+    }
+  }
+
+  for (auto& [craned_id, node_steps] : steps_to_terminate) {
+    DispatchTerminateSteps_(std::move(craned_id), std::move(node_steps));
+  }
+
+  auto now = google::protobuf::util::TimeUtil::GetCurrentTime();
+  for (const auto& [job_id, step_ids] : steps_to_complete) {
+    for (step_id_t step_id : step_ids) {
+      StepStatusChangeAsync(job_id, step_id, failed_craned_id,
+                            crane::grpc::JobStatus::Completing,
+                            ExitCode::EC_RPC_ERR, "ExecRpcError", now);
+    }
+  }
+}
+
 void JobScheduler::RetryCompletingSteps_() {
   std::unordered_map<CranedId,
                      std::unordered_map<job_id_t, std::set<step_id_t>>>
@@ -6244,15 +6297,16 @@ void JobScheduler::CleanJobStatusChangeQueueCb_() {
         rpc_span.SetAttribute("craned_id", std::string(craned_id));
 
         CraneExpected failed_steps = stub->ExecuteSteps(steps, traceparents);
-        if (failed_steps.has_value() && !failed_steps.value().empty()) {
+        if (!failed_steps.has_value()) {
+          CRANE_ERROR(
+              "ExecuteSteps RPC failed for [{}] steps on Node {}; "
+              "terminating affected steps.",
+              util::JobStepsToString(steps), craned_id);
+          HandleExecuteStepsFailure_(craned_id, steps);
+        } else if (!failed_steps.value().empty()) {
           CRANE_ERROR("Failed to ExecuteStep for [{}] steps on Node {}",
                       util::JobStepsToString(failed_steps.value()), craned_id);
-          for (const auto& [job_id, step_ids] : failed_steps.value()) {
-            for (const auto& step_id : step_ids)
-              StepCompletingAndStatusChangeAsync(
-                  job_id, step_id, craned_id, crane::grpc::JobStatus::Failed,
-                  ExitCode::EC_RPC_ERR, "ExecRpcError", now);
-          }
+          HandleExecuteStepsFailure_(craned_id, failed_steps.value());
         }
       } else {
         CRANE_ERROR(
@@ -6312,14 +6366,6 @@ void JobScheduler::CleanJobStatusChangeQueueCb_() {
             "rpc_worker_task_wait_ms={} rpc_elapsed_ms={} success={}",
             craned_id, craned_count, job_count, task_wait_ms, rpc_elapsed_ms,
             success);
-      }
-      if (!success) {
-        auto now = google::protobuf::util::TimeUtil::GetCurrentTime();
-        for (const auto& job_id : jobs) {
-          StepStatusChangeWithReasonAsync(
-              job_id, kDaemonStepId, craned_id, crane::grpc::JobStatus::Failed,
-              ExitCode::EC_RPC_ERR, "Rpc failure when free job", now);
-        }
       }
     });
   }

--- a/src/CraneCtld/JobScheduler.h
+++ b/src/CraneCtld/JobScheduler.h
@@ -21,6 +21,8 @@
 #include "CtldPublicDefs.h"
 // Precompiled header comes first!
 
+#include <deque>
+
 #include "Account/AccountDefs.h"
 #include "Array.h"
 #include "Node/CranedMetaContainer.h"
@@ -1509,7 +1511,12 @@ class JobScheduler {
     google::protobuf::Timestamp timestamp;
   };
 
-  ConcurrentQueue<JobStatusChangeArg> m_job_status_change_queue_;
+  absl::Mutex m_job_status_change_queue_mtx_;
+  std::deque<JobStatusChangeArg> m_job_status_change_incoming_
+      ABSL_GUARDED_BY(m_job_status_change_queue_mtx_);
+  // Accessed only by the job-status-change event loop. Older pending events
+  // are drained before the next incoming batch to preserve strict FIFO order.
+  std::deque<JobStatusChangeArg> m_job_status_change_pending_;
   void JobStatusChangeAsyncCb_();
 
   std::shared_ptr<uvw::async_handle> m_clean_job_status_change_handle_;

--- a/src/CraneCtld/JobScheduler.h
+++ b/src/CraneCtld/JobScheduler.h
@@ -1069,17 +1069,6 @@ class JobScheduler {
     return m_pending_map_cached_size_.load(std::memory_order_relaxed);
   }
 
-  void StepStatusChangeWithReasonAsync(uint32_t job_id, step_id_t step_id,
-                                       const CranedId& craned_index,
-                                       crane::grpc::JobStatus new_status,
-                                       uint32_t exit_code,
-                                       std::optional<std::string>&& reason,
-                                       google::protobuf::Timestamp timestamp) {
-    // TODO: Add reason implementation here!
-    StepStatusChangeAsync(job_id, step_id, craned_index, new_status, exit_code,
-                          reason.value_or(""), std::move(timestamp));
-  }
-
   void StartCraneCtldPrologThread(JobInCtld* job);
 
   void StepStatusChangeAsync(job_id_t job_id, step_id_t step_id,
@@ -1324,6 +1313,9 @@ class JobScheduler {
   void DispatchTerminateSteps_(
       CranedId craned_id,
       std::unordered_map<job_id_t, std::set<step_id_t>> steps);
+  void HandleExecuteStepsFailure_(
+      const CranedId& failed_craned_id,
+      const std::unordered_map<job_id_t, std::set<step_id_t>>& steps);
   void RetryCompletingSteps_();
 
   CraneErrCode SetHoldForJobInRamAndDb_(job_id_t job_id, bool hold);

--- a/src/CraneCtld/JobScheduler.h
+++ b/src/CraneCtld/JobScheduler.h
@@ -21,6 +21,7 @@
 #include "CtldPublicDefs.h"
 // Precompiled header comes first!
 
+#include <atomic>
 #include <deque>
 
 #include "Account/AccountDefs.h"
@@ -1514,6 +1515,7 @@ class JobScheduler {
   absl::Mutex m_job_status_change_queue_mtx_;
   std::deque<JobStatusChangeArg> m_job_status_change_incoming_
       ABSL_GUARDED_BY(m_job_status_change_queue_mtx_);
+  std::atomic_size_t m_job_status_change_queue_size_{0};
   // Accessed only by the job-status-change event loop. Older pending events
   // are drained before the next incoming batch to preserve strict FIFO order.
   std::deque<JobStatusChangeArg> m_job_status_change_pending_;

--- a/src/Craned/Core/JobManager.cpp
+++ b/src/Craned/Core/JobManager.cpp
@@ -1487,6 +1487,13 @@ void JobManager::EvCleanGrpcExecuteStepQueueCb_() {
       elem.ok_prom.set_value(CraneErrCode::ERR_NON_EXISTENT);
       continue;
     }
+    if (step_it->second->status != StepStatus::Starting) {
+      CRANE_DEBUG(
+          "[Step #{}.{}] Ignoring duplicate or late ExecuteStep in status {}.",
+          job_id, step_id, step_it->second->status);
+      elem.ok_prom.set_value(CraneErrCode::SUCCESS);
+      continue;
+    }
     step_it->second->wait_execute_span.End();
     step_it->second->ExecuteStepAsync();
     elem.ok_prom.set_value(CraneErrCode::SUCCESS);

--- a/test/CraneCtld/CtldPublicDefsTest.cpp
+++ b/test/CraneCtld/CtldPublicDefsTest.cpp
@@ -602,9 +602,47 @@ TEST(CtldStepStateMachineTest,
   EXPECT_FALSE(result.has_value());
   EXPECT_EQ(job.PrimaryStep(), nullptr);
   EXPECT_EQ(job.PrimaryStepStatus(), crane::grpc::JobStatus::Failed);
-  EXPECT_EQ(job.PrimaryStepExitCode(), 2U);
+  EXPECT_EQ(job.PrimaryStepExitCode(), 1U);
   ExpectStepFreeRequested(context, "node-a", kJobId, kDaemonStepId);
   ExpectStepFreeRequested(context, "node-b", kJobId, kDaemonStepId);
+}
+
+TEST(CtldStepStateMachineTest,
+     PendingExecuteRpcFailureSurvivesTerminationStatus) {
+  constexpr job_id_t kJobId = 60;
+  const std::vector<CranedId> craned_ids{"node-a"};
+
+  Ctld::JobInCtld job;
+  job.type = crane::grpc::Batch;
+  job.SetJobId(kJobId);
+  job.SetStatus(crane::grpc::Running);
+  job.SetPrimaryStepStatus(crane::grpc::JobStatus::Invalid);
+  job.SetDaemonStep(MakeDaemonStep(&job, craned_ids));
+  job.DaemonStep()->SetConfiguringNodes({});
+  job.DaemonStep()->SetStatus(crane::grpc::Running);
+  job.SetPrimaryStep(MakePrimaryStep(&job, craned_ids));
+
+  auto* primary_step = job.PrimaryStep();
+  primary_step->SetConfiguringNodes({});
+  primary_step->SetStatus(crane::grpc::Running);
+  ASSERT_TRUE(primary_step->SetPendingFinalResultIfUnset(crane::grpc::Failed,
+                                                         ExitCode::EC_RPC_ERR));
+
+  Ctld::StepStatusChangeContext context;
+  auto result = primary_step->StepStatusChange(
+      crane::grpc::Completing, ExitCode::EC_RPC_ERR, "execute rpc failed",
+      "node-a", TimestampAt(450), &context);
+  EXPECT_FALSE(result.has_value());
+  EXPECT_EQ(primary_step->Status(), crane::grpc::Completing);
+  ExpectStepFreeRequested(context, "node-a", kJobId, Ctld::kPrimaryStepId);
+
+  result = primary_step->StepStatusChange(crane::grpc::Cancelled,
+                                          ExitCode::EC_TERMINATED, "terminated",
+                                          "node-a", TimestampAt(451), &context);
+  EXPECT_FALSE(result.has_value());
+  EXPECT_EQ(job.PrimaryStep(), nullptr);
+  EXPECT_EQ(job.PrimaryStepStatus(), crane::grpc::Failed);
+  EXPECT_EQ(job.PrimaryStepExitCode(), ExitCode::EC_RPC_ERR);
 }
 
 TEST(CtldStepStateMachineTest,


### PR DESCRIPTION
## Summary

- mark steps as `Failed/EC_RPC_ERR` and terminate all execution nodes when `ExecuteSteps` fails or rejects a step
- preserve the first terminal result during cleanup and ignore duplicate or late Execute requests on Craned
- stop feeding `FreeJobs` RPC failures back into the state machine after the job has already reached a terminal state

## Testing

- `systemd-run --scope -p MemoryMax=15G ninja -C cmake-build-debug -j4 cranectld craned`
- `git diff --check`
- Added CTLD state-machine coverage for preserving `Failed/EC_RPC_ERR` through termination cleanup
- `ctld_public_defs_test` was not run locally because an unrelated local `test/Misc/CMakeLists.txt` change references the absent `src/Craned/Core/SupervisorProcessTracker.cpp`; CI can run the committed test in a clean checkout.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Preserved the first terminal failure result when multiple execution nodes report status changes.
  * Improved handling of execution failures by consistently marking affected steps as failed and terminating them across nodes.
  * Ignored duplicate or late execution requests to prevent steps from running after leaving the starting state.
  * Corrected cleanup behavior and exit-code reporting for failed steps.

* **Tests**
  * Added coverage for preserving failure results during cleanup.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->