### PR TITLE
fix(ci): authorize stale PR base snapshots

### DIFF
--- a/.github/ci/authorize.py
+++ b/.github/ci/authorize.py
@@ -329,14 +329,11 @@ def _resolve_pr_merge(
     for attempt in range(attempts):
         snapshot = pull_request_lookup(context.repository, number)
         _validate_pr_snapshot(context, number, snapshot)
-        if snapshot.base_sha != context.event_sha:
-            pending_reason = (
-                "the current pull request base has not converged to the trusted "
-                "workflow revision"
-            )
-        elif snapshot.mergeable is False:
+        # GitHub can retain the base SHA from the PR's last branch update. The
+        # current merge ref and its ordered parents prove the routing base.
+        if snapshot.mergeable is False:
             raise AuthorizationError("pull request has no mergeable proposed result")
-        elif snapshot.mergeable is not True or not SHA_RE.fullmatch(
+        if snapshot.mergeable is not True or not SHA_RE.fullmatch(
             snapshot.merge_commit_sha
         ):
             pending_reason = "GitHub has not computed the proposed merge"
@@ -357,12 +354,7 @@ def _resolve_pr_merge(
                 else:
                     final_snapshot = pull_request_lookup(context.repository, number)
                     _validate_pr_snapshot(context, number, final_snapshot)
-                    if final_snapshot.base_sha != context.event_sha:
-                        raise AuthorizationError(
-                            "pull request base changed during authorization; wait for "
-                            "the new run"
-                        )
-                    elif final_snapshot.mergeable is False:
+                    if final_snapshot.mergeable is False:
                         raise AuthorizationError(
                             "pull request has no mergeable proposed result"
                         )

--- a/.github/ci/test_authorize.py
+++ b/.github/ci/test_authorize.py
@@ -227,49 +227,26 @@ class AuthorizationPolicyTest(unittest.TestCase):
         self.assertEqual(result["pr_head_sha"], BACKEND_SHA)
         self.assertEqual(result["pr_merge_sha"], MERGE_SHA)
 
-    def test_waits_for_api_base_to_converge_to_trusted_workflow(self) -> None:
-        snapshots = iter(
-            [
-                _snapshot(base_sha="e" * 40),
-                _snapshot(),
-                _snapshot(),
-            ]
-        )
-        delays: list[float] = []
-
-        result = authorize.authorize_dispatch(
+    def test_stale_api_base_is_allowed_when_merge_parents_are_trusted(self) -> None:
+        result = _authorize(
             _context(pr_base_sha="e" * 40, pr_merge_sha="f" * 40),
-            lambda _repo, _actor: {"permission": "admin"},
-            _resolver,
-            lambda _repo, _number: next(snapshots),
-            _merge_ref,
-            _commit_parents,
-            sleeper=delays.append,
-            retry_delays=(0.25,),
+            pull_request_lookup=lambda _repo, _number: _snapshot(base_sha="e" * 40),
         )
 
         self.assertEqual(result["pr_base_sha"], WORKFLOW_SHA)
         self.assertEqual(result["routing_sha"], MERGE_SHA)
-        self.assertEqual(delays, [0.25])
 
-    def test_api_base_convergence_is_bounded(self) -> None:
-        calls = 0
-
-        def stale_base(_repository: str, _number: int):
-            nonlocal calls
-            calls += 1
-            return _snapshot(base_sha="e" * 40)
-
-        with self.assertRaisesRegex(
-            authorize.AuthorizationError, "base has not converged"
-        ):
+    def test_stale_api_base_does_not_allow_an_untrusted_merge_parent(self) -> None:
+        with self.assertRaisesRegex(authorize.AuthorizationError, "parents"):
             _authorize(
-                _context(pr_base_sha="e" * 40, pr_merge_sha="f" * 40),
-                pull_request_lookup=stale_base,
-                retry_delays=(0.0, 0.0),
+                pull_request_lookup=lambda _repo, _number: _snapshot(
+                    base_sha="e" * 40
+                ),
+                commit_parents_resolver=lambda _repo, _sha: (
+                    "e" * 40,
+                    BACKEND_SHA,
+                ),
             )
-
-        self.assertEqual(calls, 3)
 
     def test_waits_for_github_to_compute_mergeability(self) -> None:
         snapshots = iter(
@@ -360,11 +337,15 @@ class AuthorizationPolicyTest(unittest.TestCase):
         with self.assertRaisesRegex(authorize.AuthorizationError, "changed"):
             _authorize(pull_request_lookup=lambda _repo, _number: next(snapshots))
 
-    def test_second_snapshot_detects_base_drift(self) -> None:
+    def test_second_snapshot_allows_api_base_hint_to_change(self) -> None:
         snapshots = iter([_snapshot(), _snapshot(base_sha="e" * 40)])
 
-        with self.assertRaisesRegex(authorize.AuthorizationError, "base changed"):
-            _authorize(pull_request_lookup=lambda _repo, _number: next(snapshots))
+        result = _authorize(
+            pull_request_lookup=lambda _repo, _number: next(snapshots)
+        )
+
+        self.assertEqual(result["pr_base_sha"], WORKFLOW_SHA)
+        self.assertEqual(result["routing_sha"], MERGE_SHA)
 
     def test_mergeable_blocked_pr_is_authorized(self) -> None:
         result = _authorize(


### PR DESCRIPTION
## Summary

- stop requiring the pull request API's historical `base.sha` hint to equal the trusted workflow revision
- continue requiring the current proposed merge ref to have exactly the trusted workflow SHA and event head SHA as its ordered parents
- retain the second PR snapshot and merge-ref checks so head or merge changes during authorization still fail closed

## Root cause

PR #946 exposed a GitHub API behavior that the dispatcher did not model correctly. The PR API retained `base.sha=286d677d...` from the branch's last update while the trusted `pull_request_target` workflow ran from current `master@2738de64...`. GitHub's current proposed merge `c1b016ec...` was valid and had ordered parents `(2738de64..., a9240ab5...)`, but authorization rejected it before examining those parents.

The PR base SHA is therefore an event/API hint, not proof of the current routing base. The current merge ref and its two ordered parents provide that proof.

## Validation

- all `.github/ci/test_*.py`: 140 tests passed
- focused Ruff check passed after excluding pre-existing file-wide `EXE001`, `I001`, `UP035`, and `UP045` findings
- `git diff --check`
- read-only replay against PR #946 returned `authorized=true`, `pr_base_sha=2738de64...`, and `routing_sha=c1b016ec...`

No runner, AutoTest, K3s, FrontEnd, or branch-protection changes are included.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved pull request merge validation to correctly handle stale base references when the verified merge commit remains trusted.
  * Pull requests with untrusted merge parents are now rejected immediately.
  * Validation remains consistent when API base information changes between snapshots.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->