### PR TITLE
fix: avoid closing supervisor fds after uv handoff

### DIFF
--- a/src/Craned/Supervisor/CforedClient.cpp
+++ b/src/Craned/Supervisor/CforedClient.cpp
@@ -279,6 +279,7 @@ void CforedClient::CleanStdoutFwdHandlerQueueCb_() {
           continue;
         }
         meta.out_handle.pipe = ph;
+        meta.stdout_read = -1;
 
         ph->on<uvw::data_event>(
             [this, task_id](uvw::data_event& e, uvw::pipe_handle&) {
@@ -335,6 +336,7 @@ void CforedClient::CleanStdoutFwdHandlerQueueCb_() {
           continue;
         }
         meta.err_handle = err_ph;
+        meta.stderr_read = -1;
 
         err_ph->on<uvw::data_event>(
             [this](uvw::data_event& e, uvw::pipe_handle&) {
@@ -386,6 +388,7 @@ void CforedClient::CleanStdoutFwdHandlerQueueCb_() {
         continue;
       }
       meta.out_handle.tty = th;
+      meta.stdout_read = -1;
 
       th->on<uvw::data_event>(
           [this, task_id](uvw::data_event& e, uvw::tty_handle&) {

--- a/src/Craned/Supervisor/CforedClient.cpp
+++ b/src/Craned/Supervisor/CforedClient.cpp
@@ -293,9 +293,16 @@ void CforedClient::CleanStdoutFwdHandlerQueueCb_() {
           // EOF Received
           h.close();
           CRANE_INFO("[Task #{}] Output pipe received EOF.", tid);
-          auto& meta = this->m_fwd_meta_map.at(tid);
-          meta.output_stopped = true;
-          if (meta.err_stopped) on_finish();
+          bool should_finish = false;
+          {
+            absl::MutexLock lock(&m_mtx_);
+            auto it = m_fwd_meta_map.find(tid);
+            if (it != m_fwd_meta_map.end() && !it->second.output_stopped) {
+              it->second.output_stopped = true;
+              should_finish = it->second.err_stopped;
+            }
+          }
+          if (should_finish) on_finish();
         });
 
         ph->on<uvw::error_event>([this, tid = meta.task_id, on_finish](
@@ -303,9 +310,16 @@ void CforedClient::CleanStdoutFwdHandlerQueueCb_() {
           CRANE_WARN("[Task #{}] output pipe error: {}. Closing.", tid,
                      e.what());
           h.close();
-          auto& meta = this->m_fwd_meta_map.at(tid);
-          meta.output_stopped = true;
-          if (meta.err_stopped) on_finish();
+          bool should_finish = false;
+          {
+            absl::MutexLock lock(&m_mtx_);
+            auto it = m_fwd_meta_map.find(tid);
+            if (it != m_fwd_meta_map.end() && !it->second.output_stopped) {
+              it->second.output_stopped = true;
+              should_finish = it->second.err_stopped;
+            }
+          }
+          if (should_finish) on_finish();
         });
 
         ph->on<uvw::close_event>(
@@ -350,9 +364,16 @@ void CforedClient::CleanStdoutFwdHandlerQueueCb_() {
           CRANE_INFO("[Task #{}] Stderr pipe received EOF.", tid);
           // EOF Received
           h.close();
-          auto& meta = this->m_fwd_meta_map.at(tid);
-          meta.err_stopped = true;
-          if (meta.output_stopped) on_finish();
+          bool should_finish = false;
+          {
+            absl::MutexLock lock(&m_mtx_);
+            auto it = m_fwd_meta_map.find(tid);
+            if (it != m_fwd_meta_map.end() && !it->second.err_stopped) {
+              it->second.err_stopped = true;
+              should_finish = it->second.output_stopped;
+            }
+          }
+          if (should_finish) on_finish();
         });
 
         err_ph->on<uvw::error_event>(
@@ -361,9 +382,16 @@ void CforedClient::CleanStdoutFwdHandlerQueueCb_() {
               CRANE_WARN("[Task #{}] Stderr pipe error: {}. Closing.", tid,
                          e.what());
               h.close();
-              auto& meta = this->m_fwd_meta_map.at(tid);
-              meta.err_stopped = true;
-              if (meta.output_stopped) on_finish();
+              bool should_finish = false;
+              {
+                absl::MutexLock lock(&m_mtx_);
+                auto it = m_fwd_meta_map.find(tid);
+                if (it != m_fwd_meta_map.end() && !it->second.err_stopped) {
+                  it->second.err_stopped = true;
+                  should_finish = it->second.output_stopped;
+                }
+              }
+              if (should_finish) on_finish();
             });
 
         err_ph->on<uvw::close_event>(
@@ -397,17 +425,38 @@ void CforedClient::CleanStdoutFwdHandlerQueueCb_() {
             }
           });
 
-      th->on<uvw::end_event>([on_finish](uvw::end_event&, uvw::tty_handle& h) {
-        // The remote end is closed, go to EOF process.
-        h.close();
-        on_finish();
-      });
+      th->on<uvw::end_event>(
+          [this, task_id, on_finish](uvw::end_event&, uvw::tty_handle& h) {
+            // The remote end is closed, go to EOF process.
+            h.close();
+            bool should_finish = false;
+            {
+              absl::MutexLock lock(&m_mtx_);
+              auto it = m_fwd_meta_map.find(task_id);
+              if (it != m_fwd_meta_map.end() && !it->second.output_stopped) {
+                it->second.output_stopped = true;
+                it->second.input_stopped = true;
+                should_finish = true;
+              }
+            }
+            if (should_finish) on_finish();
+          });
 
-      th->on<uvw::error_event>([tid = meta.task_id, on_finish](
+      th->on<uvw::error_event>([this, tid = meta.task_id, on_finish](
                                    uvw::error_event& e, uvw::tty_handle& h) {
         CRANE_WARN("[Task #{}] pty read error: {}. Closing.", tid, e.what());
         h.close();
-        on_finish();
+        bool should_finish = false;
+        {
+          absl::MutexLock lock(&m_mtx_);
+          auto it = m_fwd_meta_map.find(tid);
+          if (it != m_fwd_meta_map.end() && !it->second.output_stopped) {
+            it->second.output_stopped = true;
+            it->second.input_stopped = true;
+            should_finish = true;
+          }
+        }
+        if (should_finish) on_finish();
       });
 
       th->on<uvw::close_event>(


### PR DESCRIPTION
## Summary
- mark stdout/stderr/pty read fds as handed off after uvw handle ownership is established
- keep cleanup from closing stale raw fd values that may already be reused by later crun tasks

## Verification
- systemd-run --scope -p MemoryMax=15G ninja -C cmake-build-debug src/Craned/Supervisor/csupervisor
- local crun -n 4 pwd produced 4 stdout lines with all tasks exit_code=0 and signaled=false

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability when launching and managing processes through standard input/output and pseudo-terminals.
  * Prevented active communication channels from being closed prematurely, reducing interruptions and cleanup-related failures.
  * Improved shutdown handling by ensuring pseudo-terminal output stops before task completion is reported.
  * Reduced the risk of duplicate completion events and incomplete or lost output during task termination and process cleanup.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->