### PR TITLE
fix: revert cqueue msg

### DIFF
--- a/docs/en/command/cqueue.md
+++ b/docs/en/command/cqueue.md
@@ -297,7 +297,7 @@ Flags:
   -j, --job string            Specify job ids to view (comma separated list, supports jobid or jobid_arraytaskid), default is all
       --json                  Output in JSON format
   -L, --licenses string       Specify licenses to view (comma separated list), default is all licenses
-  -m, --max-lines uint32      Limit the number of jobs returned (default 20)
+  -m, --max-lines uint32      Limit the number of lines in the output, 0 means no limit (default 1000)
   -n, --name string           Specify job names to view (comma separated list), default is all
   -w, --nodelist string       Specify node names to view (comma separated list or patterns like node[1-10]), default is all
   -N, --noheader              Do not print header line in the output

--- a/docs/en/command/cqueue.md
+++ b/docs/en/command/cqueue.md
@@ -297,7 +297,7 @@ Flags:
   -j, --job string            Specify job ids to view (comma separated list, supports jobid or jobid_arraytaskid), default is all
       --json                  Output in JSON format
   -L, --licenses string       Specify licenses to view (comma separated list), default is all licenses
-  -m, --max-lines uint32      Limit the number of lines in the output, 0 means no limit (default 1000)
+  -m, --max-lines uint32      Limit the number of lines in the output, 0 means no limit (default 10000)
   -n, --name string           Specify job names to view (comma separated list), default is all
   -w, --nodelist string       Specify node names to view (comma separated list or patterns like node[1-10]), default is all
   -N, --noheader              Do not print header line in the output

--- a/docs/zh/command/cqueue.md
+++ b/docs/zh/command/cqueue.md
@@ -285,7 +285,7 @@ Flags:
   -j, --job string            Specify job ids to view (comma separated list, supports jobid or jobid_arraytaskid), default is all
       --json                  Output in JSON format
   -L, --licenses string       Specify licenses to view (comma separated list), default is all licenses
-  -m, --max-lines uint32      Limit the number of jobs returned (default 20)
+  -m, --max-lines uint32      Limit the number of lines in the output, 0 means no limit (default 1000)
   -n, --name string           Specify job names to view (comma separated list), default is all
   -w, --nodelist string       Specify node names to view (comma separated list or patterns like node[1-10]), default is all
   -N, --noheader              Do not print header line in the output

--- a/docs/zh/command/cqueue.md
+++ b/docs/zh/command/cqueue.md
@@ -285,7 +285,7 @@ Flags:
   -j, --job string            Specify job ids to view (comma separated list, supports jobid or jobid_arraytaskid), default is all
       --json                  Output in JSON format
   -L, --licenses string       Specify licenses to view (comma separated list), default is all licenses
-  -m, --max-lines uint32      Limit the number of lines in the output, 0 means no limit (default 1000)
+  -m, --max-lines uint32      Limit the number of lines in the output, 0 means no limit (default 10000)
   -n, --name string           Specify job names to view (comma separated list), default is all
   -w, --nodelist string       Specify node names to view (comma separated list or patterns like node[1-10]), default is all
   -N, --noheader              Do not print header line in the output


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated `cqueue --max-lines` help text to clarify that it limits total output lines.
  * Documented that `0` means unlimited output and the default is 10,000 lines in English and Chinese documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->