### PR TITLE
docs(ai): add shared Codex user guide

### DIFF
--- a/docs/en/ai-assistants/shared-codex-user-guide.md
+++ b/docs/en/ai-assistants/shared-codex-user-guide.md
@@ -57,8 +57,8 @@ with your input, site policy, and installed version.
 
 **You:**
 
-> Job 4812 has remained `Pending`, and `cqueue -j 4812 -F` shows `Reason=Resources`. Did submission
-> fail?
+> Job 4812 has remained `Pending`, and the `NODELIST/REASON` column from `cqueue -j 4812 -F`
+> shows `Resource`. Did submission fail?
 
 **Codex (example response):**
 

--- a/docs/en/ai-assistants/shared-codex-user-guide.md
+++ b/docs/en/ai-assistants/shared-codex-user-guide.md
@@ -1,0 +1,109 @@
+# Using Shared Codex
+
+Shared Codex can help you write CraneSched job scripts, understand job states, and troubleshoot
+common problems from command output. The administrator has configured the model service and the
+CraneSched Skill on the shared node, so you do not need the shared API key.
+
+## Start Codex
+
+Log in to the node specified by your administrator, replace the angle-bracket placeholder with the
+real path, enter your working directory, and run:
+
+```bash
+cd <your_working_directory>
+codex
+```
+
+Describe your goal in natural language. Include the program entry point, resource requirements, job
+ID, complete error, and relevant command output when available. If `codex` is not found or cannot
+connect to the model service, contact the cluster administrator; do not try to read or change the
+system Codex configuration.
+
+The conversations below are illustrative and do not come from a real cluster. Actual responses vary
+with your input, site policy, and installed version.
+
+## Example 1: Create a job script
+
+**You:**
+
+> Write a CraneSched batch script for `train.py` using one GPU, four CPUs, 16 GB of memory, and a
+> two-hour time limit. I do not know this site's GPU partition name yet.
+
+**Codex (example response):**
+
+> Keep the partition as a placeholder until you confirm it in the site documentation:
+>
+> ```bash
+> #!/bin/bash
+> #CBATCH --job-name=train
+> #CBATCH --partition=<gpu_partition>
+> #CBATCH --nodes=1
+> #CBATCH --ntasks-per-node=1
+> #CBATCH --cpus-per-task=4
+> #CBATCH --mem=16G
+> #CBATCH --gres=gpu:1
+> #CBATCH --time=02:00:00
+> #CBATCH --output=train_%j.out
+> #CBATCH --error=train_%j.err
+>
+> python train.py
+> ```
+>
+> Save it as `train.sh`, check the shell syntax with `bash -n train.sh`, then run
+> `cbatch train.sh`. Add an account, QoS, or environment module only when required by your site;
+> do not guess those values.
+
+## Example 2: Understand a pending job
+
+**You:**
+
+> Job 4812 has remained `Pending`, and `cqueue -j 4812 -F` shows `Reason=Resources`. Did submission
+> fail?
+
+**Codex (example response):**
+
+> This does not mean submission failed. The confirmed facts are that the job remains queued and its
+> current highest-priority blocker concerns available resources. That line alone cannot predict an
+> exact start time. Inspect your own job details with:
+>
+> ```bash
+> ccontrol show job 4812
+> ```
+>
+> Check whether the requested GPUs, node count, memory, and time limit match your intent. If the
+> reason persists, give the administrator the job ID, submission time, resource request, and this
+> output rather than repeatedly resubmitting the same job.
+
+## Example 3: Troubleshoot a failed job
+
+**You:**
+
+> `cacct -j 4930 -F` shows `State=Failed` and `ExitCode=1:0`. The first error in stderr is
+> `ModuleNotFoundError: No module named 'torch'`. What should I check first?
+
+**Codex (example response):**
+
+> `ExitCode=1:0` means the application returned exit code 1, with no evidence of signal termination.
+> Together with the first error, the likely issue is that the batch environment did not load the
+> Python environment containing `torch`. Check whether the script explicitly loads the site's
+> recommended module or activates a virtual environment on shared storage, for example:
+>
+> ```bash
+> # Choose one approach using the site's real environment
+> module load <python_or_ai_module>
+> # or
+> source <shared_venv>/bin/activate
+> python -c 'import torch; print(torch.__version__)'
+> python train.py
+> ```
+>
+> Do not guess the module name or environment path. If you provide the current script and site
+> environment instructions, I can place the initialization steps correctly. Do not include passwords,
+> tokens, or a complete environment dump.
+
+## Boundaries
+
+- Review commands and scripts before running them; site documentation and the installed command's `--help` take precedence.
+- Share only relevant output. Never provide passwords, API keys, private keys, or a complete environment dump.
+- Codex gains no additional CraneSched permissions and cannot confirm site partitions, accounts, QoS, or cluster state on an administrator's behalf.
+- Before submitting or cancelling a job or changing a file, confirm that the target is yours and the effect is intended.

--- a/docs/en/ai-assistants/shared-codex-user-guide.md
+++ b/docs/en/ai-assistants/shared-codex-user-guide.md
@@ -1,8 +1,9 @@
 # Using Shared Codex
 
-Shared Codex can help you write CraneSched job scripts, understand job states, and troubleshoot
-common problems from command output. The administrator has configured the model service and the
-CraneSched Skill on the shared node, so you do not need the shared API key.
+Shared Codex can help you write CraneSched job scripts, query your jobs, explain scheduler states,
+and troubleshoot problems using command output and files in your working directory. The
+administrator has configured the model service and CraneSched Skill, so you do not need the shared
+API key.
 
 ## Start Codex
 
@@ -14,96 +15,258 @@ cd <your_working_directory>
 codex
 ```
 
-Describe your goal in natural language. Include the program entry point, resource requirements, job
-ID, complete error, and relevant command output when available. If `codex` is not found or cannot
-connect to the model service, contact the cluster administrator; do not try to read or change the
-system Codex configuration.
+Describe your goal directly. A job ID, program entry point, and expected behavior are usually enough;
+Codex can query missing information about jobs visible to your account.
 
-The conversations below are illustrative and do not come from a real cluster. Actual responses vary
-with your input, site policy, and installed version.
+## How the Agent works
 
-## Example 1: Create a job script
+By default, the cluster installation allows Codex to run these read-only commands without asking for
+approval each time:
+
+- `cqueue` for the active queue and your current jobs;
+- `cacct` for job history, states, and exit codes;
+- `ccontrol show job` / `ccontrol show step` for job and step details.
+
+The commands still run as you, and CraneSched server permissions determine what they can see. A site
+or user may configure stricter rules. Codex should prefer a specific job ID or your own jobs and
+avoid continuous refreshes or broad queries.
+
+Codex can also find scripts, logs, and existing environments in the current working directory and
+run local checks. These operations remain subject to the Codex sandbox, file permissions, and site
+policy; depending on the active configuration, the CLI may prompt before an operation that needs
+additional access.
+
+Writing a script, running `cbatch`, cancelling a job, or changing job state has side effects and is
+not covered by the default read-only list. For such a task, ask Codex to explain the proposed action
+and impact and wait for your explicit confirmation. Whether the CLI also displays a built-in approval
+prompt depends on the active site and user configuration. You can refuse or revise the plan.
+
+The conversations below are illustrative rather than results from a real cluster. Command output and
+site names exist only to demonstrate the workflow.
+
+## Example 1: Explain a basic state
 
 **You:**
 
-> Write a CraneSched batch script for `train.py` using one GPU, four CPUs, 16 GB of memory, and a
-> two-hour time limit. I do not know this site's GPU partition name yet.
+> My job is `Running`. Does that mean training succeeded?
 
 **Codex (example response):**
 
-> Keep the partition as a placeholder until you confirm it in the site documentation:
+> `Running` only means that resources are allocated and the job is executing. It does not prove that
+> training is producing correct results. Check stdout, stderr, and application metrics, then use the
+> final `State` and `ExitCode` from `cacct` after the job ends.
+
+## Example 2: Draft a script
+
+**You:**
+
+> Draft a script for `train.py`. This site's values are partition `gpu-a100`, account `ml`, and QoS
+> `normal`; request one A100, four CPUs, 16 GB of memory, and two hours. Do not write or submit yet.
+
+**Codex (example response):**
+
+> I will provide a draft in the conversation without changing a file or submitting a job:
 >
 > ```bash
 > #!/bin/bash
 > #CBATCH --job-name=train
-> #CBATCH --partition=<gpu_partition>
+> #CBATCH --partition=gpu-a100
+> #CBATCH --account=ml
+> #CBATCH --qos=normal
 > #CBATCH --nodes=1
 > #CBATCH --ntasks-per-node=1
 > #CBATCH --cpus-per-task=4
 > #CBATCH --mem=16G
-> #CBATCH --gres=gpu:1
+> #CBATCH --gres=gpu:a100:1
 > #CBATCH --time=02:00:00
 > #CBATCH --output=train_%j.out
 > #CBATCH --error=train_%j.err
 >
 > python train.py
 > ```
->
-> Save it as `train.sh`, check the shell syntax with `bash -n train.sh`, then run
-> `cbatch train.sh`. Add an account, QoS, or environment module only when required by your site;
-> do not guess those values.
 
-## Example 2: Understand a pending job
+## Example 3: Query active jobs
 
 **You:**
 
-> Job 4812 has remained `Pending`, and the `NODELIST/REASON` column from `cqueue -j 4812 -F`
-> shows `Resource`. Did submission fail?
+> Check which of my current jobs need attention.
+
+**Codex runs read-only tools:**
+
+```bash
+cqueue --self -o="%j %P %n %t %l %N %L"
+ccontrol show job 4812
+```
+
+**Relevant tool output (example):**
+
+```text
+JOBID PARTITION NAME       STATUS  TIMELIMIT NODES NODELIST(REASON)
+4812  gpu-a100  train      Pending 02:00:00  1     (Resource)
+4815  cpu       preprocess Running 01:00:00  1     cn032
+
+JobId=4812 JobState=Pending Account=ml Qos=normal Partition=gpu-a100
+Reason=Resource TimeLimit=02:00:00 ReqRes:node=1 cpu=4 mem=16G gres=gpu:a100:1
+```
 
 **Codex (example response):**
 
-> This does not mean submission failed. The confirmed facts are that the job remains queued and its
-> current highest-priority blocker concerns available resources. That line alone cannot predict an
-> exact start time. Inspect your own job details with:
+> You have two active jobs:
 >
-> ```bash
-> ccontrol show job 4812
-> ```
+> - `4815` is running on `cn032` in the `cpu` partition, with no scheduler error shown.
+> - `4812` was accepted but is waiting for resources that satisfy the complete displayed request,
+>   including one A100, four CPUs, and 16 GB. Its current reason is `Resource`, not a submission
+>   failure. The details also confirm account `ml`, QoS `normal`, and a two-hour time limit.
 >
-> Check whether the requested GPUs, node count, memory, and time limit match your intent. If the
-> reason persists, give the administrator the job ID, submission time, resource request, and this
-> output rather than repeatedly resubmitting the same job.
+> Do not resubmit it now. `Resource` describes current availability for the complete request; it does
+> not provide a guaranteed start time.
 
-## Example 3: Troubleshoot a failed job
+## Example 4: Combine history, details, and files to diagnose a failure
 
 **You:**
 
-> `cacct -j 4930 -F` shows `State=Failed` and `ExitCode=1:0`. The first error in stderr is
-> `ModuleNotFoundError: No module named 'torch'`. What should I check first?
+> My job 4930 failed. Investigate the cause for me.
+
+**Codex queries job data and inspects the working directory:**
+
+```bash
+cacct -j 4930 -F -o "%j %t %e %P %a"
+pwd
+rg --files | rg '4930|train.*\.(out|err)$'
+sed -n '1,160p' train.sh
+sed -n '1,120p' train_4930.err
+rg -n 'venvs/.*/bin/python|source .*/bin/activate' --glob '*.sh'
+test -x /home/alice/venvs/torch/bin/python
+```
+
+**Relevant results, grouped for readability (example):**
+
+```text
+JOBID STATE  EXITCODE PARTITION ACCOUNT
+4930  Failed 1:0      gpu-a100  ml
+
+/home/alice/project
+train_4930.err
+```
+
+```bash
+#!/bin/bash
+#CBATCH --job-name=train
+#CBATCH --partition=gpu-a100
+#CBATCH --output=train_%j.out
+#CBATCH --error=train_%j.err
+
+python train.py
+```
+
+```text
+ModuleNotFoundError: No module named 'torch'
+tools/check_gpu.sh:8:/home/alice/venvs/torch/bin/python -c 'import torch; print(torch.__version__)'
+The candidate interpreter is executable (test exit status 0).
+```
 
 **Codex (example response):**
 
-> `ExitCode=1:0` means the application returned exit code 1, with no evidence of signal termination.
-> Together with the first error, the likely issue is that the batch environment did not load the
-> Python environment containing `torch`. Check whether the script explicitly loads the site's
-> recommended module or activates a virtual environment on shared storage, for example:
+> The job entered `gpu-a100` and the application returned exit code 1, with no evidence of signal
+> termination. The first error occurs during Python import. The complete `train.sh` invokes an
+> unqualified `python` and contains no explicit module load, activation, or interpreter path. The
+> immediate failure is therefore that the Python environment selected by this script cannot import
+> `torch`, not queueing or a timeout.
+>
+> Another project script already uses the executable
+> `/home/alice/venvs/torch/bin/python` for a `torch` check. This is a sourced candidate, not proof
+> that it works on a compute node. I recommend changing the training command to:
 >
 > ```bash
-> # Choose one approach using the site's real environment
-> module load <python_or_ai_module>
-> # or
-> source <shared_venv>/bin/activate
-> python -c 'import torch; print(torch.__version__)'
-> python train.py
+> /home/alice/venvs/torch/bin/python train.py
 > ```
 >
-> Do not guess the module name or environment path. If you provide the current script and site
-> environment instructions, I can place the initialization steps correctly. Do not include passwords,
-> tokens, or a complete environment dump.
+> This would modify `train.sh` but would not submit a job. Do you approve the edit and a
+> `bash -n train.sh` validation? A new job must still confirm that the environment works on a compute
+> node.
+
+## Example 5: Discover configuration, write a script, and submit it
+
+**You:**
+
+> Use my latest successful training job to prepare and submit the current `train.py`. Ask before each
+> change.
+
+**Codex first queries history and searches project files:**
+
+```bash
+id -un
+cacct -u alice -n train -t completed -m 10 \
+  --type Batch -o "%j %n %P %a %q %C %M %l %t %e %s"
+rg -n '^#CBATCH --(gres|partition|account|qos|cpus-per-task|mem|time)=' \
+  /home/alice/project --glob '*.sh'
+```
+
+**Relevant tool output (example):**
+
+```text
+alice
+JOBID JOBNAME PARTITION ACCOUNT QOS    REQCPUS REQMEM TIMELIMIT STATE     EXITCODE SUBMITTIME
+4701  train   gpu-a100  ml      normal 4.00    16G    02:00:00  Completed 0:0      2026-08-10 09:42:11
+4638  train   gpu-a100  ml      normal 4.00    16G    02:00:00  Completed 0:0      2026-08-07 16:18:03
+/home/alice/project/train_4701.sh:4:#CBATCH --partition=gpu-a100
+/home/alice/project/train_4701.sh:5:#CBATCH --account=ml
+/home/alice/project/train_4701.sh:6:#CBATCH --qos=normal
+/home/alice/project/train_4701.sh:10:#CBATCH --gres=gpu:a100:1
+```
+
+**Codex (example response):**
+
+> Among the returned records, the successful matching job with the latest submission time is `4701`,
+> with state `Completed` and exit code `0:0`. `cacct` confirms partition `gpu-a100`, account `ml`,
+> QoS `normal`, four CPUs, 16 GB, and a two-hour limit.
+> The project's `train_4701.sh` also confirms `#CBATCH --gres=gpu:a100:1`. I propose creating
+> `train.sh` with these sourced values and the current `train.py` as its entry point. I will not
+> submit it yet. Do you approve writing the file?
+
+**You:**
+
+> Approved.
+
+**Codex writes and validates, then responds:**
+
+> Created `train.sh`; `bash -n train.sh` passed. Submitting it will create a job and consume cluster
+> resources. Do you approve running `cbatch train.sh`?
+
+**You:**
+
+> Submit it.
+
+**Codex submits and verifies automatically:**
+
+```bash
+cbatch train.sh
+cqueue -j 5012 -o="%j %P %n %t %l %N %L"
+ccontrol show job 5012
+```
+
+**Relevant tool output (example):**
+
+```text
+Job id allocated: 5012
+JOBID PARTITION NAME  STATUS  TIMELIMIT NODES NODELIST/REASON
+5012  gpu-a100  train Pending 02:00:00  1     Priority
+JobId=5012 JobName=train
+        User=alice(1001) Account=ml
+        JobState=Pending TimeLimit=02:00:00 Partition=gpu-a100
+        Priority=874 Qos=normal
+        ReqRes:node=1 cpu=4.00 mem=16G gres=gpu:a100:1
+```
+
+**Codex (example response):**
+
+> Submission succeeded with job ID `5012`. The query confirms `gpu-a100` / `ml` / `normal`, one A100,
+> four CPUs, 16 GB, and two hours. Its current state is `Pending` with reason `Priority`. The job is
+> correctly queued; do not submit another copy.
 
 ## Boundaries
 
-- Review commands and scripts before running them; site documentation and the installed command's `--help` take precedence.
-- Share only relevant output. Never provide passwords, API keys, private keys, or a complete environment dump.
-- Codex gains no additional CraneSched permissions and cannot confirm site partitions, accounts, QoS, or cluster state on an administrator's behalf.
-- Before submitting or cancelling a job or changing a file, confirm that the target is yours and the effect is intended.
+- Codex can give specific conclusions from actual query results but gains no CraneSched permissions beyond your account.
+- Site documentation and the installed command's `--help` take precedence; review generated scripts and change summaries before execution.
+- Never provide passwords, API keys, private keys, or a complete environment dump.
+- Nodes, partitions, accounts, QoS, services, and system configuration remain administrator responsibilities.

--- a/docs/en/ai-assistants/shared-codex.md
+++ b/docs/en/ai-assistants/shared-codex.md
@@ -55,7 +55,8 @@ codex --strict-config doctor --json
 ```
 
 `ss` should show only `127.0.0.1:617`. After a minimal real-request check, users can run `codex`
-directly or override the system default with a personal BYOK provider.
+directly or override the system default with a personal BYOK provider. See
+[Using Shared Codex](shared-codex-user-guide.md) for the user workflow.
 
 Follow the
 [full installation and configuration guide](https://github.com/PKUHPC/CraneSched-Codex/blob/main/docs/installation-and-configuration.md)

--- a/docs/en/deployment/index.md
+++ b/docs/en/deployment/index.md
@@ -198,6 +198,7 @@ Run containerized jobs in the cluster with user isolation and portable environme
 
 - **[CraneSched Skill](../ai-assistants/skill.md)** - Users can install it in their own AI assistant without a cluster Codex deployment
 - **[Shared Cluster Codex](../ai-assistants/shared-codex.md)** - Administrators can provide a ready-to-use Codex on shared nodes
+- **[Using Shared Codex](../ai-assistants/shared-codex-user-guide.md)** - User startup instructions and representative use cases
 
 ---
 

--- a/docs/zh/ai-assistants/shared-codex-user-guide.md
+++ b/docs/zh/ai-assistants/shared-codex-user-guide.md
@@ -1,0 +1,100 @@
+# 使用集群共享 Codex
+
+集群共享 Codex 可以帮助你编写鹤思作业脚本、理解作业状态，以及根据命令输出排查
+常见问题。管理员已在共享节点上配置模型服务和鹤思 Skill，你不需要获取共享 API Key。
+
+## 启动
+
+登录管理员指定的节点，将尖括号占位符替换为实际路径，进入自己的工作目录后直接运行：
+
+```bash
+cd <你的工作目录>
+codex
+```
+
+进入对话后直接用自然语言描述目标，并尽量提供程序入口、资源需求、作业 ID、完整报错
+和相关命令输出。若找不到 `codex` 命令或无法连接模型服务，请联系集群管理员；不要尝试
+读取或修改系统 Codex 配置。
+
+以下对话均为示例，不是来自真实集群。实际回答会随你的输入、本站策略和已安装版本而变化。
+
+## 示例一：生成作业脚本
+
+**你：**
+
+> 请为 `train.py` 写一个鹤思批处理脚本：使用 1 张 GPU、4 个 CPU、16G 内存，
+> 最长运行 2 小时。我还不知道本站的 GPU 分区名。
+
+**Codex（示例响应）：**
+
+> 先保留分区占位符，请按本站文档替换 `<gpu_partition>`：
+>
+> ```bash
+> #!/bin/bash
+> #CBATCH --job-name=train
+> #CBATCH --partition=<gpu_partition>
+> #CBATCH --nodes=1
+> #CBATCH --ntasks-per-node=1
+> #CBATCH --cpus-per-task=4
+> #CBATCH --mem=16G
+> #CBATCH --gres=gpu:1
+> #CBATCH --time=02:00:00
+> #CBATCH --output=train_%j.out
+> #CBATCH --error=train_%j.err
+>
+> python train.py
+> ```
+>
+> 保存为 `train.sh`，先用 `bash -n train.sh` 检查 shell 语法，再运行
+> `cbatch train.sh`。如果本站要求账户、QoS 或环境模块，请按用户手册补充；不要猜测这些值。
+
+## 示例二：理解排队原因
+
+**你：**
+
+> 我的作业 4812 一直是 `Pending`，`cqueue -j 4812 -F` 显示
+> `Reason=Resources`。这是提交失败了吗？
+
+**Codex（示例响应）：**
+
+> 这不表示提交失败。已确认的信息是：作业仍在队列中，当前最高优先级阻塞原因与可用
+> 资源有关；仅凭这一行无法判断准确开始时间。可以继续查看本人作业详情：
+>
+> ```bash
+> ccontrol show job 4812
+> ```
+>
+> 核对请求的 GPU、节点数、内存和时限是否符合预期。若原因长期不变，请把作业 ID、
+> 提交时间、资源请求和上述输出交给管理员，不要反复重投同一个作业。
+
+## 示例三：排查失败作业
+
+**你：**
+
+> `cacct -j 4930 -F` 显示 `State=Failed`、`ExitCode=1:0`，错误文件中第一条错误是
+> `ModuleNotFoundError: No module named 'torch'`。应该先查什么？
+
+**Codex（示例响应）：**
+
+> `ExitCode=1:0` 表示应用返回了退出码 1，没有信号终止的证据。结合第一条错误，较可能是
+> 批作业环境没有加载包含 `torch` 的 Python 环境。先检查脚本是否显式加载本站推荐的模块，
+> 或激活位于共享存储上的虚拟环境，例如：
+>
+> ```bash
+> # 按本站实际环境选择一种方式
+> module load <python_or_ai_module>
+> # 或
+> source <shared_venv>/bin/activate
+> python -c 'import torch; print(torch.__version__)'
+> python train.py
+> ```
+>
+> 不要猜模块名或环境路径。若你提供当前脚本和本站环境说明，我可以帮你把初始化步骤放到
+> 正确位置；请勿粘贴密码、令牌或完整环境变量。
+
+## 使用边界
+
+- Codex 给出的命令和脚本应在执行前由你检查，站点文档和命令的 `--help` 优先。
+- 提供最少且相关的输出；不要发送密码、API Key、私钥或完整环境变量。
+- Codex 不会获得额外的 CraneSched 权限，也不能代替管理员确认分区、账户、QoS 或集群状态。
+- 取消作业、提交作业或修改文件前，确认目标只属于你且影响范围符合预期。

--- a/docs/zh/ai-assistants/shared-codex-user-guide.md
+++ b/docs/zh/ai-assistants/shared-codex-user-guide.md
@@ -52,8 +52,8 @@ codex
 
 **你：**
 
-> 我的作业 4812 一直是 `Pending`，`cqueue -j 4812 -F` 显示
-> `Reason=Resources`。这是提交失败了吗？
+> 我的作业 4812 一直是 `Pending`，`cqueue -j 4812 -F` 的 `NODELIST/REASON`
+> 列显示 `Resource`。这是提交失败了吗？
 
 **Codex（示例响应）：**
 

--- a/docs/zh/ai-assistants/shared-codex-user-guide.md
+++ b/docs/zh/ai-assistants/shared-codex-user-guide.md
@@ -1,7 +1,8 @@
 # 使用集群共享 Codex
 
-集群共享 Codex 可以帮助你编写鹤思作业脚本、理解作业状态，以及根据命令输出排查
-常见问题。管理员已在共享节点上配置模型服务和鹤思 Skill，你不需要获取共享 API Key。
+集群共享 Codex 可以帮助你编写鹤思作业脚本、查询本人作业、解释调度状态，并根据
+命令输出和工作目录中的文件排查问题。管理员已配置模型服务和鹤思 Skill，你不需要
+获取共享 API Key。
 
 ## 启动
 
@@ -12,89 +13,246 @@ cd <你的工作目录>
 codex
 ```
 
-进入对话后直接用自然语言描述目标，并尽量提供程序入口、资源需求、作业 ID、完整报错
-和相关命令输出。若找不到 `codex` 命令或无法连接模型服务，请联系集群管理员；不要尝试
-读取或修改系统 Codex 配置。
+进入对话后直接描述目标。提供作业 ID、程序入口和预期行为即可；缺少的本人作业信息，
+Codex 可以按需查询。
 
-以下对话均为示例，不是来自真实集群。实际回答会随你的输入、本站策略和已安装版本而变化。
+## Agent 如何工作
 
-## 示例一：生成作业脚本
+集群版默认允许 Codex 执行以下只读命令，无需每次请求批准：
+
+- `cqueue`：查询当前队列和本人活动作业；
+- `cacct`：查询作业历史、状态和退出码；
+- `ccontrol show job` / `ccontrol show step`：查看作业或作业步详情。
+
+这些命令仍以你的身份运行，CraneSched 服务端权限决定可见范围。站点或用户可以配置
+更严格的规则。Codex 应优先查询明确的作业 ID 或本人作业，避免持续刷新或宽范围查询。
+
+Codex 还可以在当前工作目录中查找脚本、日志和已有环境，并运行本地检查；这些操作受
+Codex 沙箱、文件权限和站点策略约束；操作需要额外访问权限时，命令行是否提示审批取决于
+生效的配置。
+
+写入脚本、执行 `cbatch`、取消作业或修改作业状态会产生副作用，不属于上述默认只读
+名单。处理这类任务时，应要求 Codex 先说明操作和影响，并等待你的明确确认。命令行是否
+还会显示 Codex 内置审批界面，取决于生效的站点和用户配置。你可以拒绝或要求修改方案。
+
+以下对话均为示例，不是来自真实集群；命令输出和站点名称仅用于展示工作方式。
+
+## 示例一：解释基本状态
 
 **你：**
 
-> 请为 `train.py` 写一个鹤思批处理脚本：使用 1 张 GPU、4 个 CPU、16G 内存，
-> 最长运行 2 小时。我还不知道本站的 GPU 分区名。
+> 作业显示 `Running`，是否说明训练已经成功？
 
 **Codex（示例响应）：**
 
-> 先保留分区占位符，请按本站文档替换 `<gpu_partition>`：
+> `Running` 只表示资源已分配且作业正在执行，不能证明训练结果正确。应继续检查 stdout、
+> stderr 和应用指标；作业结束后再结合 `cacct` 的 `State` 与 `ExitCode` 判断是否成功。
+
+## 示例二：生成脚本草稿
+
+**你：**
+
+> 为 `train.py` 生成一个脚本草稿。本站参数是分区 `gpu-a100`、账户 `ml`、QoS
+> `normal`；申请 1 张 A100、4 个 CPU、16G 内存和 2 小时。先不要写文件或提交。
+
+**Codex（示例响应）：**
+
+> 我会只在对话中生成草稿，不修改文件或提交作业：
 >
 > ```bash
 > #!/bin/bash
 > #CBATCH --job-name=train
-> #CBATCH --partition=<gpu_partition>
+> #CBATCH --partition=gpu-a100
+> #CBATCH --account=ml
+> #CBATCH --qos=normal
 > #CBATCH --nodes=1
 > #CBATCH --ntasks-per-node=1
 > #CBATCH --cpus-per-task=4
 > #CBATCH --mem=16G
-> #CBATCH --gres=gpu:1
+> #CBATCH --gres=gpu:a100:1
 > #CBATCH --time=02:00:00
 > #CBATCH --output=train_%j.out
 > #CBATCH --error=train_%j.err
 >
 > python train.py
 > ```
->
-> 保存为 `train.sh`，先用 `bash -n train.sh` 检查 shell 语法，再运行
-> `cbatch train.sh`。如果本站要求账户、QoS 或环境模块，请按用户手册补充；不要猜测这些值。
 
-## 示例二：理解排队原因
+## 示例三：主动查询当前作业
 
 **你：**
 
-> 我的作业 4812 一直是 `Pending`，`cqueue -j 4812 -F` 的 `NODELIST/REASON`
-> 列显示 `Resource`。这是提交失败了吗？
+> 帮我看看现在有哪些作业需要关注。
+
+**Codex 调用只读工具：**
+
+```bash
+cqueue --self -o="%j %P %n %t %l %N %L"
+ccontrol show job 4812
+```
+
+**工具返回的关键信息（示例）：**
+
+```text
+JOBID PARTITION NAME       STATUS  TIMELIMIT NODES NODELIST(REASON)
+4812  gpu-a100  train      Pending 02:00:00  1     (Resource)
+4815  cpu       preprocess Running 01:00:00  1     cn032
+
+JobId=4812 JobState=Pending Account=ml Qos=normal Partition=gpu-a100
+Reason=Resource TimeLimit=02:00:00 ReqRes:node=1 cpu=4 mem=16G gres=gpu:a100:1
+```
 
 **Codex（示例响应）：**
 
-> 这不表示提交失败。已确认的信息是：作业仍在队列中，当前最高优先级阻塞原因与可用
-> 资源有关；仅凭这一行无法判断准确开始时间。可以继续查看本人作业详情：
+> 你有 2 个活动作业：
 >
-> ```bash
-> ccontrol show job 4812
-> ```
+> - `4815` 正在 `cpu` 分区的 `cn032` 上运行；当前没有调度异常。
+> - `4812` 已成功进入队列，但在等待能够满足所示完整请求的资源，其中包括 1 张 A100、
+>   4 CPU 和 16G 内存；当前原因是 `Resource`，不是提交失败。账户 `ml`、QoS `normal`
+>   和 2 小时时限也已由作业详情确认。
 >
-> 核对请求的 GPU、节点数、内存和时限是否符合预期。若原因长期不变，请把作业 ID、
-> 提交时间、资源请求和上述输出交给管理员，不要反复重投同一个作业。
+> 当前无需重投。`Resource` 只说明此刻没有满足整个请求的可用资源，不能据此承诺开始时间。
 
-## 示例三：排查失败作业
+## 示例四：组合历史、详情和文件定位失败
 
 **你：**
 
-> `cacct -j 4930 -F` 显示 `State=Failed`、`ExitCode=1:0`，错误文件中第一条错误是
-> `ModuleNotFoundError: No module named 'torch'`。应该先查什么？
+> 我的作业 4930 失败了，请直接帮我查原因。
+
+**Codex 查询作业数据并检查工作目录：**
+
+```bash
+cacct -j 4930 -F -o "%j %t %e %P %a"
+pwd
+rg --files | rg '4930|train.*\.(out|err)$'
+sed -n '1,160p' train.sh
+sed -n '1,120p' train_4930.err
+rg -n 'venvs/.*/bin/python|source .*/bin/activate' --glob '*.sh'
+test -x /home/alice/venvs/torch/bin/python
+```
+
+**为便于阅读而分组的关键结果（示例）：**
+
+```text
+JOBID STATE  EXITCODE PARTITION ACCOUNT
+4930  Failed 1:0      gpu-a100  ml
+
+/home/alice/project
+train_4930.err
+```
+
+```bash
+#!/bin/bash
+#CBATCH --job-name=train
+#CBATCH --partition=gpu-a100
+#CBATCH --output=train_%j.out
+#CBATCH --error=train_%j.err
+
+python train.py
+```
+
+```text
+ModuleNotFoundError: No module named 'torch'
+tools/check_gpu.sh:8:/home/alice/venvs/torch/bin/python -c 'import torch; print(torch.__version__)'
+候选解释器可执行（`test` 退出状态为 0）。
+```
 
 **Codex（示例响应）：**
 
-> `ExitCode=1:0` 表示应用返回了退出码 1，没有信号终止的证据。结合第一条错误，较可能是
-> 批作业环境没有加载包含 `torch` 的 Python 环境。先检查脚本是否显式加载本站推荐的模块，
-> 或激活位于共享存储上的虚拟环境，例如：
+> 已确认作业进入 `gpu-a100` 分区并由应用返回退出码 1，没有信号终止的证据。错误发生在
+> Python 导入阶段；完整的 `train.sh` 使用未限定路径的 `python`，没有显式加载模块、激活
+> 虚拟环境或指定解释器路径。因此当前最早且直接的失败原因是该脚本选中的 Python 环境
+> 无法导入 `torch`，不是排队或超时。
+>
+> 项目的另一份脚本已使用可执行的 `/home/alice/venvs/torch/bin/python` 检查 `torch`；
+> 这是有项目文件依据的候选方案，但还不能证明它在计算节点可用。建议把训练命令改为：
 >
 > ```bash
-> # 按本站实际环境选择一种方式
-> module load <python_or_ai_module>
-> # 或
-> source <shared_venv>/bin/activate
-> python -c 'import torch; print(torch.__version__)'
-> python train.py
+> /home/alice/venvs/torch/bin/python train.py
 > ```
 >
-> 不要猜模块名或环境路径。若你提供当前脚本和本站环境说明，我可以帮你把初始化步骤放到
-> 正确位置；请勿粘贴密码、令牌或完整环境变量。
+> 这会修改 `train.sh`，但不会提交作业。是否批准我修改并运行 `bash -n train.sh` 验证？
+> 修改后仍需通过新作业确认该环境在计算节点可用。
+
+## 示例五：查找配置、写入脚本并提交
+
+**你：**
+
+> 参考我最近成功的同类训练作业，为当前 `train.py` 准备脚本并提交。每一步变更先让我确认。
+
+**Codex 先查询历史并检索项目文件：**
+
+```bash
+id -un
+cacct -u alice -n train -t completed -m 10 \
+  --type Batch -o "%j %n %P %a %q %C %M %l %t %e %s"
+rg -n '^#CBATCH --(gres|partition|account|qos|cpus-per-task|mem|time)=' \
+  /home/alice/project --glob '*.sh'
+```
+
+**工具返回的关键信息（示例）：**
+
+```text
+alice
+JOBID JOBNAME PARTITION ACCOUNT QOS    REQCPUS REQMEM TIMELIMIT STATE     EXITCODE SUBMITTIME
+4701  train   gpu-a100  ml      normal 4.00    16G    02:00:00  Completed 0:0      2026-08-10 09:42:11
+4638  train   gpu-a100  ml      normal 4.00    16G    02:00:00  Completed 0:0      2026-08-07 16:18:03
+/home/alice/project/train_4701.sh:4:#CBATCH --partition=gpu-a100
+/home/alice/project/train_4701.sh:5:#CBATCH --account=ml
+/home/alice/project/train_4701.sh:6:#CBATCH --qos=normal
+/home/alice/project/train_4701.sh:10:#CBATCH --gres=gpu:a100:1
+```
+
+**Codex（示例响应）：**
+
+> 返回记录中提交时间最新的成功同类作业是 `4701`，状态 `Completed`、退出码 `0:0`；
+> `cacct` 确认其使用 `gpu-a100` 分区、`ml` 账户、`normal` QoS、4 CPU、16G 内存和
+> 2 小时。项目中的
+> `train_4701.sh` 还确认了 `#CBATCH --gres=gpu:a100:1`。我准备以这些有来源的值创建
+> `train.sh`，入口为当前目录的 `train.py`，暂不提交。是否批准写入该文件？
+
+**你：**
+
+> 批准。
+
+**Codex 写入并验证后响应：**
+
+> 已创建 `train.sh`，`bash -n train.sh` 通过。提交会创建作业并消耗集群资源。
+> 是否批准执行 `cbatch train.sh`？
+
+**你：**
+
+> 批准提交。
+
+**Codex 提交并自动验证：**
+
+```bash
+cbatch train.sh
+cqueue -j 5012 -o="%j %P %n %t %l %N %L"
+ccontrol show job 5012
+```
+
+**工具返回的关键信息（示例）：**
+
+```text
+Job id allocated: 5012
+JOBID PARTITION NAME  STATUS  TIMELIMIT NODES NODELIST/REASON
+5012  gpu-a100  train Pending 02:00:00  1     Priority
+JobId=5012 JobName=train
+        User=alice(1001) Account=ml
+        JobState=Pending TimeLimit=02:00:00 Partition=gpu-a100
+        Priority=874 Qos=normal
+        ReqRes:node=1 cpu=4.00 mem=16G gres=gpu:a100:1
+```
+
+**Codex（示例响应）：**
+
+> 提交成功，新作业 ID 为 `5012`。查询确认脚本使用 `gpu-a100` / `ml` / `normal`，
+> 请求 1 张 A100、4 CPU、16G 内存和 2 小时；当前状态为 `Pending`，原因是 `Priority`。
+> 作业已正常进入队列，无需再次提交。
 
 ## 使用边界
 
-- Codex 给出的命令和脚本应在执行前由你检查，站点文档和命令的 `--help` 优先。
-- 提供最少且相关的输出；不要发送密码、API Key、私钥或完整环境变量。
-- Codex 不会获得额外的 CraneSched 权限，也不能代替管理员确认分区、账户、QoS 或集群状态。
-- 取消作业、提交作业或修改文件前，确认目标只属于你且影响范围符合预期。
+- Codex 可以依据实际查询结果给出具体结论，但不会获得超出你账户的 CraneSched 权限。
+- 站点文档和当前命令的 `--help` 优先；执行前仍应检查生成的脚本和变更摘要。
+- 不要提供密码、API Key、私钥或完整环境变量。
+- 管理节点、分区、账户、QoS、服务和系统配置仍由管理员负责。

--- a/docs/zh/ai-assistants/shared-codex.md
+++ b/docs/zh/ai-assistants/shared-codex.md
@@ -53,7 +53,8 @@ codex --strict-config doctor --json
 ```
 
 `ss` 应只显示 `127.0.0.1:617`。完成最小真实请求验证后，普通用户可直接运行
-`codex`，也可以用自己的 BYOK provider 覆盖系统默认值。
+`codex`，也可以用自己的 BYOK provider 覆盖系统默认值。用户操作方式参见
+[使用集群共享 Codex](shared-codex-user-guide.md)。
 
 配置文件格式、升级、轮换、回滚、故障排查和卸载步骤以
 [完整安装与配置指南](https://github.com/PKUHPC/CraneSched-Codex/blob/main/docs/installation-and-configuration.md)

--- a/docs/zh/deployment/index.md
+++ b/docs/zh/deployment/index.md
@@ -198,6 +198,7 @@ MongoDB 存储作业历史记录、用户账户和资源使用数据。
 
 - **[鹤思 Skill](../ai-assistants/skill.md)** - 用户可安装到自己的 AI 助手中，无需集群部署 Codex
 - **[集群共享 Codex](../ai-assistants/shared-codex.md)** - 管理员为共享节点提供开箱即用的 Codex
+- **[使用集群共享 Codex](../ai-assistants/shared-codex-user-guide.md)** - 用户启动方法和典型使用案例
 
 ---
 

--- a/mkdocs.yaml
+++ b/mkdocs.yaml
@@ -88,6 +88,7 @@ nav:
   - AI Assistants:
     - CraneSched Skill: ai-assistants/skill.md
     - Shared Cluster Codex: ai-assistants/shared-codex.md
+    - Using Shared Codex: ai-assistants/shared-codex-user-guide.md
   - Commands:
       - Job Submission:
           - cbatch: command/cbatch.md
@@ -198,6 +199,7 @@ plugins:
             AI Assistants: AI 助手
             CraneSched Skill: 鹤思 Skill
             Shared Cluster Codex: 集群共享 Codex
+            Using Shared Codex: 使用集群共享 Codex
         - locale: en
           name: English
           build: true


### PR DESCRIPTION
## Summary

- add bilingual user guides for starting the cluster-shared Codex with `codex`
- explain the packaged default allow rules for `cqueue`, `cacct`, and low-risk `ccontrol show job/step` queries
- provide two simple examples and three tool-driven Agent workflows with evidence-based conclusions
- demonstrate discovering verified job parameters, requesting approval, writing a script, submitting it after approval, and verifying the new job
- link the guide from the AI Assistants navigation, deployment overview, and administrator guide

The examples are illustrative; this change uses no screenshots or live Codex invocation.

## Validation

- `git diff --check origin/master...HEAD`
- local links across all AI Assistant pages
- strict bilingual MkDocs build
- generated Chinese and English HTML contains direct startup and all five examples
- independent Standards and Spec SubAgent review

Closes #955


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive English and Chinese user guides for Shared Codex.
  * Documented read-only queries, sandbox and approval behavior, job workflows, troubleshooting, configuration discovery, script drafting, submission, and verification.
  * Added navigation and contextual links to the guides from AI Assistant and deployment documentation.
  * Clarified operational boundaries, credential protection, and administrator responsibilities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->