### PR TITLE
fix(craned): create supervisor socket directory at startup

### DIFF
--- a/src/CraneCtld/Database/DbClient.cpp
+++ b/src/CraneCtld/Database/DbClient.cpp
@@ -265,9 +265,8 @@ void SetJobSummaryQueryCommonFilter(
       bsoncxx::builder::basic::array arr;
       for (const auto& job_id : request->filter_job_ids())
         arr.append(static_cast<int32_t>(job_id));
-      match_doc.append(
-          kvp("job_id",
-              bsoncxx::builder::basic::make_document(kvp("$in", arr))));
+      match_doc.append(kvp(
+          "job_id", bsoncxx::builder::basic::make_document(kvp("$in", arr))));
     }
 
     // partition

--- a/src/Craned/Core/Craned.cpp
+++ b/src/Craned/Core/Craned.cpp
@@ -1353,6 +1353,10 @@ void CreateRequiredDirectories() {
   ok = util::os::CreateFolders(g_config.CranedScriptDir);
   if (!ok) std::exit(1);
 
+  ok = util::os::CreateFolders(g_config.CraneBaseDir /
+                               kDefaultSupervisorUnixSockDir);
+  if (!ok) std::exit(1);
+
   ok = util::os::CreateFoldersForFile(g_config.CranedLogFile);
   if (!ok) std::exit(1);
 }

--- a/src/Craned/Supervisor/Supervisor.cpp
+++ b/src/Craned/Supervisor/Supervisor.cpp
@@ -312,8 +312,7 @@ bool CreateRequiredDirectories() {
     if (!ok) return ok;
   }
 
-  ok = util::os::CreateFolders(g_config.SupervisorUnixSockPath.parent_path());
-  return ok;
+  return true;
 }
 
 void GlobalVariableInit(int grpc_output_fd) {


### PR DESCRIPTION
## Summary

- create the shared Supervisor Unix socket directory during Craned startup
- stop each Supervisor process from racing to create the same directory
- keep Supervisor-owned script and log directory initialization unchanged

## Root cause

CI run `31673501624` exposed a concurrent startup race in cases `1.0.0.5` and `3.4.6.13`. Multiple Supervisors checked the shared directory at the same time. After one process created it, another observed `create_directories()` returning `false` with a successful `error_code`, which the existing helper treated as failure:

```text
Failed to create folder /var/cranetest/craned/supervisor: Success
```

That Supervisor aborted with internal `EC_SPAWN_FAILED=324`, reported by `cacct` as `0:68`.

The directory is Craned-owned shared state, so Craned now creates it before any Supervisor can be spawned. Supervisors only create their process-specific supporting directories.

## Validation

- standard AutoTest Compose `ci-debug` build and RPM/DEB packaging passed
- `clang-format --dry-run --Werror` passed for both changed files
- `git diff --check` passed
- `1.0.0.5`: 3/3 independent environment cycles passed
- `3.4.6.13`: 3/3 independent environment cycles passed
- no recurrence of the directory error, `EC_SPAWN_FAILED`, or `Failed 0:68`

No AutoTest cases or output matching rules were changed. The full system suite was not run locally.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved setup of the default Supervisor socket directory.
  * Startup now stops when the required socket directory cannot be created.
  * Prevented unnecessary creation of directories based on custom socket paths.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->