### PR TITLE
docs(ai): add assistant deployment guides

### DIFF
--- a/docs/en/ai-assistants/shared-codex.md
+++ b/docs/en/ai-assistants/shared-codex.md
@@ -1,0 +1,64 @@
+# Shared Cluster Codex
+
+[CraneSched-Codex](https://github.com/PKUHPC/CraneSched-Codex) lets administrators provide a
+ready-to-use Codex on shared login nodes. Its RPM contains a pinned Codex, the CraneSched Skill,
+system defaults, and a loopback proxy. The administrator configures the real upstream endpoint and
+credential after installation; neither is stored in the RPM or Git.
+
+This service is optional. Users who only want CraneSched guidance in a personal AI assistant can
+install the [CraneSched Skill](skill.md) instead.
+
+## Scope
+
+The current RPM targets shared x86_64 EL9 nodes such as Rocky Linux, AlmaLinux, and RHEL 9. It provides:
+
+- a Managed Default that lets users run `codex` without configuring the shared API key;
+- a root-only proxy that holds the administrator's upstream credential;
+- the system-wide CraneSched Skill and default rules for read-only CraneSched commands;
+- BYOK, allowing users to override the default with their own provider and credential.
+
+It does not provide multi-user authentication, per-user quotas, or usage accounting. Any local user
+who can reach the proxy may consume the shared quota, so those controls must be implemented by the
+site or upstream provider.
+
+## Administrator setup
+
+Download the RPM from the [latest Release](https://github.com/PKUHPC/CraneSched-Codex/releases/latest)
+and install it on each target node:
+
+```bash
+sudo dnf install ./cranesched-codex-*.el9.x86_64.rpm
+```
+
+Create `/etc/codex/proxy-upstream.conf` as a `root:root`, mode `0600` file. Use `sudoedit` to enter
+exactly two lines: the full Responses endpoint and its bearer token. Never place the token in command
+arguments, environment variables, logs, Issues, or pull requests.
+
+```bash
+sudo install -d -m 0755 -o root -g root /etc/codex
+sudo install -m 0600 -o root -g root /dev/null \
+  /etc/codex/proxy-upstream.conf
+sudoedit /etc/codex/proxy-upstream.conf
+sudo chown root:root /etc/codex/proxy-upstream.conf
+sudo chmod 0600 /etc/codex/proxy-upstream.conf
+sudo systemctl enable --now cranesched-codex-proxy.service
+```
+
+Verify the package, service, and loopback-only listener:
+
+```bash
+rpm -q cranesched-codex
+codex --version
+sudo systemctl is-active cranesched-codex-proxy.service
+sudo ss -ltnp '( sport = :617 )'
+codex --strict-config doctor --json
+```
+
+`ss` should show only `127.0.0.1:617`. After a minimal real-request check, users can run `codex`
+directly or override the system default with a personal BYOK provider.
+
+Follow the
+[full installation and configuration guide](https://github.com/PKUHPC/CraneSched-Codex/blob/main/docs/installation-and-configuration.md)
+for the exact file format, upgrades, rotation, rollback, troubleshooting, and removal. Review the
+[architecture and security boundaries](https://github.com/PKUHPC/CraneSched-Codex/blob/main/docs/architecture-and-security.md)
+before production deployment.

--- a/docs/en/ai-assistants/skill.md
+++ b/docs/en/ai-assistants/skill.md
@@ -1,0 +1,46 @@
+# CraneSched Skill
+
+The CraneSched Skill is a set of usage and first-line troubleshooting instructions for AI assistants. It helps users:
+
+- write and review jobs using `cbatch`, `calloc`, `crun`, and related commands;
+- understand queues, job states, pending reasons, and exit codes;
+- troubleshoot resource requests, GPUs, MPI, multi-node jobs, containers, and failures;
+- separate user-level checks from cluster issues that require an administrator.
+
+The Skill grants no additional permissions and does not replace site documentation or policy. Answers should follow the installed command's `--help`, site guidance, and the user's actual output.
+
+## Who can use it
+
+Any CraneSched user can install the Skill in a personal AI assistant. It is independent of the
+[shared cluster Codex](shared-codex.md): users can use it with their own Codex, Claude Code, or
+another Agent that reads `SKILL.md`, even when the cluster administrator has not deployed Codex.
+
+## Install
+
+The canonical source is
+[`docs/skills/cranesched-skill`](https://github.com/PKUHPC/CraneSched/tree/master/docs/skills/cranesched-skill).
+Install the complete directory rather than copying only `SKILL.md`; the `references/` directory is
+part of the Skill.
+
+This example uses a sparse clone and installs the Skill in the common Agent Skills directory:
+
+```bash
+skill_source="${XDG_DATA_HOME:-$HOME/.local/share}/cranesched-skill-source"
+git clone --depth 1 --filter=blob:none --sparse \
+  https://github.com/PKUHPC/CraneSched.git "${skill_source}"
+git -C "${skill_source}" sparse-checkout set docs/skills/cranesched-skill
+mkdir -p "${HOME}/.agents/skills"
+ln -s "${skill_source}/docs/skills/cranesched-skill" \
+  "${HOME}/.agents/skills/cranesched-skill"
+```
+
+- **Codex and Agent Skills-compatible tools:** use `~/.agents/skills/`, or the tool's documented user-level Skill directory.
+- **Claude Code:** change `~/.agents/skills` in the last two commands to `~/.claude/skills`.
+- **Agents without automatic Skill discovery:** keep the source directory and explicitly ask the Agent to read its `SKILL.md` before handling a CraneSched question.
+
+Restart the Agent or open a new session, then ask it to use `cranesched-skill`, or simply request a
+CraneSched task such as "write a CraneSched GPU job script." Update the Skill with:
+
+```bash
+git -C "${skill_source}" pull --ff-only
+```

--- a/docs/en/deployment/index.md
+++ b/docs/en/deployment/index.md
@@ -194,6 +194,11 @@ Run containerized jobs in the cluster with user isolation and portable environme
 
 - **[Container Deployment](./container.md)** - Configure CRI runtime, enable container job support
 
+### AI Assistants
+
+- **[CraneSched Skill](../ai-assistants/skill.md)** - Users can install it in their own AI assistant without a cluster Codex deployment
+- **[Shared Cluster Codex](../ai-assistants/shared-codex.md)** - Administrators can provide a ready-to-use Codex on shared nodes
+
 ---
 
 ## Getting Help

--- a/docs/zh/ai-assistants/shared-codex.md
+++ b/docs/zh/ai-assistants/shared-codex.md
@@ -1,0 +1,60 @@
+# 集群共享 Codex
+
+[CraneSched-Codex](https://github.com/PKUHPC/CraneSched-Codex) 供管理员在共享登录节点上
+提供开箱即用的 Codex。RPM 包含固定版本的 Codex、鹤思 Skill、系统默认配置和本机
+loopback proxy；真实上游 endpoint 与凭据由管理员在安装后配置，不进入 RPM 或 Git。
+
+这是一项可选服务。只想在个人 AI 助手中使用鹤思知识的用户，安装
+[鹤思 Skill](skill.md) 即可。
+
+## 适用范围
+
+当前 RPM 面向 x86_64 EL9（Rocky Linux、AlmaLinux 或 RHEL 9）共享节点。它提供：
+
+- 用户无需配置共享 API Key 即可运行 `codex` 的 Managed Default；
+- 由 root-only proxy 代持的管理员凭据；
+- 系统级鹤思 Skill 和只读 CraneSched 命令默认规则；
+- 用户通过自己的 provider 和凭据覆盖默认配置的 BYOK 能力。
+
+它不提供多用户认证、按用户限额或用量统计。任何能访问本机 proxy 的用户都可能
+消耗共享额度，管理员必须在上游和站点侧另行治理。
+
+## 管理员配置
+
+从 [最新 Release](https://github.com/PKUHPC/CraneSched-Codex/releases/latest) 下载 RPM，
+在目标节点安装：
+
+```bash
+sudo dnf install ./cranesched-codex-*.el9.x86_64.rpm
+```
+
+创建 `/etc/codex/proxy-upstream.conf`，保持 `root:root`、权限 `0600`，并用
+`sudoedit` 填写两行内容：完整的 Responses endpoint 和 bearer token。不要把 token
+放入命令行、环境变量、日志、Issue 或 PR。
+
+```bash
+sudo install -d -m 0755 -o root -g root /etc/codex
+sudo install -m 0600 -o root -g root /dev/null \
+  /etc/codex/proxy-upstream.conf
+sudoedit /etc/codex/proxy-upstream.conf
+sudo chown root:root /etc/codex/proxy-upstream.conf
+sudo chmod 0600 /etc/codex/proxy-upstream.conf
+sudo systemctl enable --now cranesched-codex-proxy.service
+```
+
+检查安装、服务和仅监听本机的端口：
+
+```bash
+rpm -q cranesched-codex
+codex --version
+sudo systemctl is-active cranesched-codex-proxy.service
+sudo ss -ltnp '( sport = :617 )'
+codex --strict-config doctor --json
+```
+
+`ss` 应只显示 `127.0.0.1:617`。完成最小真实请求验证后，普通用户可直接运行
+`codex`，也可以用自己的 BYOK provider 覆盖系统默认值。
+
+配置文件格式、升级、轮换、回滚、故障排查和卸载步骤以
+[完整安装与配置指南](https://github.com/PKUHPC/CraneSched-Codex/blob/main/docs/installation-and-configuration.md)
+为准；部署前还应阅读[架构与安全边界](https://github.com/PKUHPC/CraneSched-Codex/blob/main/docs/architecture-and-security.md)。

--- a/docs/zh/ai-assistants/skill.md
+++ b/docs/zh/ai-assistants/skill.md
@@ -1,0 +1,47 @@
+# 鹤思 Skill
+
+鹤思 Skill 是一组供 AI 助手读取的 CraneSched 使用与一线排障指南。它可以帮助用户：
+
+- 编写和检查 `cbatch`、`calloc`、`crun` 等作业命令与脚本；
+- 理解队列、作业状态、排队原因和退出码；
+- 排查资源请求、GPU、MPI、多节点、容器和作业失败问题；
+- 区分用户可自行检查的内容与需要交给管理员的集群问题。
+
+Skill 不会授予额外权限，也不会代替集群的用户手册和策略。回答应以当前安装版本的
+`--help`、本站文档和用户实际输出为准。
+
+## 谁可以使用
+
+所有鹤思用户都可以把 Skill 安装到自己的 AI 助手中。它与
+[集群共享 Codex](shared-codex.md) 相互独立：即使管理员没有部署集群版 Codex，
+用户仍可在自己的 Codex、Claude Code 或其他能读取 `SKILL.md` 的 Agent 中使用。
+
+## 安装
+
+Skill 的权威源文件位于
+[`docs/skills/cranesched-skill`](https://github.com/PKUHPC/CraneSched/tree/master/docs/skills/cranesched-skill)。
+安装时必须保留整个目录，不能只复制 `SKILL.md`，因为其中的 `references/` 也是
+回答所需资料。
+
+下面的示例将仓库稀疏克隆到用户目录，并安装到通用的 Agent Skills 目录：
+
+```bash
+skill_source="${XDG_DATA_HOME:-$HOME/.local/share}/cranesched-skill-source"
+git clone --depth 1 --filter=blob:none --sparse \
+  https://github.com/PKUHPC/CraneSched.git "${skill_source}"
+git -C "${skill_source}" sparse-checkout set docs/skills/cranesched-skill
+mkdir -p "${HOME}/.agents/skills"
+ln -s "${skill_source}/docs/skills/cranesched-skill" \
+  "${HOME}/.agents/skills/cranesched-skill"
+```
+
+- **Codex 或支持 Agent Skills 的工具**：使用 `~/.agents/skills/`，或按工具文档安装到其用户级 Skill 目录。
+- **Claude Code**：可将最后两条命令中的 `~/.agents/skills` 改为 `~/.claude/skills`。
+- **不自动发现 Skill 的 Agent**：保留源目录，并明确要求它读取其中的 `SKILL.md` 后再处理鹤思问题。
+
+重新启动 Agent 或开启新会话后，可以直接询问“帮我写一个鹤思 GPU 作业脚本”，
+或显式要求使用 `cranesched-skill`。更新 Skill 时运行：
+
+```bash
+git -C "${skill_source}" pull --ff-only
+```

--- a/docs/zh/deployment/index.md
+++ b/docs/zh/deployment/index.md
@@ -194,6 +194,11 @@ MongoDB 存储作业历史记录、用户账户和资源使用数据。
 
 - **[容器功能部署](./container.md)** - 配置 CRI 运行时，启用容器作业支持
 
+### AI 助手
+
+- **[鹤思 Skill](../ai-assistants/skill.md)** - 用户可安装到自己的 AI 助手中，无需集群部署 Codex
+- **[集群共享 Codex](../ai-assistants/shared-codex.md)** - 管理员为共享节点提供开箱即用的 Codex
+
 ---
 
 ## 获取帮助

--- a/mkdocs.yaml
+++ b/mkdocs.yaml
@@ -85,6 +85,9 @@ nav:
       - Prolog & Epilog Guide: deployment/configuration/prolog_epilog_guide.md
       - PMIx Support: deployment/configuration/pmix.md
       - Resource Limit Guide: deployment/configuration/partition_resource_limit_guide.md
+  - AI Assistants:
+    - CraneSched Skill: ai-assistants/skill.md
+    - Shared Cluster Codex: ai-assistants/shared-codex.md
   - Commands:
       - Job Submission:
           - cbatch: command/cbatch.md
@@ -192,6 +195,9 @@ plugins:
             PowerControl Deployment: 节能模块部署
             Plugins: 插件部署
             PMIx Support: PMIx 使用指南
+            AI Assistants: AI 助手
+            CraneSched Skill: 鹤思 Skill
+            Shared Cluster Codex: 集群共享 Codex
         - locale: en
           name: English
           build: true


### PR DESCRIPTION
## Summary

- add a dedicated bilingual AI Assistants documentation section
- document the standalone CraneSched Skill for personal Codex, Claude Code, and other Agent Skills-compatible assistants
- document the optional shared cluster Codex and its concise administrator setup
- link the new guides from the deployment overview

## Validation

- `git diff --check origin/master...HEAD`
- `/tmp/cranesched-docs-venv/bin/mkdocs build --strict --site-dir /tmp/cranesched-docs-site`

Closes #952


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added English and Chinese guides for the CraneSched Skill, including supported tasks, installation, configuration, discovery, troubleshooting, and updates.
  * Added administrator documentation for deploying and securing the shared CraneSched-Codex service.
  * Added AI Assistant links to the deployment guides.
  * Added English and Chinese navigation entries for the new documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->