### PR TITLE
docs: tolerate missing pam_crane module

### DIFF
--- a/docs/en/deployment/configuration/pam.md
+++ b/docs/en/deployment/configuration/pam.md
@@ -25,8 +25,8 @@ cp build/src/Misc/Pam/pam_crane.so /usr/lib64/security/
 
 Edit `/etc/pam.d/sshd` and add the following lines:
 
-- Add `account required pam_crane.so` **before** `account include password-auth`
-- Add `session required pam_crane.so` **after** `session include password-auth`
+- Add `account [success=ok module_unknown=ignore default=bad] pam_crane.so` **before** `account include password-auth`
+- Add `session [success=ok module_unknown=ignore default=bad] pam_crane.so` **after** `session include password-auth`
 
 **Example configuration:**
 
@@ -37,7 +37,7 @@ auth       substack     password-auth
 auth       include      postlogin
 # Used with polkit to reauthorize users in remote sessions
 -auth      optional     pam_reauthorize.so prepare
-account    required     pam_crane.so
+account    [success=ok module_unknown=ignore default=bad] pam_crane.so
 account    required     pam_nologin.so
 account    include      password-auth
 password   include      password-auth
@@ -49,14 +49,14 @@ session    required     pam_selinux.so open env_params
 session    required     pam_namespace.so
 session    optional     pam_keyinit.so force revoke
 session    include      password-auth
-session    required     pam_crane.so
+session    [success=ok module_unknown=ignore default=bad] pam_crane.so
 session    include      postlogin
 # Used with polkit to reauthorize users in remote sessions
 -session   optional     pam_reauthorize.so prepare
 ```
 
 !!! warning
-    The line `session required pam_crane.so` must be placed **after** `session include password-auth`.
+    The line `session [success=ok module_unknown=ignore default=bad] pam_crane.so` must be placed **after** `session include password-auth`.
 
 ## Testing
 

--- a/docs/zh/deployment/configuration/pam.md
+++ b/docs/zh/deployment/configuration/pam.md
@@ -25,8 +25,8 @@ cp build/src/Misc/Pam/pam_crane.so /usr/lib64/security/
 
 编辑 `/etc/pam.d/sshd` 并添加以下行：
 
-- 在 `account include password-auth` **之前**添加 `account required pam_crane.so`
-- 在 `session include password-auth` **之后**添加 `session required pam_crane.so`
+- 在 `account include password-auth` **之前**添加 `account [success=ok module_unknown=ignore default=bad] pam_crane.so`
+- 在 `session include password-auth` **之后**添加 `session [success=ok module_unknown=ignore default=bad] pam_crane.so`
 
 **配置示例：**
 
@@ -37,7 +37,7 @@ auth       substack     password-auth
 auth       include      postlogin
 # Used with polkit to reauthorize users in remote sessions
 -auth      optional     pam_reauthorize.so prepare
-account    required     pam_crane.so
+account    [success=ok module_unknown=ignore default=bad] pam_crane.so
 account    required     pam_nologin.so
 account    include      password-auth
 password   include      password-auth
@@ -49,14 +49,14 @@ session    required     pam_selinux.so open env_params
 session    required     pam_namespace.so
 session    optional     pam_keyinit.so force revoke
 session    include      password-auth
-session    required     pam_crane.so
+session    [success=ok module_unknown=ignore default=bad] pam_crane.so
 session    include      postlogin
 # Used with polkit to reauthorize users in remote sessions
 -session   optional     pam_reauthorize.so prepare
 ```
 
 !!! warning
-    行 `session required pam_crane.so` 必须放在 `session include password-auth` **之后**。
+    行 `session [success=ok module_unknown=ignore default=bad] pam_crane.so` 必须放在 `session include password-auth` **之后**。
 
 ## 测试
 

--- a/scripts/uninstall_cranectld.sh
+++ b/scripts/uninstall_cranectld.sh
@@ -11,7 +11,6 @@ rm -f /etc/systemd/system/cranectld.service
 rm -rf /etc/crane
 
 if grep -q "pam_crane.so" /etc/pam.d/sshd; then
-   sed -i '/account    required     pam_crane.so/d' /etc/pam.d/sshd
-   sed -i '/session    optional     pam_crane.so/d' /etc/pam.d/sshd
+   sed -i '/pam_crane\.so/d' /etc/pam.d/sshd
 fi
 systemctl deamon-reload

--- a/scripts/uninstall_craned.sh
+++ b/scripts/uninstall_craned.sh
@@ -9,7 +9,6 @@ rm -f /etc/systemd/system/craned.service
 
 rm -f /usr/lib64/security/pam_crane.so
 if grep -q "pam_crane.so" /etc/pam.d/sshd; then
-   sed -i '/account    required     pam_crane.so/d' /etc/pam.d/sshd
-   sed -i '/session    required     pam_crane.so/d' /etc/pam.d/sshd
+   sed -i '/pam_crane\.so/d' /etc/pam.d/sshd
 fi
 systemctl daemon-reload

--- a/scripts/uninstall_pam.sh
+++ b/scripts/uninstall_pam.sh
@@ -1,5 +1,4 @@
 #!/bin/bash
 if grep -q "pam_crane.so" /etc/pam.d/sshd; then
-   sed -i '/^#account    required     pam_crane.so/d' /etc/pam.d/sshd
-   sed -i '/^#session    optional     pam_crane.so/d' /etc/pam.d/sshd
+   sed -i '/pam_crane\.so/d' /etc/pam.d/sshd
 fi


### PR DESCRIPTION
## Summary
- document PAM control syntax that ignores missing pam_crane modules while preserving failure handling for loaded modules
- update English and Chinese PAM configuration examples
- make uninstall scripts remove pam_crane lines regardless of the old or new control syntax

## Tests
- git diff --check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated PAM configuration examples in English and Chinese with revised account and session rules.
  * Clarified rule ordering and behavior when modules are unavailable or unrecognized.
  * Removed outdated session configuration guidance.

* **Bug Fixes**
  * Improved PAM cleanup during uninstallation by removing all matching PAM integration entries, including nonstandard or previously unsupported entries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->