### PR TITLE
ci: harden FrontEnd branch routing

### DIFF
--- a/.github/ci/README.md
+++ b/.github/ci/README.md
@@ -15,6 +15,24 @@ privileged job is dispatched only when all of the following are true:
   reran that same workflow run;
 - Backend and FrontEnd refs resolve to full commit SHAs.
 
+For every authorized Backend pull-request event or approved rerun, the hosted
+job looks for an exact, case-sensitive branch with the same name in
+`PKUHPC/CraneSched-FrontEnd`. It uses GitHub's branch-reference API, so a tag or
+other commit-ish value with the same name does not match. Only an explicit 404
+for that branch permits fallback to FrontEnd `master`; permission, rate-limit,
+timeout and malformed-response failures stop authorization. The selected branch
+head is immediately verified and locked to its full commit SHA. The privileged
+runner checks out only that SHA and never falls back during checkout if the
+branch subsequently moves or is deleted.
+
+Approved fork pull requests use the same central FrontEnd branch lookup; no
+FrontEnd fork is queried. Backend `push` and `schedule` events always select the
+exact FrontEnd `master` branch, while `workflow_dispatch` retains its explicit
+`frontend_ref` commit-ish input. FrontEnd pushes do not trigger Backend CI.
+Selection is recalculated only for a new Backend event or a manual workflow
+rerun, then recorded as `matching_branch`, `master_fallback`, `master_default`
+or `manual_ref` in the job summary and sanitized artifact manifest.
+
 The privileged job uses the dedicated repository-scoped runner selected by the
 exact `cranesystemtest` label. Repository registration prevents other
 repositories from dispatching to it, but GitHub does not restrict which
@@ -70,8 +88,11 @@ temporary merge commit. Protect
 `.github/workflows/**` and `.github/ci/**` through branch protection and
 required maintainer review because this static guard is an accidental-change
 check, not a GitHub-enforced workflow authorization boundary.
-The sanitized artifact manifest and summary retain the base, head, and routing
-SHAs so reviewers can distinguish tested source from the inspected merge tree.
+The sanitized artifact manifest and summary retain the base, head, routing and
+authorized FrontEnd revisions so reviewers can distinguish tested source from
+the inspected merge tree. If a generated plan or aggregate result omits the
+FrontEnd SHA or disagrees with the authorized SHA, artifact collection reports
+an infrastructure error with exit code `2`.
 
 ## Repository variables
 

--- a/.github/ci/authorize.py
+++ b/.github/ci/authorize.py
@@ -58,6 +58,7 @@ class DispatchContext:
 
 PermissionLookup = Callable[[str, str], dict[str, object]]
 CommitResolver = Callable[[str, str], Optional[str]]
+BranchResolver = Callable[[str, str], Optional[str]]
 
 
 @dataclass(frozen=True)
@@ -138,6 +139,15 @@ def _required_commit(
     revision = resolver(repository, ref)
     if revision is None or not SHA_RE.fullmatch(revision):
         raise AuthorizationError(f"{label} ref did not resolve to a full commit SHA")
+    return revision
+
+
+def _required_branch(
+    resolver: BranchResolver, repository: str, branch: str, label: str
+) -> str:
+    revision = resolver(repository, branch)
+    if revision is None or not SHA_RE.fullmatch(revision):
+        raise AuthorizationError(f"{label} branch did not resolve to a full commit SHA")
     return revision
 
 
@@ -391,6 +401,7 @@ def authorize_dispatch(
     issue_comments_lookup: IssueCommentsLookup | None = None,
     issue_comment_lookup: IssueCommentLookup | None = None,
     *,
+    branch_resolver: BranchResolver | None = None,
     sleeper: Sleeper = time.sleep,
     retry_delays: tuple[float, ...] = _MERGE_RETRY_DELAYS,
 ) -> dict[str, str]:
@@ -439,16 +450,25 @@ def authorize_dispatch(
         pr_base_sha = context.event_sha
         pr_head_sha = context.pr_head_sha
         pr_merge_sha = routing_sha
+        if branch_resolver is None:
+            raise AuthorizationError("FrontEnd branch lookup is unavailable")
         frontend_ref = context.pr_head_ref
-        frontend_sha = commit_resolver(context.frontend_repository, frontend_ref)
+        frontend_sha = branch_resolver(context.frontend_repository, frontend_ref)
         if frontend_sha is None:
             frontend_ref = "master"
-            frontend_sha = _required_commit(
-                commit_resolver,
+            frontend_sha = _required_branch(
+                branch_resolver,
                 context.frontend_repository,
                 frontend_ref,
                 "FrontEnd",
             )
+            frontend_source = "master_fallback"
+        else:
+            if not SHA_RE.fullmatch(frontend_sha):
+                raise AuthorizationError(
+                    "FrontEnd matching branch did not resolve to a full commit SHA"
+                )
+            frontend_source = "matching_branch"
     elif context.event_name == "workflow_dispatch":
         _require_maintainer(context, permission_lookup)
         backend_sha = _required_commit(
@@ -464,17 +484,21 @@ def authorize_dispatch(
             frontend_ref,
             "FrontEnd",
         )
+        frontend_source = "manual_ref"
         routing_sha = backend_sha
     elif context.event_name in {"push", "schedule"}:
         backend_sha = context.event_sha
         routing_sha = backend_sha
+        if branch_resolver is None:
+            raise AuthorizationError("FrontEnd branch lookup is unavailable")
         frontend_ref = "master"
-        frontend_sha = _required_commit(
-            commit_resolver,
+        frontend_sha = _required_branch(
+            branch_resolver,
             context.frontend_repository,
             frontend_ref,
             "FrontEnd",
         )
+        frontend_source = "master_default"
     else:
         raise AuthorizationError(f"unsupported dispatch event: {context.event_name}")
 
@@ -492,6 +516,11 @@ def authorize_dispatch(
         raise AuthorizationError("Routing commit verification failed")
     if not SHA_RE.fullmatch(frontend_sha):
         raise AuthorizationError("FrontEnd ref did not resolve to a full commit SHA")
+    verified_frontend = _required_commit(
+        commit_resolver, context.frontend_repository, frontend_sha, "FrontEnd"
+    )
+    if verified_frontend != frontend_sha:
+        raise AuthorizationError("FrontEnd commit verification failed")
     if any(character in frontend_ref for character in "\r\n"):
         raise AuthorizationError("FrontEnd ref contains an invalid output character")
 
@@ -504,6 +533,7 @@ def authorize_dispatch(
         "pr_merge_sha": pr_merge_sha,
         "frontend_ref": frontend_ref,
         "frontend_sha": frontend_sha,
+        "frontend_source": frontend_source,
         "workflow_sha": context.event_sha,
     }
 
@@ -575,6 +605,25 @@ class GitHubApi:
             return None
         revision = value.get("sha")
         return revision if isinstance(revision, str) else None
+
+    def branch_head(self, repository: str, branch: str) -> str | None:
+        encoded_branch = urllib.parse.quote(branch, safe="")
+        value = self._get(
+            f"repos/{repository}/git/ref/heads/{encoded_branch}",
+            missing_statuses=frozenset({404}),
+        )
+        if value is None:
+            return None
+        target = value.get("object")
+        if (
+            value.get("ref") != f"refs/heads/{branch}"
+            or not isinstance(target, dict)
+            or target.get("type") != "commit"
+            or not isinstance(target.get("sha"), str)
+            or SHA_RE.fullmatch(target["sha"]) is None
+        ):
+            raise AuthorizationError("GitHub branch response is malformed")
+        return target["sha"]
 
     def pull_request(self, repository: str, number: int) -> PullRequestSnapshot:
         value = self._get(f"repos/{repository}/pulls/{number}")
@@ -770,6 +819,7 @@ def main() -> int:
         api.commit_parents,
         api.issue_comments,
         api.issue_comment,
+        branch_resolver=api.branch_head,
     )
     with output_path.open("a", encoding="utf-8") as output:
         for name in (
@@ -781,6 +831,7 @@ def main() -> int:
             "pr_merge_sha",
             "frontend_ref",
             "frontend_sha",
+            "frontend_source",
             "workflow_sha",
         ):
             output.write(f"{name}={result[name]}\n")

--- a/.github/ci/collect-cranetestkit-artifacts.py
+++ b/.github/ci/collect-cranetestkit-artifacts.py
@@ -63,11 +63,28 @@ ANSI_ESCAPE = re.compile(r"\x1b\[[0-?]*[ -/]*[@-~]")
 UNSAFE_CONTROLS = re.compile(r"[\x00-\x08\x0b\x0c\x0e-\x1f\x7f]")
 BIDI_CONTROLS = re.compile(r"[\u202a-\u202e\u2066-\u2069]")
 FULL_SHA = re.compile(r"^[0-9a-f]{40}$")
+FRONTEND_REPOSITORY = "PKUHPC/CraneSched-FrontEnd"
+FRONTEND_SOURCES = (
+    "matching_branch",
+    "master_fallback",
+    "master_default",
+    "manual_ref",
+)
 
 
 def _full_sha(value: str) -> str:
     if FULL_SHA.fullmatch(value) is None:
         raise argparse.ArgumentTypeError("revision must be a full lowercase commit SHA")
+    return value
+
+
+def _frontend_ref(value: str) -> str:
+    if (
+        not value
+        or len(value) > 1024
+        or any(character in value for character in "\r\n")
+    ):
+        raise argparse.ArgumentTypeError("FrontEnd ref is invalid")
     return value
 
 
@@ -106,9 +123,9 @@ def _redact(value: str) -> tuple[str, int]:
     count = 0
     for pattern in REDACTIONS:
         value, replacements = pattern.subn(
-            lambda match: match.group(1) + "[REDACTED]"
-            if match.lastindex
-            else "[REDACTED]",
+            lambda match: (
+                match.group(1) + "[REDACTED]" if match.lastindex else "[REDACTED]"
+            ),
             value,
         )
         count += replacements
@@ -370,7 +387,9 @@ def _shard_context(
                     "wall": None,
                     "case_time": None,
                     "estimate": estimate,
-                    "result": "MISSING" if not records else f"DUPLICATE ({len(records)})",
+                    "result": "MISSING"
+                    if not records
+                    else f"DUPLICATE ({len(records)})",
                     "terminal": False,
                 }
             )
@@ -410,7 +429,9 @@ def _shard_context(
                 "slot": slot,
                 "cases": len(cases) if isinstance(cases, list) else planned_count,
                 "counts": counts,
-                "wall": _duration_between(record.get("started_at"), record.get("finished_at")),
+                "wall": _duration_between(
+                    record.get("started_at"), record.get("finished_at")
+                ),
                 "case_time": case_time,
                 "estimate": estimate,
                 "result": outcome,
@@ -489,6 +510,33 @@ def _resolve_exit_code(
     return None, []
 
 
+def _frontend_revision_diagnostics(
+    run_root: Path,
+    result: dict[str, object],
+    plan: dict[str, object],
+    authorized_sha: str,
+) -> list[str]:
+    if not run_root.is_dir() or run_root.is_symlink():
+        return []
+    diagnostics: list[str] = []
+    for label, relative, document in (
+        ("Aggregate result", Path("result.json"), result),
+        ("Plan", Path("plan/manifest.json"), plan),
+    ):
+        if _safe_source(run_root, relative) is None:
+            continue
+        sources = document.get("sources")
+        actual = sources.get("frontend") if isinstance(sources, dict) else None
+        if actual is None:
+            diagnostics.append(f"{label} FrontEnd SHA is missing")
+        elif actual != authorized_sha:
+            diagnostics.append(
+                f"{label} FrontEnd SHA {actual} does not match authorized SHA "
+                f"{authorized_sha}"
+            )
+    return diagnostics
+
+
 def _suite_digest(result: dict[str, object], plan: dict[str, object]) -> str:
     candidates = [result.get("suite_digest")]
     suite = plan.get("suite")
@@ -557,9 +605,7 @@ def _shard_evidence_diagnostics(
         if shard_index not in planned:
             diagnostics.append(f"shard {shard_index} is not present in the plan")
         if not row["terminal"]:
-            diagnostics.append(
-                f"shard {shard_index} is {str(row['result']).lower()}"
-            )
+            diagnostics.append(f"shard {shard_index} is {str(row['result']).lower()}")
             continue
         shard_result = row["result"]
         if shard_result in {"INFRASTRUCTURE ERROR", "INCOMPLETE"}:
@@ -597,6 +643,9 @@ def _write_summary(
     routing_sha: str | None = None,
     pr_base_sha: str | None = None,
     pr_head_sha: str | None = None,
+    frontend_ref: str,
+    frontend_sha: str,
+    frontend_source: str,
 ) -> int | None:
     result = _read_run_json(run_root, Path("result.json"))
     state = _read_run_json(run_root, Path("state.json"))
@@ -605,14 +654,18 @@ def _write_summary(
     sources = result.get("sources") or plan.get("sources") or {}
     if not isinstance(sources, dict):
         sources = {}
-    shard_rows, case_locations, shard_fatals = _shard_context(run_root, plan, allocation)
-    exit_code, exit_diagnostics = _resolve_exit_code(
-        result, state, execute_exit_code
+    shard_rows, case_locations, shard_fatals = _shard_context(
+        run_root, plan, allocation
     )
+    exit_code, exit_diagnostics = _resolve_exit_code(result, state, execute_exit_code)
+    frontend_diagnostics = _frontend_revision_diagnostics(
+        run_root, result, plan, frontend_sha
+    )
+    if frontend_diagnostics:
+        exit_code = 2
+        exit_diagnostics.extend(frontend_diagnostics)
     if exit_code in {0, 1}:
-        shard_diagnostics = _shard_evidence_diagnostics(
-            plan, shard_rows, exit_code
-        )
+        shard_diagnostics = _shard_evidence_diagnostics(plan, shard_rows, exit_code)
         if shard_diagnostics:
             exit_code = 2
             exit_diagnostics.extend(shard_diagnostics)
@@ -646,7 +699,9 @@ def _write_summary(
         identifiers = result.get(key)
         if isinstance(identifiers, list) and identifiers:
             visible = [str(identifier) for identifier in identifiers[:10]]
-            suffix = f" (+{len(identifiers) - 10} more)" if len(identifiers) > 10 else ""
+            suffix = (
+                f" (+{len(identifiers) - 10} more)" if len(identifiers) > 10 else ""
+            )
             infrastructure_messages.append(
                 f"{label}: {len(identifiers)} ({', '.join(visible)}{suffix})"
             )
@@ -670,9 +725,7 @@ def _write_summary(
     elif has_aggregate_cases:
         not_run_count = aggregate_counts["not_run"]
     elif shard_rows:
-        checkpoint_not_run = sum(
-            int(row["counts"]["not_run"]) for row in shard_rows
-        )
+        checkpoint_not_run = sum(int(row["counts"]["not_run"]) for row in shard_rows)
         not_run_count = f"{checkpoint_not_run} (partial)"
     else:
         not_run_count = "unavailable"
@@ -742,7 +795,9 @@ def _write_summary(
             {
                 "id": case_id,
                 "name": (
-                    case.get("name") if isinstance(case.get("name"), str) else "unavailable"
+                    case.get("name")
+                    if isinstance(case.get("name"), str)
+                    else "unavailable"
                 ),
                 "status": case.get("status", "unavailable"),
                 "shard": shard,
@@ -764,7 +819,16 @@ def _write_summary(
         lines.extend(["### Failed, errored, or not-run cases", ""])
         _append_table(
             lines,
-            ("Case", "Name", "Status", "Shard", "Worker", "Duration", "Message", "Logs"),
+            (
+                "Case",
+                "Name",
+                "Status",
+                "Shard",
+                "Worker",
+                "Duration",
+                "Message",
+                "Logs",
+            ),
             [
                 (
                     case["id"],
@@ -879,19 +943,28 @@ def _write_summary(
                     placement,
                 )
             )
-        _append_table(lines, ("Case", "Name", "Status", "Duration", "Placement"), slow_rows)
+        _append_table(
+            lines, ("Case", "Name", "Status", "Duration", "Placement"), slow_rows
+        )
         lines.append("")
 
     provenance_rows = [
         ("Run ID", run_id),
         ("Phase", state.get("phase", "not-created")),
         ("Exit code", exit_code if exit_code is not None else "unavailable"),
+        ("Authorized FrontEnd repository", FRONTEND_REPOSITORY),
+        ("Authorized FrontEnd ref", frontend_ref),
+        ("Authorized FrontEnd source", frontend_source),
+        ("Authorized FrontEnd SHA", frontend_sha),
         ("Backend SHA", sources.get("backend", "unavailable")),
         ("Frontend SHA", sources.get("frontend", "unavailable")),
         ("AutoTest SHA", sources.get("autotest", "unavailable")),
         ("Build ID", result.get("build_id", plan.get("build_id", "unavailable"))),
         ("Suite digest", _suite_digest(result, plan)),
-        ("Plan digest", result.get("plan_digest", plan.get("plan_digest", "unavailable"))),
+        (
+            "Plan digest",
+            result.get("plan_digest", plan.get("plan_digest", "unavailable")),
+        ),
         ("Image", result.get("image_digest", plan.get("image_digest", "unavailable"))),
         ("Started", result.get("started_at", "unavailable")),
         ("Finished", result.get("finished_at", "unavailable")),
@@ -910,7 +983,9 @@ def _write_summary(
     text = "\n".join(lines) + "\n"
     encoded = text.encode("utf-8")
     if len(encoded) > MAX_SUMMARY_BYTES:
-        suffix = "\n\n_Report truncated; download the JSON artifact for complete details._\n"
+        suffix = (
+            "\n\n_Report truncated; download the JSON artifact for complete details._\n"
+        )
         limit = MAX_SUMMARY_BYTES - len(suffix.encode("utf-8"))
         text = encoded[:limit].decode("utf-8", errors="ignore") + suffix
     destination.write_text(text, encoding="utf-8")
@@ -929,6 +1004,9 @@ def main() -> int:
     parser.add_argument("--routing-sha", type=_full_sha)
     parser.add_argument("--pr-base-sha", type=_full_sha)
     parser.add_argument("--pr-head-sha", type=_full_sha)
+    parser.add_argument("--frontend-ref", type=_frontend_ref, required=True)
+    parser.add_argument("--frontend-sha", type=_full_sha, required=True)
+    parser.add_argument("--frontend-source", choices=FRONTEND_SOURCES, required=True)
     args = parser.parse_args()
     if (args.pr_base_sha is None) != (args.pr_head_sha is None):
         parser.error("PR base and head SHAs must be provided together")
@@ -954,6 +1032,9 @@ def main() -> int:
         routing_sha=args.routing_sha,
         pr_base_sha=args.pr_base_sha,
         pr_head_sha=args.pr_head_sha,
+        frontend_ref=args.frontend_ref,
+        frontend_sha=args.frontend_sha,
+        frontend_source=args.frontend_source,
     )
     include_failure_logs = args.include_logs or summary_exit_code != 0
     if run_root.exists() and not run_root.is_symlink() and run_root.is_dir():
@@ -1023,13 +1104,17 @@ def main() -> int:
         "run_id": args.run_id,
         "run_present": run_root.is_dir() and not run_root.is_symlink(),
         "failure_logs_included": include_failure_logs,
-        "check_exit_code": (
-            summary_exit_code if summary_exit_code in {0, 1, 2} else 2
-        ),
+        "check_exit_code": (summary_exit_code if summary_exit_code in {0, 1, 2} else 2),
         "revision_routing": {
             "routing_sha": args.routing_sha,
             "pr_base_sha": args.pr_base_sha,
             "pr_head_sha": args.pr_head_sha,
+            "frontend": {
+                "repository": FRONTEND_REPOSITORY,
+                "ref": args.frontend_ref,
+                "sha": args.frontend_sha,
+                "source": args.frontend_source,
+            },
         },
         "files": entries,
     }

--- a/.github/ci/test_authorize.py
+++ b/.github/ci/test_authorize.py
@@ -63,7 +63,20 @@ def _resolver(repository: str, ref: str) -> str | None:
         "master",
     }:
         return BACKEND_SHA if ref == "master" else ref
-    if repository == "PKUHPC/CraneSched-FrontEnd" and ref in {"feature/test", "master"}:
+    if repository == "PKUHPC/CraneSched-FrontEnd" and ref in {
+        FRONTEND_SHA,
+        "feature/test",
+        "master",
+    }:
+        return FRONTEND_SHA
+    return None
+
+
+def _branch_resolver(repository: str, branch: str) -> str | None:
+    if repository == "PKUHPC/CraneSched-FrontEnd" and branch in {
+        "feature/test",
+        "master",
+    }:
         return FRONTEND_SHA
     return None
 
@@ -171,6 +184,7 @@ def _authorize(
     commit_parents_resolver=_commit_parents,
     issue_comments_lookup=None,
     issue_comment_lookup=None,
+    branch_resolver=_branch_resolver,
     retry_delays: tuple[float, ...] = (),
 ) -> dict[str, str]:
     resolved_context = context or _context()
@@ -185,6 +199,7 @@ def _authorize(
         commit_parents_resolver,
         issue_comments_lookup,
         issue_comment_lookup,
+        branch_resolver=branch_resolver,
         sleeper=lambda _delay: None,
         retry_delays=retry_delays,
     )
@@ -210,6 +225,8 @@ class AuthorizationPolicyTest(unittest.TestCase):
         self.assertEqual(result["pr_head_sha"], BACKEND_SHA)
         self.assertEqual(result["pr_merge_sha"], MERGE_SHA)
         self.assertEqual(result["frontend_sha"], FRONTEND_SHA)
+        self.assertEqual(result["frontend_ref"], "feature/test")
+        self.assertEqual(result["frontend_source"], "matching_branch")
         self.assertEqual(result["workflow_sha"], WORKFLOW_SHA)
 
     def test_missing_event_merge_sha_uses_verified_current_merge(self) -> None:
@@ -239,9 +256,7 @@ class AuthorizationPolicyTest(unittest.TestCase):
     def test_stale_api_base_does_not_allow_an_untrusted_merge_parent(self) -> None:
         with self.assertRaisesRegex(authorize.AuthorizationError, "parents"):
             _authorize(
-                pull_request_lookup=lambda _repo, _number: _snapshot(
-                    base_sha="e" * 40
-                ),
+                pull_request_lookup=lambda _repo, _number: _snapshot(base_sha="e" * 40),
                 commit_parents_resolver=lambda _repo, _sha: (
                     "e" * 40,
                     BACKEND_SHA,
@@ -265,6 +280,7 @@ class AuthorizationPolicyTest(unittest.TestCase):
             lambda _repo, _number: next(snapshots),
             _merge_ref,
             _commit_parents,
+            branch_resolver=_branch_resolver,
             sleeper=delays.append,
             retry_delays=(0.25,),
         )
@@ -340,9 +356,7 @@ class AuthorizationPolicyTest(unittest.TestCase):
     def test_second_snapshot_allows_api_base_hint_to_change(self) -> None:
         snapshots = iter([_snapshot(), _snapshot(base_sha="e" * 40)])
 
-        result = _authorize(
-            pull_request_lookup=lambda _repo, _number: next(snapshots)
-        )
+        result = _authorize(pull_request_lookup=lambda _repo, _number: next(snapshots))
 
         self.assertEqual(result["pr_base_sha"], WORKFLOW_SHA)
         self.assertEqual(result["routing_sha"], MERGE_SHA)
@@ -357,8 +371,14 @@ class AuthorizationPolicyTest(unittest.TestCase):
         self.assertEqual(result["routing_sha"], MERGE_SHA)
 
     def test_initial_fork_run_requests_comment_before_permission_lookup(self) -> None:
+        branch_lookups: list[tuple[str, str]] = []
+
         def unexpected_permission(_repo, _actor):
             self.fail("permission lookup must not run for an initial fork attempt")
+
+        def unexpected_branch(repository: str, branch: str) -> str | None:
+            branch_lookups.append((repository, branch))
+            return FRONTEND_SHA
 
         with self.assertRaisesRegex(authorize.AuthorizationError, "/request-ci"):
             authorize.authorize_dispatch(
@@ -368,7 +388,10 @@ class AuthorizationPolicyTest(unittest.TestCase):
                 _pull_request,
                 _merge_ref,
                 _commit_parents,
+                branch_resolver=unexpected_branch,
             )
+
+        self.assertEqual(branch_lookups, [])
 
     def test_fork_rerun_without_attestation_is_rejected(self) -> None:
         with self.assertRaisesRegex(authorize.AuthorizationError, "no valid"):
@@ -407,14 +430,13 @@ class AuthorizationPolicyTest(unittest.TestCase):
             pull_request_lookup=_fork_pull_request,
             commit_parents_resolver=_fork_commit_parents,
             issue_comments_lookup=lambda _repo, _number: (_attestation_comment(),),
-            issue_comment_lookup=lambda _repo, _number, _comment_id: (
-                _request_comment()
-            ),
+            issue_comment_lookup=lambda _repo, _number, _comment_id: _request_comment(),
         )
 
         self.assertEqual(result["backend_sha"], FORK_HEAD_SHA)
         self.assertEqual(result["routing_sha"], MERGE_SHA)
         self.assertEqual(result["pr_head_sha"], FORK_HEAD_SHA)
+        self.assertEqual(result["frontend_source"], "matching_branch")
 
     def test_maintainer_request_allows_a_different_maintainer_to_rerun(self) -> None:
         result = _authorize(
@@ -424,8 +446,8 @@ class AuthorizationPolicyTest(unittest.TestCase):
             pull_request_lookup=_fork_pull_request,
             commit_parents_resolver=_fork_commit_parents,
             issue_comments_lookup=lambda _repo, _number: (_attestation_comment(),),
-            issue_comment_lookup=lambda _repo, _number, _comment_id: (
-                _request_comment(author_login="request-maintainer")
+            issue_comment_lookup=lambda _repo, _number, _comment_id: _request_comment(
+                author_login="request-maintainer"
             ),
         )
 
@@ -551,7 +573,7 @@ class AuthorizationPolicyTest(unittest.TestCase):
         def resolver(repository: str, ref: str) -> str | None:
             if repository == "PKUHPC/CraneSched" and ref == WORKFLOW_SHA:
                 return WORKFLOW_SHA
-            if repository == "PKUHPC/CraneSched-FrontEnd" and ref == "master":
+            if repository == "PKUHPC/CraneSched-FrontEnd" and ref == FRONTEND_SHA:
                 return FRONTEND_SHA
             return None
 
@@ -561,10 +583,13 @@ class AuthorizationPolicyTest(unittest.TestCase):
                     _context(event_name=event_name, event_sha=WORKFLOW_SHA),
                     unexpected_permission,
                     resolver,
+                    branch_resolver=_branch_resolver,
                 )
                 self.assertEqual(result["backend_sha"], WORKFLOW_SHA)
                 self.assertEqual(result["routing_sha"], WORKFLOW_SHA)
                 self.assertEqual(result["pr_base_sha"], "")
+                self.assertEqual(result["frontend_ref"], "master")
+                self.assertEqual(result["frontend_source"], "master_default")
                 self.assertEqual(result["workflow_sha"], WORKFLOW_SHA)
 
     def test_non_default_workflow_ref_is_rejected(self) -> None:
@@ -590,6 +615,19 @@ class AuthorizationPolicyTest(unittest.TestCase):
                 _resolver,
             )
 
+    def test_manual_dispatch_keeps_explicit_commitish_resolution(self) -> None:
+        result = _authorize(
+            _context(
+                event_name="workflow_dispatch",
+                manual_backend_ref="master",
+                manual_frontend_ref="feature/test",
+            )
+        )
+
+        self.assertEqual(result["frontend_ref"], "feature/test")
+        self.assertEqual(result["frontend_sha"], FRONTEND_SHA)
+        self.assertEqual(result["frontend_source"], "manual_ref")
+
     def test_missing_matching_frontend_branch_falls_back_to_master(self) -> None:
         def resolver(repository: str, ref: str) -> str | None:
             if repository == "PKUHPC/CraneSched" and ref in {
@@ -597,7 +635,12 @@ class AuthorizationPolicyTest(unittest.TestCase):
                 MERGE_SHA,
             }:
                 return ref
-            if repository == "PKUHPC/CraneSched-FrontEnd" and ref == "master":
+            if repository == "PKUHPC/CraneSched-FrontEnd" and ref == FRONTEND_SHA:
+                return FRONTEND_SHA
+            return None
+
+        def branch_resolver(repository: str, branch: str) -> str | None:
+            if repository == "PKUHPC/CraneSched-FrontEnd" and branch == "master":
                 return FRONTEND_SHA
             return None
 
@@ -605,12 +648,101 @@ class AuthorizationPolicyTest(unittest.TestCase):
             _context(pr_head_ref="backend-only-branch"),
             permission="admin",
             resolver=resolver,
+            branch_resolver=branch_resolver,
             pull_request_lookup=lambda _repo, _number: _snapshot(
                 head_ref="backend-only-branch"
             ),
         )
         self.assertEqual(result["frontend_ref"], "master")
         self.assertEqual(result["frontend_sha"], FRONTEND_SHA)
+        self.assertEqual(result["frontend_source"], "master_fallback")
+
+    def test_same_name_tag_does_not_count_as_a_matching_branch(self) -> None:
+        commit_queries: list[tuple[str, str]] = []
+
+        def resolver(repository: str, ref: str) -> str | None:
+            commit_queries.append((repository, ref))
+            if repository == "PKUHPC/CraneSched" and ref in {
+                BACKEND_SHA,
+                MERGE_SHA,
+            }:
+                return ref
+            if repository == "PKUHPC/CraneSched-FrontEnd" and ref in {
+                "tag-only",
+                FRONTEND_SHA,
+            }:
+                return FRONTEND_SHA
+            return None
+
+        result = _authorize(
+            _context(pr_head_ref="tag-only"),
+            resolver=resolver,
+            branch_resolver=lambda _repository, branch: (
+                FRONTEND_SHA if branch == "master" else None
+            ),
+            pull_request_lookup=lambda _repo, _number: _snapshot(head_ref="tag-only"),
+        )
+
+        self.assertEqual(result["frontend_ref"], "master")
+        self.assertEqual(result["frontend_source"], "master_fallback")
+        self.assertNotIn(("PKUHPC/CraneSched-FrontEnd", "tag-only"), commit_queries)
+
+    def test_slash_branch_is_matched_exactly(self) -> None:
+        result = _authorize(
+            _context(pr_head_ref="feature/nested/test"),
+            branch_resolver=lambda repository, branch: (
+                FRONTEND_SHA
+                if repository == "PKUHPC/CraneSched-FrontEnd"
+                and branch in {"feature/nested/test", "master"}
+                else None
+            ),
+            pull_request_lookup=lambda _repo, _number: _snapshot(
+                head_ref="feature/nested/test"
+            ),
+        )
+
+        self.assertEqual(result["frontend_ref"], "feature/nested/test")
+        self.assertEqual(result["frontend_source"], "matching_branch")
+
+    def test_missing_frontend_master_fails_closed(self) -> None:
+        with self.assertRaisesRegex(authorize.AuthorizationError, "FrontEnd branch"):
+            _authorize(
+                _context(pr_head_ref="missing"),
+                branch_resolver=lambda _repository, _branch: None,
+                pull_request_lookup=lambda _repo, _number: _snapshot(
+                    head_ref="missing"
+                ),
+            )
+
+    def test_frontend_sha_must_still_resolve_as_a_commit(self) -> None:
+        def resolver(repository: str, ref: str) -> str | None:
+            if repository == "PKUHPC/CraneSched" and ref in {
+                BACKEND_SHA,
+                MERGE_SHA,
+            }:
+                return ref
+            return None
+
+        with self.assertRaisesRegex(authorize.AuthorizationError, "FrontEnd ref"):
+            _authorize(resolver=resolver)
+
+    def test_frontend_commit_verification_must_match_selected_sha(self) -> None:
+        different_sha = "f" * 40
+
+        def resolver(repository: str, ref: str) -> str | None:
+            if repository == "PKUHPC/CraneSched" and ref in {
+                BACKEND_SHA,
+                MERGE_SHA,
+            }:
+                return ref
+            if repository == "PKUHPC/CraneSched-FrontEnd" and ref == FRONTEND_SHA:
+                return different_sha
+            return None
+
+        with self.assertRaisesRegex(
+            authorize.AuthorizationError, "verification failed"
+        ):
+            _authorize(resolver=resolver)
 
 
 class GitHubApiTest(unittest.TestCase):
@@ -636,6 +768,88 @@ class GitHubApiTest(unittest.TestCase):
                 ),
             ):
                 self.assertIsNone(api.commit("PKUHPC/CraneSched", "missing/ref"))
+
+    def test_branch_head_uses_exact_encoded_heads_ref(self) -> None:
+        api = authorize.GitHubApi("test-token")
+        response = {
+            "ref": "refs/heads/feature/nested/test",
+            "object": {"type": "commit", "sha": FRONTEND_SHA},
+        }
+
+        with mock.patch.object(api, "_get", return_value=response) as get:
+            revision = api.branch_head(
+                "PKUHPC/CraneSched-FrontEnd", "feature/nested/test"
+            )
+
+        self.assertEqual(revision, FRONTEND_SHA)
+        self.assertEqual(
+            get.call_args.args[0],
+            "repos/PKUHPC/CraneSched-FrontEnd/git/ref/heads/feature%2Fnested%2Ftest",
+        )
+        self.assertEqual(get.call_args.kwargs["missing_statuses"], frozenset({404}))
+
+    def test_only_branch_404_is_treated_as_missing(self) -> None:
+        api = authorize.GitHubApi("test-token")
+        with mock.patch.object(
+            authorize.urllib.request,
+            "urlopen",
+            side_effect=self._http_error(404),
+        ):
+            self.assertIsNone(api.branch_head("PKUHPC/CraneSched-FrontEnd", "missing"))
+
+        for status in (403, 422, 429, 500):
+            with (
+                self.subTest(status=status),
+                mock.patch.object(
+                    authorize.urllib.request,
+                    "urlopen",
+                    side_effect=self._http_error(status),
+                ),
+                self.assertRaisesRegex(authorize.AuthorizationError, f"HTTP {status}"),
+            ):
+                api.branch_head("PKUHPC/CraneSched-FrontEnd", "missing")
+
+    def test_branch_timeout_fails_closed(self) -> None:
+        api = authorize.GitHubApi("test-token")
+        with (
+            mock.patch.object(
+                authorize.urllib.request,
+                "urlopen",
+                side_effect=TimeoutError,
+            ),
+            self.assertRaisesRegex(authorize.AuthorizationError, "request failed"),
+        ):
+            api.branch_head("PKUHPC/CraneSched-FrontEnd", "feature/test")
+
+    def test_branch_response_must_be_an_exact_commit_ref(self) -> None:
+        api = authorize.GitHubApi("test-token")
+        malformed = (
+            {
+                "ref": "refs/heads/Feature/Test",
+                "object": {"type": "commit", "sha": FRONTEND_SHA},
+            },
+            {
+                "ref": "refs/tags/feature/test",
+                "object": {"type": "commit", "sha": FRONTEND_SHA},
+            },
+            {
+                "ref": "refs/heads/feature/test",
+                "object": {"type": "tag", "sha": FRONTEND_SHA},
+            },
+            {
+                "ref": "refs/heads/feature/test",
+                "object": {"type": "commit", "sha": "short"},
+            },
+            {"ref": "refs/heads/feature/test", "object": "invalid"},
+        )
+
+        for response in malformed:
+            with (
+                self.subTest(response=response),
+                mock.patch.object(api, "_get", return_value=response),
+                self.assertRaisesRegex(authorize.AuthorizationError, "malformed"),
+            ):
+                api.branch_head("PKUHPC/CraneSched-FrontEnd", "feature/test")
 
     def test_permission_lookup_keeps_422_fail_closed(self) -> None:
         api = authorize.GitHubApi("test-token")

--- a/.github/ci/test_collect_cranetestkit_artifacts.py
+++ b/.github/ci/test_collect_cranetestkit_artifacts.py
@@ -12,7 +12,9 @@ from unittest import mock
 
 
 SCRIPT = Path(__file__).with_name("collect-cranetestkit-artifacts.py")
-SPEC = importlib.util.spec_from_file_location("cranesched_ci_artifact_collection", SCRIPT)
+SPEC = importlib.util.spec_from_file_location(
+    "cranesched_ci_artifact_collection", SCRIPT
+)
 assert SPEC is not None and SPEC.loader is not None
 collection = importlib.util.module_from_spec(SPEC)
 sys.modules[SPEC.name] = collection
@@ -32,6 +34,9 @@ class ArtifactCollectionTest(unittest.TestCase):
         routing_sha: str | None = None,
         pr_base_sha: str | None = None,
         pr_head_sha: str | None = None,
+        frontend_ref: str = "master",
+        frontend_sha: str = "b" * 40,
+        frontend_source: str = "master_default",
     ) -> None:
         command = [
             sys.executable,
@@ -42,6 +47,12 @@ class ArtifactCollectionTest(unittest.TestCase):
             str(destination),
             "--run-id",
             "gh-123-1",
+            "--frontend-ref",
+            frontend_ref,
+            "--frontend-sha",
+            frontend_sha,
+            "--frontend-source",
+            frontend_source,
         ]
         if logs:
             command.append("--include-logs")
@@ -204,10 +215,7 @@ class ArtifactCollectionTest(unittest.TestCase):
                 ),
                 encoding="utf-8",
             )
-            private_key = (
-                "private_key=-----BEGIN PRIVATE KEY-----\n"
-                + "A" * 5000
-            )
+            private_key = "private_key=-----BEGIN PRIVATE KEY-----\n" + "A" * 5000
             (run_root / "state.json").write_text(
                 json.dumps(
                     {
@@ -284,7 +292,9 @@ class ArtifactCollectionTest(unittest.TestCase):
         with tempfile.TemporaryDirectory() as temporary:
             root = Path(temporary)
             cases = [
-                self._case(f"1.0.0.{index}", "passed", float(index), name=f"slow-{index}")
+                self._case(
+                    f"1.0.0.{index}", "passed", float(index), name=f"slow-{index}"
+                )
                 for index in range(1, 12)
             ]
             run_root = self._run(
@@ -294,8 +304,12 @@ class ArtifactCollectionTest(unittest.TestCase):
                 shards=[cases[:6], cases[6:]],
                 workers={"wrl02": [0, 1]},
             )
-            self._checkpoint(run_root, "wrl02", 0, 0, cases[:6], exit_code=0, duration=30)
-            self._checkpoint(run_root, "wrl02", 1, 1, cases[6:], exit_code=0, duration=40)
+            self._checkpoint(
+                run_root, "wrl02", 0, 0, cases[:6], exit_code=0, duration=30
+            )
+            self._checkpoint(
+                run_root, "wrl02", 1, 1, cases[6:], exit_code=0, duration=40
+            )
 
             destination = root / "artifact"
             self._collect(
@@ -344,12 +358,18 @@ class ArtifactCollectionTest(unittest.TestCase):
                 routing_sha=routing_sha,
                 pr_base_sha=base_sha,
                 pr_head_sha=head_sha,
+                frontend_ref="feature/test|<unsafe>`branch",
+                frontend_source="matching_branch",
             )
 
             summary = (destination / "summary.md").read_text(encoding="utf-8")
             self.assertIn(f"`{routing_sha}`", summary)
             self.assertIn(f"`{base_sha}`", summary)
             self.assertIn(f"`{head_sha}`", summary)
+            self.assertIn("PKUHPC/CraneSched-FrontEnd", summary)
+            self.assertIn("matching_branch", summary)
+            self.assertIn("feature/test\\|&lt;unsafe&gt;&#96;branch", summary)
+            self.assertNotIn("<unsafe>", summary)
             manifest = json.loads(
                 (destination / "artifact-manifest.json").read_text(encoding="utf-8")
             )
@@ -359,8 +379,74 @@ class ArtifactCollectionTest(unittest.TestCase):
                     "routing_sha": routing_sha,
                     "pr_base_sha": base_sha,
                     "pr_head_sha": head_sha,
+                    "frontend": {
+                        "repository": "PKUHPC/CraneSched-FrontEnd",
+                        "ref": "feature/test|<unsafe>`branch",
+                        "sha": "b" * 40,
+                        "source": "matching_branch",
+                    },
                 },
             )
+
+    def test_frontend_revision_mismatch_is_infrastructure_error(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary:
+            root = Path(temporary)
+            cases = [self._case("1.0.0.1", "passed", 1.0)]
+            run_root = self._run(
+                root,
+                cases,
+                exit_code=0,
+                shards=[cases],
+                workers={"wrl02": [0]},
+            )
+            self._checkpoint(run_root, "wrl02", 0, 0, cases, exit_code=0)
+            result = json.loads((run_root / "result.json").read_text(encoding="utf-8"))
+            result["sources"]["frontend"] = "c" * 40
+            self._write_json(run_root / "result.json", result)
+
+            destination = root / "artifact"
+            self._collect(run_root, destination, execute_exit_code=0)
+
+            summary = (destination / "summary.md").read_text(encoding="utf-8")
+            manifest = json.loads(
+                (destination / "artifact-manifest.json").read_text(encoding="utf-8")
+            )
+            self.assertIn("system test: INFRASTRUCTURE ERROR", summary)
+            self.assertIn("does not match authorized SHA", summary)
+            self.assertEqual(manifest["check_exit_code"], 2)
+
+    def test_missing_frontend_revision_in_generated_plan_is_infrastructure_error(
+        self,
+    ) -> None:
+        with tempfile.TemporaryDirectory() as temporary:
+            root = Path(temporary)
+            run_root = root / "runs/gh-123-1"
+            self._write_json(run_root / "plan/manifest.json", {"sharding": {}})
+
+            destination = root / "artifact"
+            self._collect(run_root, destination)
+
+            summary = (destination / "summary.md").read_text(encoding="utf-8")
+            manifest = json.loads(
+                (destination / "artifact-manifest.json").read_text(encoding="utf-8")
+            )
+            self.assertIn("Plan FrontEnd SHA is missing", summary)
+            self.assertEqual(manifest["check_exit_code"], 2)
+
+    def test_preflight_failure_without_plan_or_result_has_no_source_mismatch(
+        self,
+    ) -> None:
+        with tempfile.TemporaryDirectory() as temporary:
+            root = Path(temporary)
+            run_root = root / "runs/gh-123-1"
+            run_root.mkdir(parents=True)
+
+            destination = root / "artifact"
+            self._collect(run_root, destination)
+
+            summary = (destination / "summary.md").read_text(encoding="utf-8")
+            self.assertNotIn("FrontEnd SHA is missing", summary)
+            self.assertNotIn("does not match authorized SHA", summary)
 
     def test_exit_one_summary_reports_failed_and_error_cases(self) -> None:
         with tempfile.TemporaryDirectory() as temporary:
@@ -418,10 +504,7 @@ class ArtifactCollectionTest(unittest.TestCase):
                 workers={"wrl04": [0]},
                 infrastructure_errors=[
                     "<script>Authorization: Bearer secret-token</script>",
-                    (
-                        "shard 0 fatal during teardown: "
-                        "password=hunter2"
-                    ),
+                    ("shard 0 fatal during teardown: password=hunter2"),
                 ],
                 missing_case_ids=["1.0.0.2"],
             )
@@ -495,8 +578,7 @@ class ArtifactCollectionTest(unittest.TestCase):
         with tempfile.TemporaryDirectory() as temporary:
             root = Path(temporary)
             cases = [
-                self._case(f"3.0.0.{index}", "not_run", 0.0)
-                for index in range(1, 26)
+                self._case(f"3.0.0.{index}", "not_run", 0.0) for index in range(1, 26)
             ]
             infrastructure = [
                 (
@@ -543,12 +625,13 @@ class ArtifactCollectionTest(unittest.TestCase):
             self._write_json(
                 run_root / "plan/manifest.json",
                 {
+                    "sources": {"frontend": "b" * 40},
                     "sharding": {
                         "shards": [
                             {"index": 0, "cases": []},
                             {"index": 1, "cases": []},
                         ]
-                    }
+                    },
                 },
             )
             self._write_json(
@@ -626,9 +709,7 @@ class ArtifactCollectionTest(unittest.TestCase):
 
                     destination = root / "artifact"
                     self._collect(run_root, destination, execute_exit_code=0)
-                    summary = (destination / "summary.md").read_text(
-                        encoding="utf-8"
-                    )
+                    summary = (destination / "summary.md").read_text(encoding="utf-8")
                     manifest = json.loads(
                         (destination / "artifact-manifest.json").read_text(
                             encoding="utf-8"
@@ -678,12 +759,8 @@ class ArtifactCollectionTest(unittest.TestCase):
                 shards=[[failed_case], [not_run_case]],
                 workers={"wrl02": [0, 1]},
             )
-            self._checkpoint(
-                run_root, "wrl02", 0, 0, [failed_case], exit_code=1
-            )
-            self._checkpoint(
-                run_root, "wrl02", 1, 1, [not_run_case], exit_code=0
-            )
+            self._checkpoint(run_root, "wrl02", 0, 0, [failed_case], exit_code=1)
+            self._checkpoint(run_root, "wrl02", 1, 1, [not_run_case], exit_code=0)
 
             destination = root / "artifact"
             self._collect(run_root, destination, execute_exit_code=1)
@@ -728,6 +805,7 @@ class ArtifactCollectionTest(unittest.TestCase):
             self._write_json(
                 run_root / "plan/manifest.json",
                 {
+                    "sources": {"frontend": "b" * 40},
                     "suite": {"digest": "suite-primary"},
                     "sharding": {
                         "suite_digest": "suite-secondary",
@@ -745,7 +823,13 @@ class ArtifactCollectionTest(unittest.TestCase):
 
             self._write_json(
                 run_root / "plan/manifest.json",
-                {"sharding": {"suite_digest": "suite-secondary", "shards": []}},
+                {
+                    "sources": {"frontend": "b" * 40},
+                    "sharding": {
+                        "suite_digest": "suite-secondary",
+                        "shards": [],
+                    },
+                },
             )
             fallback_destination = root / "fallback-artifact"
             self._collect(run_root, fallback_destination)
@@ -809,6 +893,7 @@ class ArtifactCollectionTest(unittest.TestCase):
             self._write_json(
                 run_root / "plan/manifest.json",
                 {
+                    "sources": {"frontend": "b" * 40},
                     "sharding": {
                         "shards": [
                             {
@@ -817,7 +902,7 @@ class ArtifactCollectionTest(unittest.TestCase):
                                 "cases": [],
                             }
                         ]
-                    }
+                    },
                 },
             )
 
@@ -835,7 +920,9 @@ class ArtifactCollectionTest(unittest.TestCase):
             linked_run.symlink_to(run_root, target_is_directory=True)
             linked_destination = root / "linked-artifact"
             self._collect(linked_run, linked_destination)
-            linked_summary = (linked_destination / "summary.md").read_text(encoding="utf-8")
+            linked_summary = (linked_destination / "summary.md").read_text(
+                encoding="utf-8"
+            )
             self.assertNotIn("outside-secret", linked_summary)
             self.assertIn("system test: INCOMPLETE", linked_summary)
 
@@ -860,6 +947,12 @@ class ArtifactCollectionTest(unittest.TestCase):
                     str(destination),
                     "--run-id",
                     "gh-123-1",
+                    "--frontend-ref",
+                    "master",
+                    "--frontend-sha",
+                    "b" * 40,
+                    "--frontend-source",
+                    "master_default",
                 ],
                 check=False,
                 capture_output=True,

--- a/.github/ci/test_validate_workflow_routing.py
+++ b/.github/ci/test_validate_workflow_routing.py
@@ -206,6 +206,43 @@ class WorkflowRoutingPolicyTest(unittest.TestCase):
             workflow,
         )
 
+    def test_frontend_routing_is_sha_pinned_and_fully_reported(self) -> None:
+        workflow = WORKFLOW_PATH.read_text(encoding="utf-8")
+        self.assertIn(
+            "frontend_source: ${{ steps.authorize.outputs.frontend_source }}",
+            workflow,
+        )
+        self.assertIn(
+            "FRONTEND_SOURCE: ${{ needs.authorize.outputs.frontend_source }}",
+            workflow,
+        )
+
+        checkout = workflow.index("- name: Checkout exact FrontEnd revision")
+        checkout_end = workflow.find("\n      - name:", checkout + 1)
+        checkout_block = workflow[checkout:checkout_end]
+        self.assertIn(
+            "ref: ${{ needs.authorize.outputs.frontend_sha }}", checkout_block
+        )
+        self.assertNotIn("frontend_ref", checkout_block)
+
+        collect = workflow.index("- name: Collect sanitized CI artifacts")
+        collect_end = workflow.find("\n      - name:", collect + 1)
+        collect_block = workflow[collect:collect_end]
+        self.assertIn('--frontend-ref "$FRONTEND_REF"', collect_block)
+        self.assertIn('--frontend-sha "$FRONTEND_SHA"', collect_block)
+        self.assertIn('--frontend-source "$FRONTEND_SOURCE"', collect_block)
+
+    def test_revision_summary_escapes_frontend_routing_as_json_and_html(self) -> None:
+        workflow = WORKFLOW_PATH.read_text(encoding="utf-8")
+        start = workflow.index("- name: Record revision routing provenance")
+        end = workflow.find("\n      - name:", start + 1)
+        block = workflow[start:end]
+        self.assertIn("json.dumps(", block)
+        self.assertIn("html.escape(", block)
+        self.assertIn('os.environ["FRONTEND_REF"]', block)
+        self.assertIn('os.environ["FRONTEND_SOURCE"]', block)
+        self.assertNotIn('echo "- FrontEnd', block)
+
     def test_authorization_receives_actions_run_identity(self) -> None:
         workflow = WORKFLOW_PATH.read_text(encoding="utf-8")
         self.assertIn("GITHUB_RUN_ID: ${{ github.run_id }}", workflow)

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -69,6 +69,7 @@ jobs:
       pr_merge_sha: ${{ steps.authorize.outputs.pr_merge_sha }}
       frontend_ref: ${{ steps.authorize.outputs.frontend_ref }}
       frontend_sha: ${{ steps.authorize.outputs.frontend_sha }}
+      frontend_source: ${{ steps.authorize.outputs.frontend_source }}
       workflow_sha: ${{ steps.authorize.outputs.workflow_sha }}
     steps:
       - name: Checkout trusted authorization policy
@@ -173,6 +174,7 @@ jobs:
       PR_MERGE_SHA: ${{ needs.authorize.outputs.pr_merge_sha }}
       FRONTEND_SHA: ${{ needs.authorize.outputs.frontend_sha }}
       FRONTEND_REF: ${{ needs.authorize.outputs.frontend_ref }}
+      FRONTEND_SOURCE: ${{ needs.authorize.outputs.frontend_source }}
     defaults:
       run:
         shell: bash
@@ -200,17 +202,52 @@ jobs:
 
       - name: Record revision routing provenance
         run: |
-          {
-            echo "### CI revision routing"
-            echo "- Backend test SHA: \`$BACKEND_SHA\`"
-            if [[ -n "$PR_HEAD_SHA" ]]; then
-              echo "- PR base SHA: \`$PR_BASE_SHA\`"
-              echo "- PR head SHA: \`$PR_HEAD_SHA\`"
-              echo "- Proposed merge routing SHA: \`$ROUTING_SHA\`"
-            else
-              echo "- Workflow routing SHA: \`$ROUTING_SHA\`"
-            fi
-          } >> "$GITHUB_STEP_SUMMARY"
+          /usr/bin/python3 - "$GITHUB_STEP_SUMMARY" <<'PY'
+          import html
+          import json
+          import os
+          import sys
+
+          def code(value: str) -> str:
+              encoded = json.dumps(value, ensure_ascii=True)
+              return html.escape(encoded, quote=True).replace("`", "&#96;")
+
+          lines = [
+              "### CI revision routing",
+              f"- Backend test SHA: <code>{code(os.environ['BACKEND_SHA'])}</code>",
+          ]
+          if os.environ["PR_HEAD_SHA"]:
+              lines.extend(
+                  [
+                      f"- PR base SHA: <code>{code(os.environ['PR_BASE_SHA'])}</code>",
+                      f"- PR head SHA: <code>{code(os.environ['PR_HEAD_SHA'])}</code>",
+                      "- Proposed merge routing SHA: "
+                      f"<code>{code(os.environ['ROUTING_SHA'])}</code>",
+                  ]
+              )
+          else:
+              lines.append(
+                  "- Workflow routing SHA: "
+                  f"<code>{code(os.environ['ROUTING_SHA'])}</code>"
+              )
+          frontend = json.dumps(
+              {
+                  "repository": "PKUHPC/CraneSched-FrontEnd",
+                  "ref": os.environ["FRONTEND_REF"],
+                  "sha": os.environ["FRONTEND_SHA"],
+                  "source": os.environ["FRONTEND_SOURCE"],
+              },
+              ensure_ascii=True,
+              sort_keys=True,
+          )
+          lines.append(
+              "- FrontEnd: <code>"
+              + html.escape(frontend, quote=True).replace("`", "&#96;")
+              + "</code>"
+          )
+          with open(sys.argv[1], "a", encoding="utf-8") as summary:
+              summary.write("\n".join(lines) + "\n")
+          PY
 
       - name: Validate deployment variables
         env:
@@ -444,6 +481,11 @@ jobs:
             arguments+=(--build-duration-seconds "$BUILD_DURATION_SECONDS")
           fi
           arguments+=(--routing-sha "$ROUTING_SHA")
+          arguments+=(
+            --frontend-ref "$FRONTEND_REF"
+            --frontend-sha "$FRONTEND_SHA"
+            --frontend-source "$FRONTEND_SOURCE"
+          )
           if [[ -n "$PR_HEAD_SHA" ]]; then
             arguments+=(--pr-base-sha "$PR_BASE_SHA" --pr-head-sha "$PR_HEAD_SHA")
           fi

--- a/src/CraneCtld/JobScheduler.cpp
+++ b/src/CraneCtld/JobScheduler.cpp
@@ -8326,8 +8326,7 @@ CraneExpectedRich<void> JobScheduler::AcquireJobAttributes(JobInCtld* job) {
           "--mem or increase the task or CPU count",
           util::ReadableMemory(job->JobToCtld().mem_per_node()),
           job->JobToCtld().ntasks_per_node(),
-          job->req_task_res_view.CpuCountDouble(),
-          job->partition_id));
+          job->req_task_res_view.CpuCountDouble(), job->partition_id));
     }
     if (job->JobToCtld().has_mem_per_cpu()) {
       return std::unexpected(FormatRichErr(
@@ -8337,16 +8336,14 @@ CraneExpectedRich<void> JobScheduler::AcquireJobAttributes(JobInCtld* job) {
           "--mem-per-cpu or adjust the task or CPU count",
           util::ReadableMemory(job->JobToCtld().mem_per_cpu()),
           job->JobToCtld().ntasks_per_node(),
-          job->req_task_res_view.CpuCountDouble(),
-          job->partition_id));
+          job->req_task_res_view.CpuCountDouble(), job->partition_id));
     }
     return std::unexpected(FormatRichErr(
         CraneErrCode::ERR_INVALID_PARAM,
         "--ntasks-per-node={} and --cpus-per-task={} cannot satisfy the "
         "default memory limits of partition '{}'; adjust the task or CPU count",
         job->JobToCtld().ntasks_per_node(),
-        job->req_task_res_view.CpuCountDouble(),
-        job->partition_id));
+        job->req_task_res_view.CpuCountDouble(), job->partition_id));
   }
 
   CRANE_TRACE(


### PR DESCRIPTION
## Summary

- resolve Backend PR FrontEnd revisions through the exact GitHub branch-ref API
- fall back to FrontEnd `master` only when the same-name branch returns HTTP 404
- lock every selected FrontEnd revision to a verified full SHA and expose its routing source
- preserve FrontEnd routing provenance in summaries and artifacts, with plan/result mismatch mapped to infrastructure exit code 2

## Security and behavior

- unapproved fork runs still stop before any FrontEnd lookup
- approved forks query only `PKUHPC/CraneSched-FrontEnd`, never a FrontEnd fork
- tags and other commit-ish values cannot satisfy automatic same-name matching
- FrontEnd API errors, malformed responses, missing master, and SHA verification drift fail closed
- the self-hosted job continues to checkout only the authorized FrontEnd SHA

## Validation

- `python3 -m unittest discover -s .github/ci -p 'test_*.py'` (155 tests)
- Ruff format check and Python error-rule check
- actionlint v1.7.7
- workflow YAML parse
- repository runner routing guard
- `git diff --check`

## Post-merge canary

The two production K3s canary runs require this trusted workflow to be present on `master`:

1. create matching temporary Backend and FrontEnd branches and verify `matching_branch`
2. delete the FrontEnd branch, rerun the same Backend head, and verify `master_fallback`

Both runs must retain complete coverage with exit code 0 before the temporary Backend PR and branches are removed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * FrontEnd branch routing now supports matching pull-request branches with controlled fallback to `master`.
  * Builds record the selected FrontEnd repository, branch, source, and verified commit.
  * Workflow summaries and artifacts include escaped, validated revision provenance.

* **Bug Fixes**
  * Invalid, missing, or mismatched FrontEnd revisions now fail validation.
  * Artifact collection reports infrastructure failures for inconsistent revision metadata.

* **Tests**
  * Added coverage for branch selection, SHA verification, routing provenance, and artifact validation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->