### PR TITLE
docs: improve CentOS 7 deployment guide

### DIFF
--- a/docs/en/deployment/backend/CentOS7.md
+++ b/docs/en/deployment/backend/CentOS7.md
@@ -1,67 +1,72 @@
 # Deployment Guide for CentOS 7
 
-
 !!! warning
-    This guide is for **CentOS 7**, which has reached **End of Life (EOL)**. Future updates of CraneSched rely on modern compilers, so this tutorial **may not work as intended** and is no longer guaranteed to be maintained.
+    CentOS 7 has reached **End of Life (EOL)**. CraneSched depends on modern compilers, so this guide is intended only for existing clusters that must continue to run CentOS 7 and is not guaranteed to receive long-term maintenance. Prefer a supported distribution such as Rocky Linux 9.
 
+This guide assumes x86-64, CGroup v1, and a dedicated build node. Unless stated otherwise, run all commands on the **build node** as **root**. If artifacts will be distributed to other nodes, build on the oldest CPU model in the cluster or disable `-march=native` as shown below.
 
-## 1. Configure Build Environment
+## 1. Configure the Build Environment
 
-All commands below should be executed on the **build node** as the **root** user.
-
-
-Install additional repositories:
+The public CentOS 7 repositories may no longer be available. Configure Yum to use a working Vault or internal mirror before installing the additional repositories and complete build toolchain:
 
 ```bash
 yum install -y epel-release centos-release-scl-rh
-yum install -y ninja-build patch devtoolset-11 rh-git218
+yum install -y \
+    ca-certificates wget curl tar gzip bzip2 xz unzip make which \
+    patch autoconf automake libtool flex bison pkgconfig ninja-build \
+    devtoolset-11 rh-git218
 ```
 
-Add to `~/.bash_profile`:
+Enable the newer bootstrap compiler and Git:
 
 ```bash
 source scl_source enable devtoolset-11
 source scl_source enable rh-git218
 ```
 
-## 2. Environment Preparation
+Add these two lines to the build user's `~/.bash_profile` if the build must continue in a new login session.
 
-### 2.1 Disable SELinux
+## 2. Prepare the Environment
+
+### 2.1 Check the CGroup Version
+
+CentOS 7 normally uses CGroup v1. Check the actual mount layout on the target compute nodes before building:
+
+```bash
+mount | grep cgroup
+```
+
+The build command below explicitly sets `-DCRANE_ENABLE_CGROUP_V2=OFF`. Do not rely on the project default because it may change between releases.
+
+### 2.2 Configure SELinux
+
+Validate the SELinux policy in a test environment first. If no suitable policy is available, disable SELinux on every node:
 
 ```bash
 setenforce 0
 sed -i s#SELINUX=enforcing#SELINUX=disabled# /etc/selinux/config
 ```
 
-### 2.2 Install Certificates
-
-```bash
-yum -y install ca-certificates
-```
-
 ### 2.3 Synchronize System Time
 
-
 ```bash
-yum -y install ntp ntpdate
-systemctl start ntpd
-systemctl enable ntpd
+yum install -y ntp ntpdate
+systemctl enable --now ntpd
 timedatectl set-timezone Asia/Shanghai
 ```
 
-### 2.4 Configure Firewall
+### 2.4 Configure the Firewall
 
 !!! tip
-    If you have multiple nodes, perform this step on **each node**. Otherwise, inter-node communication will fail.
+    Configure the firewall on **every node** in a multi-node cluster. Otherwise, inter-node communication will fail. The ports in `/etc/crane/config.yaml` are authoritative.
 
-    Please see the config file `/etc/crane/config.yaml` for port configuration details.
+The firewall can be disabled:
 
 ```bash
-systemctl stop firewalld
-systemctl disable firewalld
+systemctl disable --now firewalld
 ```
 
-If your cluster requires the firewall to remain active, open the following ports:
+If the firewall must remain enabled, open the ports used by the CraneSched configuration. The default configuration normally requires:
 
 ```bash
 firewall-cmd --add-port=10013/tcp --permanent --zone=public
@@ -72,136 +77,261 @@ firewall-cmd --add-port=873/tcp --permanent --zone=public
 firewall-cmd --reload
 ```
 
-## 3. Install Dependencies
+## 3. Install Project Dependencies
+
+### 3.1 System Development Libraries
 
 ```bash
-yum install -y openssl-devel curl-devel pam-devel zlib-devel zlib-static libaio-devel libcurl-devel systemd-devel lua-devel
+yum install -y \
+    libstdc++-devel libstdc++-static \
+    openssl-devel libcurl-devel pam-devel \
+    zlib-devel zlib-static libaio-devel systemd-devel lua-devel
 ```
 
-Lua support is enabled by default. CentOS 7 is EOL; if `lua-devel` cannot be
-installed from normal repositories, use a vault or internal mirror.
+Lua support is enabled by default. If `lua-devel` is unavailable from the Vault or internal mirror, configure with `-DCRANE_ENABLE_LUA=OFF`.
 
-Install libcgroup from source:
+Install `devtoolset-11-libasan-devel` or `devtoolset-11-libtsan-devel` only when enabling AddressSanitizer or ThreadSanitizer. Production builds do not need them by default.
+
+### 3.2 Install libcgroup
+
+The libcgroup package in the CentOS 7 repositories is too old. Install libcgroup 3.1.0, matching the version currently bundled by the project, and disable its unnecessary systemd integration:
 
 ```bash
-yum install -y tar bison flex automake
-
 wget https://github.com/libcgroup/libcgroup/releases/download/v3.1.0/libcgroup-3.1.0.tar.gz
-tar -zxvf libcgroup-3.1.0.tar.gz
-
+echo "976ec4b1e03c0498308cfd28f1b256b40858f636abc8d1f9db24f0a7ea9e1258  libcgroup-3.1.0.tar.gz" | sha256sum -c -
+tar -xzf libcgroup-3.1.0.tar.gz
 cd libcgroup-3.1.0
-./configure
-make -j
+./configure --prefix=/usr/local --disable-systemd
+make -j"$(nproc)"
 make install
+cd ..
 ```
 
-## 4. Install Toolchain
-
-CraneSched requires the following toolchain versions:
-
-* CMake ≥ 3.24
-* libstdc++ ≥ 11
-* clang ≥ 19 or g++ ≥ 14
-
-### 4.1 CMake
+Register the library and pkg-config paths, then verify the installation:
 
 ```bash
-sudo yum install -y wget
+printf '/usr/local/lib\n/usr/local/lib64\n' > /etc/ld.so.conf.d/crane-local.conf
+ldconfig
+export PKG_CONFIG_PATH="/usr/local/lib/pkgconfig:/usr/local/lib64/pkgconfig:${PKG_CONFIG_PATH}"
+pkg-config --modversion libcgroup
+```
+
+### 3.3 Install Subid
+
+The current release looks for `libsubid` during CMake configuration, even if the cluster does not currently use containers. CentOS 7 normally does not provide a sufficiently new `shadow-utils-subid-devel`, so install it from Shadow 4.9 source:
+
+```bash
+wget https://github.com/shadow-maint/shadow/releases/download/v4.9/shadow-4.9.tar.gz
+tar -xzf shadow-4.9.tar.gz
+cd shadow-4.9
+./configure --prefix=/usr/local \
+    --without-libcrack \
+    --without-tcb \
+    --without-nscd \
+    --without-group-name-max-length \
+    LIBS="-lpam_misc -lpam"
+make -j"$(nproc)"
+# Install only libsubid to avoid replacing CentOS account tools such as passwd and useradd
+make -C libsubid install
+ldconfig
+cd ..
+```
+
+Confirm that the header and shared library exist:
+
+```bash
+test -f /usr/local/include/shadow/subid.h
+test -f /usr/local/lib/libsubid.so || test -f /usr/local/lib64/libsubid.so
+```
+
+## 4. Install the Toolchain
+
+CraneSched requires:
+
+* CMake >= 3.24
+* g++ >= 14, or clang++ >= 19
+
+The GCC 4.8 supplied by CentOS 7 cannot build the current release.
+
+### 4.1 Install CMake
+
+```bash
 wget https://github.com/Kitware/CMake/releases/download/v3.26.4/cmake-3.26.4-linux-x86_64.sh
 bash cmake-3.26.4-linux-x86_64.sh --prefix=/usr/local --skip-license
-cmake --version
+/usr/local/bin/cmake --version
 ```
 
-### 4.2 GCC 14
+### 4.2 Install GCC 14
 
-CraneSched requires **libstdc++ ≥ 11**. The default GCC 4.8 on CentOS 7 is too old, so we need to build and install GCC 14 from source.
+Use devtoolset-11 as the bootstrap compiler and install GCC 14.2 under the conventional `/usr/local` prefix:
 
 ```bash
-yum install -y tar bzip2
-wget https://ftp.gnu.org/gnu/gcc/gcc-14.1.0/gcc-14.1.0.tar.gz
+source scl_source enable devtoolset-11
 
-tar -zxvf gcc-14.1.0.tar.gz
-cd gcc-14.1.0
-
+wget https://ftp.gnu.org/gnu/gcc/gcc-14.2.0/gcc-14.2.0.tar.gz
+tar -xzf gcc-14.2.0.tar.gz
+cd gcc-14.2.0
 ./contrib/download_prerequisites
 mkdir build && cd build
-../configure --enable-checking=release --enable-languages=c,c++ --disable-multilib
-make -j
+../configure --prefix=/usr/local \
+    --enable-checking=release \
+    --enable-languages=c,c++ \
+    --disable-multilib
+make -j"$(nproc)"
 make install
+cd ../..
 ```
 
-If you are using clang, you can use libstdc++ from GCC 14 by adding the following flags to CMake (step 6):
+Activate and verify the compiler that will actually be used. Do not merely check that a `gcc` command exists:
 
 ```bash
--DCMAKE_C_FLAGS_INIT="--gcc-toolchain=/usr/local" \
--DCMAKE_CXX_FLAGS_INIT="--gcc-toolchain=/usr/local"
+export PATH="/usr/local/bin:${PATH}"
+export LD_LIBRARY_PATH="/usr/local/lib64:/usr/local/lib:${LD_LIBRARY_PATH}"
+hash -r
+
+command -v gcc g++
+gcc -dumpfullversion
+g++ -dumpfullversion
 ```
 
-## 5. Build and Install
+Both version commands must report `14.x`, and `command -v` must point to `/usr/local/bin`.
 
-Lua support is enabled by default. If you do not want to build Lua support, add
-`-DCRANE_ENABLE_LUA=OFF` to the CMake command.
+!!! tip
+    The Binutils version supplied by CentOS 7 is old. A normal build can usually proceed, but GCC requires Binutils 2.35+ for reliable LTO support. If CMake reports IPO/LTO or linker errors, install a newer release such as Binutils 2.41 under a separate prefix and reconfigure. LLDB is not required for a normal GCC build.
+
+## 5. Optional: Install PMIx and UCX
+
+PMIx is needed only to launch MPI jobs with `crun --mpi=pmix`. UCX is an optional direct-connection optimization for high-speed networks such as InfiniBand or RoCE.
+
+Install the OpenPMIx build dependencies on CentOS 7:
+
+```bash
+yum install -y libevent-devel hwloc-devel
+```
+
+See the [PMIx Guide](../configuration/pmix.md) for versions, the Open MPI build, and UCX configuration. Also follow these rules:
+
+1. Install PMIx, MPI, and UCX at a stable path visible to every runtime node, or install them separately on every node.
+2. Set UCX's `PKG_CONFIG_PATH` before configuring CraneSched and verify it with `pkg-config --libs ucx`; otherwise UCX support will not be compiled.
+3. For custom shared-library paths, add `-DCMAKE_INSTALL_RPATH_USE_LINK_PATH=ON` and verify library resolution with `ldd` on every runtime node.
+4. OpenPMIx does not replace an MPI implementation. MPI programs still require a PMIx-capable implementation such as Open MPI 4.1+.
+
+## 6. Build and Install
 
 ```bash
 git clone https://github.com/PKUHPC/CraneSched.git
 cd CraneSched
 
-mkdir build && cd build
-cmake -G Ninja -DCMAKE_C_COMPILER=/usr/bin/gcc \
-               -DCMAKE_CXX_COMPILER=/usr/bin/g++ \
-               -DCRANE_USE_SYSTEM_LIBCGROUP=ON \
-               -DCRANE_ENABLE_CGROUP_V2=OFF ..
-cmake --build .
-ninja install
+cmake -S . -B build -G Ninja \
+    -DCMAKE_C_COMPILER=/usr/local/bin/gcc \
+    -DCMAKE_CXX_COMPILER=/usr/local/bin/g++ \
+    -DCMAKE_BUILD_TYPE=Release \
+    -DCRANE_USE_SYSTEM_LIBCGROUP=ON \
+    -DCRANE_ENABLE_CGROUP_V2=OFF \
+    -DCRANE_NATIVE_ARCH_OPT=OFF \
+    -DSUBID_INCLUDE_DIR=/usr/local/include/shadow \
+    -DSUBID_LIBRARY=/usr/local/lib/libsubid.so
+cmake --build build -j"$(nproc)"
 ```
 
-!!! info
-    If you prefer to use RPM packages, please refer to the [Packaging Guide](../packaging.md) for instructions.
-
-For deploying CraneSched to multiple nodes, please follow the [Multi-node Deployment Guide](../configuration/multi-node.md).
-
-## 6. Install and Configure MongoDB
-
-MongoDB is required on the **control node** only.
-
-Please follow the [Database Configuration Guide](../configuration/database.md) for detailed instructions.
-
-!!! info
-    CentOS 7 supports up to MongoDB 7.0. See the database configuration guide for specific installation instructions.
-
-## 7. PAM Module Setup
-
-PAM module configuration is optional but recommended for production clusters.
-
-Please follow the [PAM Module Configuration Guide](../configuration/pam.md) for detailed instructions.
-
-## 8. Configure and Launch Services
-
-For cluster configuration details, see the [Cluster Configuration Guide](../configuration/config.md).
-
-After configuring, choose your startup method:
-
-### Using systemd (Recommended)
-
-**Control node only**: Create crane user (automatic with RPM packages):
+Adjust `SUBID_LIBRARY` if `libsubid.so` was installed under `/usr/local/lib64`. If PMIx is enabled, also add:
 
 ```bash
-sudo groupadd --system crane 2>/dev/null || true
-sudo useradd --system --gid crane --shell /usr/sbin/nologin --create-home crane 2>/dev/null || true
+-DWITH_PMIX=/path/to/pmix \
+-DCMAKE_INSTALL_RPATH_USE_LINK_PATH=ON
 ```
 
-Then start services:
+!!! note
+    `CRANE_NATIVE_ARCH_OPT` is enabled by default. This guide disables it so that one build can be safely distributed across nodes with different CPU models. It may be set to `ON` when every node has an identical CPU and native optimization is preferred.
+
+Check the important configuration values and shared libraries before installing:
+
+```bash
+cmake -LA -N build | grep -E 'CMAKE_(C|CXX)_COMPILER|CRANE_ENABLE_CGROUP_V2|CRANE_NATIVE_ARCH_OPT|WITH_PMIX'
+ldd build/src/CraneCtld/cranectld | grep 'not found' && exit 1 || true
+ldd build/src/Craned/craned | grep 'not found' && exit 1 || true
+```
+
+For a source installation:
+
+```bash
+cmake --install build
+```
+
+## 7. Build and Install RPM Packages
+
+The RPM version supplied by CentOS 7 does not support zstd compression. Override the project's default compression when generating packages that must be installed on CentOS 7:
+
+```bash
+yum install -y rpm-build
+cpack --config build/CPackConfig.cmake \
+    -G RPM \
+    -D CPACK_RPM_COMPRESSION_TYPE=gzip
+```
+
+When the frontend project generates RPM packages through GoReleaser, also set `compression: gzip` for every RPM entry in `.goreleaser.yaml`. This changes only package compression; lowering the TLS version or modifying application code is not required.
+
+Inspect package contents and dependencies before installing:
+
+```bash
+rpm -qpl build/*.rpm
+rpm -qpR build/*.rpm
+```
+
+Do not use `rpm --nodeps` to bypass missing dependencies. PMIx, UCX, or Subid installed at custom paths may not be resolved correctly by the package manager. Ensure that every target node has the required shared libraries and check after installation:
+
+```bash
+# On the control node
+if ldd /usr/bin/cranectld | grep 'not found'; then exit 1; fi
+
+# On a compute node
+if ldd /usr/bin/craned | grep 'not found'; then exit 1; fi
+```
+
+See the [Packaging Guide](../packaging.md) for the complete packaging workflow and the [Multi-node Deployment Guide](../configuration/multi-node.md) for cluster deployment.
+
+## 8. Install and Configure the Database
+
+An external MongoDB deployment is needed only on the **control-node** side. MongoDB 7.0 is the latest release supported on CentOS 7. See the [Database Configuration Guide](../configuration/database.md) for installation and embedded database alternatives.
+
+## 9. PAM Module Setup
+
+The PAM module is optional but recommended for production clusters. Enable it only after the cluster services have been validated, following the [PAM Module Guide](../configuration/pam.md), so that an incorrect configuration does not lock out SSH access.
+
+## 10. Configure and Start Services
+
+Prepare the configuration files using the [Cluster Configuration Guide](../configuration/config.md). The RPM post-installation script creates the `crane` system user automatically. Create it manually only for a source installation that uses systemd:
+
+```bash
+groupadd --system crane 2>/dev/null || true
+useradd --system --gid crane --shell /sbin/nologin --create-home crane 2>/dev/null || true
+```
+
+For MPI, RDMA, or accelerator workloads that lock substantial memory, configure memlock for `craned.service` on every compute node:
+
+```bash
+mkdir -p /etc/systemd/system/craned.service.d
+cat > /etc/systemd/system/craned.service.d/override.conf <<'EOF'
+[Service]
+LimitMEMLOCK=infinity
+EOF
+```
+
+Start the services and inspect their status:
 
 ```bash
 systemctl daemon-reload
-systemctl start cranectld  # Control node
-systemctl start craned     # Compute node
+systemctl enable --now cranectld  # Control node
+systemctl enable --now craned     # Compute node
+
+# Check the relevant service on each node type
+systemctl --no-pager --full status cranectld
+systemctl --no-pager --full status craned
 ```
 
-### Running binaries directly
+Run binaries directly only for debugging:
 
 ```bash
-cd build/src
-CraneCtld/cranectld  # Control node
-Craned/craned        # Compute node
+build/src/CraneCtld/cranectld  # Control node
+build/src/Craned/craned        # Compute node
 ```

--- a/docs/zh/deployment/backend/CentOS7.md
+++ b/docs/zh/deployment/backend/CentOS7.md
@@ -1,63 +1,72 @@
 # CentOS 7 部署指南
 
 !!! warning
-    本指南适用于 **CentOS 7**，该系统已达到**生命周期终止（EOL）**。鹤思的未来更新依赖于现代编译器，因此本教程**可能无法按预期工作**，且不再保证得到维护。
+    CentOS 7 已达到**生命周期终止（EOL）**。鹤思依赖现代编译器，本指南仅用于必须继续运行 CentOS 7 的存量集群，且不再保证长期维护。请优先使用 Rocky Linux 9 等受支持的发行版。
+
+本指南以 x86-64 架构、CGroup v1 和独立构建节点为基准。以下命令除特别说明外，均应在**构建节点**上以 **root** 用户执行。构建产物需要分发到其他节点时，应在集群中最旧的 CPU 型号上构建，或按本文关闭 `-march=native`。
 
 ## 1. 配置构建环境
 
-以下所有命令应在**构建节点**上以 **root** 用户身份执行。
-
-安装附加仓库：
+CentOS 7 的公共软件源可能已经不可用。请先将 Yum 配置为可用的 Vault 或内部镜像，再安装附加仓库和完整的构建工具：
 
 ```bash
 yum install -y epel-release centos-release-scl-rh
-yum install -y ninja-build patch devtoolset-11 rh-git218
+yum install -y \
+    ca-certificates wget curl tar gzip bzip2 xz unzip make which \
+    patch autoconf automake libtool flex bison pkgconfig ninja-build \
+    devtoolset-11 rh-git218
 ```
 
-添加到 `~/.bash_profile`：
+启用较新的引导编译器和 Git：
 
 ```bash
 source scl_source enable devtoolset-11
 source scl_source enable rh-git218
 ```
 
+如果需要在新的登录会话中继续构建，可将以上两行加入构建用户的 `~/.bash_profile`。
+
 ## 2. 环境准备
 
-### 2.1 禁用 SELinux
+### 2.1 检查 CGroup 版本
+
+CentOS 7 通常使用 CGroup v1。构建前先确认目标计算节点的实际挂载方式：
+
+```bash
+mount | grep cgroup
+```
+
+本文后续会显式设置 `-DCRANE_ENABLE_CGROUP_V2=OFF`。不要依赖项目默认值，因为默认值可能随版本变化。
+
+### 2.2 配置 SELinux
+
+先在测试环境验证 SELinux 策略。若暂时没有适用的策略，可在所有节点上禁用 SELinux：
 
 ```bash
 setenforce 0
 sed -i s#SELINUX=enforcing#SELINUX=disabled# /etc/selinux/config
 ```
 
-### 2.2 安装证书
-
-```bash
-yum -y install ca-certificates
-```
-
 ### 2.3 同步系统时间
 
 ```bash
-yum -y install ntp ntpdate
-systemctl start ntpd
-systemctl enable ntpd
+yum install -y ntp ntpdate
+systemctl enable --now ntpd
 timedatectl set-timezone Asia/Shanghai
 ```
 
 ### 2.4 配置防火墙
 
 !!! tip
-    如果您有多个节点，请在**每个节点**上执行此步骤。否则，节点间通信将失败。
+    多节点集群需要在**每个节点**上配置防火墙，否则节点间通信会失败。实际端口以 `/etc/crane/config.yaml` 为准。
 
-    有关端口配置详细信息，请参阅配置文件 `/etc/crane/config.yaml`。
+可以禁用防火墙：
 
 ```bash
-systemctl stop firewalld
-systemctl disable firewalld
+systemctl disable --now firewalld
 ```
 
-如果您的集群需要保持防火墙处于活动状态，请开放以下端口：
+如果需要保持防火墙启用，请开放鹤思配置使用的端口。默认配置通常需要：
 
 ```bash
 firewall-cmd --add-port=10013/tcp --permanent --zone=public
@@ -68,135 +77,261 @@ firewall-cmd --add-port=873/tcp --permanent --zone=public
 firewall-cmd --reload
 ```
 
-## 3. 安装依赖
+## 3. 安装项目依赖
+
+### 3.1 系统开发库
 
 ```bash
-yum install -y openssl-devel curl-devel pam-devel zlib-devel zlib-static libaio-devel libcurl-devel systemd-devel lua-devel
+yum install -y \
+    libstdc++-devel libstdc++-static \
+    openssl-devel libcurl-devel pam-devel \
+    zlib-devel zlib-static libaio-devel systemd-devel lua-devel
 ```
 
-Lua 支持默认开启。CentOS 7 已 EOL；如果无法从普通仓库安装 `lua-devel`，请使用 vault 或内部镜像。
+Lua 支持默认开启。如果无法从 Vault 或内部镜像安装 `lua-devel`，可在配置时添加 `-DCRANE_ENABLE_LUA=OFF`。
 
-从源码安装 libcgroup：
+仅在启用 AddressSanitizer 或 ThreadSanitizer 时，才需要安装对应的 `devtoolset-11-libasan-devel` 或 `devtoolset-11-libtsan-devel`，生产构建不需要默认安装它们。
+
+### 3.2 安装 libcgroup
+
+CentOS 7 仓库中的 libcgroup 版本过旧。安装与项目当前内置版本一致的 libcgroup 3.1.0，并关闭该库中不需要的 systemd 集成：
 
 ```bash
-yum install -y tar bison flex automake
-
 wget https://github.com/libcgroup/libcgroup/releases/download/v3.1.0/libcgroup-3.1.0.tar.gz
-tar -zxvf libcgroup-3.1.0.tar.gz
-
+echo "976ec4b1e03c0498308cfd28f1b256b40858f636abc8d1f9db24f0a7ea9e1258  libcgroup-3.1.0.tar.gz" | sha256sum -c -
+tar -xzf libcgroup-3.1.0.tar.gz
 cd libcgroup-3.1.0
-./configure
-make -j
+./configure --prefix=/usr/local --disable-systemd
+make -j"$(nproc)"
 make install
+cd ..
+```
+
+注册动态库和 pkg-config 路径并验证安装：
+
+```bash
+printf '/usr/local/lib\n/usr/local/lib64\n' > /etc/ld.so.conf.d/crane-local.conf
+ldconfig
+export PKG_CONFIG_PATH="/usr/local/lib/pkgconfig:/usr/local/lib64/pkgconfig:${PKG_CONFIG_PATH}"
+pkg-config --modversion libcgroup
+```
+
+### 3.3 安装 Subid
+
+当前版本在 CMake 配置阶段会查找 `libsubid`，即使集群暂时不使用容器功能也必须提供该开发库。CentOS 7 通常没有足够新的 `shadow-utils-subid-devel`，可从 Shadow 4.9 源码安装：
+
+```bash
+wget https://github.com/shadow-maint/shadow/releases/download/v4.9/shadow-4.9.tar.gz
+tar -xzf shadow-4.9.tar.gz
+cd shadow-4.9
+./configure --prefix=/usr/local \
+    --without-libcrack \
+    --without-tcb \
+    --without-nscd \
+    --without-group-name-max-length \
+    LIBS="-lpam_misc -lpam"
+make -j"$(nproc)"
+# 只安装 libsubid，避免覆盖 CentOS 自带的 passwd、useradd 等账号工具
+make -C libsubid install
+ldconfig
+cd ..
+```
+
+确认头文件和动态库存在：
+
+```bash
+test -f /usr/local/include/shadow/subid.h
+test -f /usr/local/lib/libsubid.so || test -f /usr/local/lib64/libsubid.so
 ```
 
 ## 4. 安装工具链
 
-鹤思需要以下工具链版本:
+鹤思需要以下工具链版本：
 
-* CMake ≥ 3.24
-* libstdc++ ≥ 11
-* clang ≥ 19 或 g++ ≥ 14
+* CMake >= 3.24
+* g++ >= 14，或 clang++ >= 19
 
-### 4.1 CMake
+CentOS 7 自带的 GCC 4.8 无法构建当前版本。
+
+### 4.1 安装 CMake
 
 ```bash
-sudo yum install -y wget
 wget https://github.com/Kitware/CMake/releases/download/v3.26.4/cmake-3.26.4-linux-x86_64.sh
 bash cmake-3.26.4-linux-x86_64.sh --prefix=/usr/local --skip-license
-cmake --version
+/usr/local/bin/cmake --version
 ```
 
-### 4.2 GCC 14
+### 4.2 安装 GCC 14
 
-鹤思需要 **libstdc++ ≥ 11**。CentOS 7 上的默认 GCC 4.8 太旧，因此我们需要从源码构建并安装 GCC 14。
+使用 devtoolset-11 作为引导编译器，将 GCC 14.2 安装到通用前缀 `/usr/local`：
 
 ```bash
-yum install -y tar bzip2
-wget https://ftp.gnu.org/gnu/gcc/gcc-14.1.0/gcc-14.1.0.tar.gz
+source scl_source enable devtoolset-11
 
-tar -zxvf gcc-14.1.0.tar.gz
-cd gcc-14.1.0
-
+wget https://ftp.gnu.org/gnu/gcc/gcc-14.2.0/gcc-14.2.0.tar.gz
+tar -xzf gcc-14.2.0.tar.gz
+cd gcc-14.2.0
 ./contrib/download_prerequisites
 mkdir build && cd build
-../configure --enable-checking=release --enable-languages=c,c++ --disable-multilib
-make -j
+../configure --prefix=/usr/local \
+    --enable-checking=release \
+    --enable-languages=c,c++ \
+    --disable-multilib
+make -j"$(nproc)"
 make install
+cd ../..
 ```
 
-如果您使用 clang，可以通过向 CMake 添加以下标志（步骤 6）来使用 GCC 14 的 libstdc++：
+激活并验证实际使用的编译器。不要仅检查 `gcc` 命令是否存在：
 
 ```bash
--DCMAKE_C_FLAGS_INIT="--gcc-toolchain=/usr/local" \
--DCMAKE_CXX_FLAGS_INIT="--gcc-toolchain=/usr/local"
+export PATH="/usr/local/bin:${PATH}"
+export LD_LIBRARY_PATH="/usr/local/lib64:/usr/local/lib:${LD_LIBRARY_PATH}"
+hash -r
+
+command -v gcc g++
+gcc -dumpfullversion
+g++ -dumpfullversion
 ```
 
-## 5. 构建和安装
+两条版本命令都应输出 `14.x`，且 `command -v` 应指向 `/usr/local/bin`。
 
-Lua 支持默认开启。如不希望构建 Lua 支持，请在 CMake 命令中加入
-`-DCRANE_ENABLE_LUA=OFF`。
+!!! tip
+    CentOS 7 自带的 Binutils 较旧。普通构建通常可以继续，但 GCC 官方要求 Binutils 2.35+ 才能可靠使用 LTO。如果 CMake 报告 IPO/LTO 或链接器错误，可将 Binutils 2.41 等较新版本安装到独立前缀后重新配置；无需为普通 GCC 构建额外安装 LLDB。
+
+## 5. 可选：安装 PMIx 和 UCX
+
+只有需要通过 `crun --mpi=pmix` 启动 MPI 作业时才需要 PMIx；UCX 仅用于 InfiniBand、RoCE 等高速网络上的可选直连优化。
+
+CentOS 7 上构建 OpenPMIx 前需要：
+
+```bash
+yum install -y libevent-devel hwloc-devel
+```
+
+具体版本、Open MPI 构建方式和 UCX 配置请参阅 [PMIx 使用指南](../configuration/pmix.md)。安装时还应遵循以下原则：
+
+1. PMIx、MPI 和 UCX 应安装到所有运行节点均可访问的固定路径，或分别部署到每个节点。
+2. 构建前设置 UCX 的 `PKG_CONFIG_PATH`，并用 `pkg-config --libs ucx` 验证；否则 CraneSched 不会编译 UCX 支持。
+3. 使用自定义共享库路径时，在 CMake 中添加 `-DCMAKE_INSTALL_RPATH_USE_LINK_PATH=ON`，并在每个运行节点用 `ldd` 验证库解析结果。
+4. 安装 OpenPMIx 并不能替代 MPI 实现；运行 MPI 程序仍需 Open MPI 4.1+ 等支持 PMIx 的 MPI。
+
+## 6. 构建和安装
 
 ```bash
 git clone https://github.com/PKUHPC/CraneSched.git
 cd CraneSched
 
-mkdir build && cd build
-cmake -G Ninja -DCMAKE_C_COMPILER=/usr/bin/gcc \
-               -DCMAKE_CXX_COMPILER=/usr/bin/g++ \
-               -DCRANE_USE_SYSTEM_LIBCGROUP=ON \
-               -DCRANE_ENABLE_CGROUP_V2=OFF ..
-cmake --build .
-ninja install
+cmake -S . -B build -G Ninja \
+    -DCMAKE_C_COMPILER=/usr/local/bin/gcc \
+    -DCMAKE_CXX_COMPILER=/usr/local/bin/g++ \
+    -DCMAKE_BUILD_TYPE=Release \
+    -DCRANE_USE_SYSTEM_LIBCGROUP=ON \
+    -DCRANE_ENABLE_CGROUP_V2=OFF \
+    -DCRANE_NATIVE_ARCH_OPT=OFF \
+    -DSUBID_INCLUDE_DIR=/usr/local/include/shadow \
+    -DSUBID_LIBRARY=/usr/local/lib/libsubid.so
+cmake --build build -j"$(nproc)"
 ```
 
-!!! info
-    如果您希望使用 RPM 软件包，请参阅[打包指南](../packaging.md)获取说明。
-
-对于多节点部署鹤思，请按照[多节点部署指南](../configuration/multi-node.md)。
-
-## 6. 安装和配置 MongoDB
-
-MongoDB 仅在**控制节点**上需要。
-
-请按照[数据库配置指南](../configuration/database.md)获取详细说明。
-
-!!! info
-    CentOS 7 最高支持 MongoDB 7.0。有关具体安装说明，请参阅数据库配置指南。
-
-## 7. PAM 模块设置
-
-PAM 模块配置是可选的，但建议用于生产集群。
-
-请按照 [PAM 模块配置指南](../configuration/pam.md)获取详细说明。
-
-## 8. 配置和启动服务
-
-有关集群配置详细信息，请参阅[集群配置指南](../configuration/config.md)。
-
-配置完成后，根据启动方式选择：
-
-### 使用 systemd 启动（推荐）
-
-**仅控制节点**需要先创建 crane 用户（RPM 包安装时自动创建）：
+如果 `libsubid.so` 实际安装在 `/usr/local/lib64`，相应调整 `SUBID_LIBRARY`。如果启用了 PMIx，再添加：
 
 ```bash
-sudo groupadd --system crane 2>/dev/null || true
-sudo useradd --system --gid crane --shell /usr/sbin/nologin --create-home crane 2>/dev/null || true
+-DWITH_PMIX=/path/to/pmix \
+-DCMAKE_INSTALL_RPATH_USE_LINK_PATH=ON
 ```
 
-然后启动服务：
+!!! note
+    `CRANE_NATIVE_ARCH_OPT` 默认开启。本文将其关闭，以便同一构建产物安全分发到不同 CPU 型号的节点。如果所有节点 CPU 完全一致并且更重视本机优化，可以显式改为 `ON`。
+
+安装前检查关键配置和动态库：
+
+```bash
+cmake -LA -N build | grep -E 'CMAKE_(C|CXX)_COMPILER|CRANE_ENABLE_CGROUP_V2|CRANE_NATIVE_ARCH_OPT|WITH_PMIX'
+ldd build/src/CraneCtld/cranectld | grep 'not found' && exit 1 || true
+ldd build/src/Craned/craned | grep 'not found' && exit 1 || true
+```
+
+源码安装：
+
+```bash
+cmake --install build
+```
+
+## 7. 构建和安装 RPM
+
+CentOS 7 自带的 RPM 不支持 zstd 压缩。生成需要在 CentOS 7 上安装的软件包时，覆盖项目的默认压缩方式：
+
+```bash
+yum install -y rpm-build
+cpack --config build/CPackConfig.cmake \
+    -G RPM \
+    -D CPACK_RPM_COMPRESSION_TYPE=gzip
+```
+
+前端项目通过 GoReleaser 生成 RPM 时，也要将 `.goreleaser.yaml` 中各 RPM 包的 `compression` 设置为 `gzip`。该修改只影响软件包压缩格式，不需要降低 TLS 版本或修改业务代码。
+
+安装前检查包内容和依赖：
+
+```bash
+rpm -qpl build/*.rpm
+rpm -qpR build/*.rpm
+```
+
+不要使用 `rpm --nodeps` 绕过缺失依赖。自定义路径中的 PMIx、UCX 或 Subid 不一定会被系统包管理器正确解析；必须确保目标节点存在对应动态库，并在安装后检查：
+
+```bash
+# 在控制节点
+if ldd /usr/bin/cranectld | grep 'not found'; then exit 1; fi
+
+# 在计算节点
+if ldd /usr/bin/craned | grep 'not found'; then exit 1; fi
+```
+
+更完整的打包流程请参阅[打包指南](../packaging.md)。多节点部署请参阅[多节点部署指南](../configuration/multi-node.md)。
+
+## 8. 安装和配置数据库
+
+外部 MongoDB 仅在**控制节点**侧需要。CentOS 7 支持的最新 MongoDB 版本为 7.0，具体安装和嵌入式数据库选项请参阅[数据库配置指南](../configuration/database.md)。
+
+## 9. PAM 模块设置
+
+PAM 模块配置是可选的，但建议用于生产集群。请在集群服务验证正常后，再按照 [PAM 模块配置指南](../configuration/pam.md)启用访问控制，以免配置错误导致 SSH 登录被锁定。
+
+## 10. 配置和启动服务
+
+先按照[集群配置指南](../configuration/config.md)准备配置文件。RPM 安装脚本会自动创建 `crane` 系统用户；仅在源码安装并使用 systemd 时需要手动创建：
+
+```bash
+groupadd --system crane 2>/dev/null || true
+useradd --system --gid crane --shell /sbin/nologin --create-home crane 2>/dev/null || true
+```
+
+对于需要锁定大量内存的 MPI、RDMA 或加速器作业，建议为所有计算节点上的 `craned.service` 配置 memlock：
+
+```bash
+mkdir -p /etc/systemd/system/craned.service.d
+cat > /etc/systemd/system/craned.service.d/override.conf <<'EOF'
+[Service]
+LimitMEMLOCK=infinity
+EOF
+```
+
+启动服务并检查日志：
 
 ```bash
 systemctl daemon-reload
-systemctl start cranectld  # 控制节点
-systemctl start craned     # 计算节点
+systemctl enable --now cranectld  # 控制节点
+systemctl enable --now craned     # 计算节点
+
+# 在对应类型的节点上检查相应服务
+systemctl --no-pager --full status cranectld
+systemctl --no-pager --full status craned
 ```
 
-### 直接运行二进制文件
+直接运行二进制文件仅建议用于调试：
 
 ```bash
-cd build/src
-CraneCtld/cranectld  # 控制节点
-Craned/craned        # 计算节点
+build/src/CraneCtld/cranectld  # 控制节点
+build/src/Craned/craned        # 计算节点
 ```


### PR DESCRIPTION
## Summary

- expand the Chinese and English CentOS 7 deployment guides with a complete, reusable build path
- document libcgroup, Subid, GCC 14, CGroup v1, optional PMIx/UCX, and runtime library verification
- cover portable multi-node builds and CentOS 7-compatible RPM compression

## Why

The previous guide omitted several dependencies and validation steps that were discovered during a real CentOS 7 cluster deployment. That forced operators to infer compiler paths, patch around old system libraries, bypass RPM dependency checks, and debug missing runtime libraries after deployment.

This update captures the generally applicable lessons while excluding site-specific hostnames, shared-storage paths, Vault/SCOW configuration, tracing choices, LLDB setup, and application-level TLS changes.

## Impact

Operators now get an end-to-end CentOS 7 build and packaging workflow that:

- installs and verifies the required toolchain and development libraries
- builds only `libsubid` from Shadow instead of replacing system account tools
- explicitly targets CGroup v1 and disables CPU-specific optimization for portable RPMs
- treats PMIx and UCX as optional features with shared-library and RPATH checks
- generates gzip-compressed RPMs supported by CentOS 7 and avoids `rpm --nodeps`

## Validation

- `git diff --check`
- relative-link checks for both changed guides
- `mkdocs build --strict` for the Chinese and English documentation sites


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Expanded the English and Chinese CentOS 7 deployment guides with updated prerequisites and EOL considerations.
  * Added guidance for system configuration, security settings, dependencies, compiler and build tools, optional integrations, packaging, database/PAM setup, and service validation.
  * Clarified build, installation, and troubleshooting verification steps.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->