### PR TITLE
fix: handle cfored FQDN targets

### DIFF
--- a/src/CraneCtld/RpcService/CranedKeeper.cpp
+++ b/src/CraneCtld/RpcService/CranedKeeper.cpp
@@ -1008,8 +1008,12 @@ void CranedKeeper::ConnectCranedNode_(CranedId const &craned_id,
               ProtoTimestampToString(token), m_channel_count_.fetch_add(1) + 1);
 
   if (g_config.ListenConf.TlsConfig.Enabled) {
-    SetTlsHostnameOverride(&channel_args, craned_id,
-                           g_config.ListenConf.TlsConfig.DomainSuffix);
+    std::string craned_fqdn = craned_id;
+    const std::string &domain_suffix =
+        g_config.ListenConf.TlsConfig.DomainSuffix;
+    if (!domain_suffix.empty() && !craned_fqdn.ends_with("." + domain_suffix))
+      craned_fqdn += "." + domain_suffix;
+    SetTlsHostnameOverride(&channel_args, craned_fqdn);
     craned->m_channel_ = CreateTcpTlsCustomChannelByIp(
         ip_addr, g_config.CranedListenConf.CranedListenPort,
         g_config.ListenConf.TlsConfig.InternalCerts, channel_args);

--- a/src/Craned/Core/CranedForPamServer.cpp
+++ b/src/Craned/Core/CranedForPamServer.cpp
@@ -101,9 +101,13 @@ grpc::Status CranedForPamServiceImpl::QueryStepFromPortForward(
       CRANE_TRACE("Remote address {} was resolved as {}",
                   request->ssh_remote_address(), remote_hostname);
 
+      std::string remote_fqdn = remote_hostname;
+      const std::string &domain_suffix =
+          g_config.ListenConf.TlsConfig.DomainSuffix;
+      if (!domain_suffix.empty() && !remote_fqdn.ends_with("." + domain_suffix))
+        remote_fqdn += "." + domain_suffix;
       channel_of_remote_service = CreateTcpTlsChannelByHostname(
-          remote_hostname, crane_port, g_config.ListenConf.TlsConfig.TlsCerts,
-          g_config.ListenConf.TlsConfig.DomainSuffix);
+          remote_fqdn, crane_port, g_config.ListenConf.TlsConfig.TlsCerts);
     } else {
       CRANE_ERROR("Failed to resolve remote address {}.",
                   request->ssh_remote_address());

--- a/src/Craned/Core/CtldClient.cpp
+++ b/src/Craned/Core/CtldClient.cpp
@@ -865,14 +865,19 @@ void CtldClient::InitGrpcChannel(const std::string& server_address) {
   if (g_config.CompressedRpc)
     channel_args.SetCompressionAlgorithm(GRPC_COMPRESS_GZIP);
 
-  if (g_config.ListenConf.TlsConfig.Enabled)
+  if (g_config.ListenConf.TlsConfig.Enabled) {
+    std::string ctld_fqdn = server_address;
+    const std::string& domain_suffix =
+        g_config.ListenConf.TlsConfig.DomainSuffix;
+    if (!domain_suffix.empty() && !ctld_fqdn.ends_with("." + domain_suffix))
+      ctld_fqdn += "." + domain_suffix;
     m_ctld_channel_ = CreateTcpTlsCustomChannelByHostname(
-        server_address, g_config.CraneCtldForInternalListenPort,
-        g_config.ListenConf.TlsConfig.TlsCerts,
-        g_config.ListenConf.TlsConfig.DomainSuffix, channel_args);
-  else
+        ctld_fqdn, g_config.CraneCtldForInternalListenPort,
+        g_config.ListenConf.TlsConfig.TlsCerts, channel_args);
+  } else {
     m_ctld_channel_ = CreateTcpInsecureCustomChannel(
         server_address, g_config.CraneCtldForInternalListenPort, channel_args);
+  }
 
   // std::unique_ptr will automatically release the dangling stub.
   m_stub_ = CraneCtldForInternal::NewStub(m_ctld_channel_);

--- a/src/Craned/Supervisor/CforedClient.cpp
+++ b/src/Craned/Supervisor/CforedClient.cpp
@@ -53,6 +53,12 @@ CforedClient::CforedClient() {
         CleanStopTaskIOQueueCb_();
       });
 
+  m_process_stop_async_handle_ = m_loop_->resource<uvw::async_handle>();
+  m_process_stop_async_handle_->on<uvw::async_event>(
+      [this](const uvw::async_event&, uvw::async_handle&) {
+        ProcessStopQueueCb_();
+      });
+
   std::shared_ptr<uvw::idle_handle> idle_handle =
       m_loop_->resource<uvw::idle_handle>();
 
@@ -301,7 +307,7 @@ void CforedClient::CleanStdoutFwdHandlerQueueCb_() {
             auto it = m_fwd_meta_map.find(tid);
             if (it != m_fwd_meta_map.end() && !it->second.output_stopped) {
               it->second.output_stopped = true;
-              should_finish = it->second.err_stopped;
+              should_finish = QueueStopTaskIoIfReadyNoLock_(tid, &it->second);
             }
           }
           if (should_finish) on_finish();
@@ -318,7 +324,7 @@ void CforedClient::CleanStdoutFwdHandlerQueueCb_() {
             auto it = m_fwd_meta_map.find(tid);
             if (it != m_fwd_meta_map.end() && !it->second.output_stopped) {
               it->second.output_stopped = true;
-              should_finish = it->second.err_stopped;
+              should_finish = QueueStopTaskIoIfReadyNoLock_(tid, &it->second);
             }
           }
           if (should_finish) on_finish();
@@ -372,29 +378,29 @@ void CforedClient::CleanStdoutFwdHandlerQueueCb_() {
             auto it = m_fwd_meta_map.find(tid);
             if (it != m_fwd_meta_map.end() && !it->second.err_stopped) {
               it->second.err_stopped = true;
-              should_finish = it->second.output_stopped;
+              should_finish = QueueStopTaskIoIfReadyNoLock_(tid, &it->second);
             }
           }
           if (should_finish) on_finish();
         });
 
-        err_ph->on<uvw::error_event>(
-            [this, tid = meta.task_id, on_finish](uvw::error_event& e,
-                                                  uvw::pipe_handle& h) {
-              CRANE_WARN("[Task #{}] Stderr pipe error: {}. Closing.", tid,
-                         e.what());
-              h.close();
-              bool should_finish = false;
-              {
-                absl::MutexLock lock(&m_mtx_);
-                auto it = m_fwd_meta_map.find(tid);
-                if (it != m_fwd_meta_map.end() && !it->second.err_stopped) {
-                  it->second.err_stopped = true;
-                  should_finish = it->second.output_stopped;
-                }
-              }
-              if (should_finish) on_finish();
-            });
+        err_ph->on<uvw::error_event>([this, tid = meta.task_id, on_finish](
+                                         uvw::error_event& e,
+                                         uvw::pipe_handle& h) {
+          CRANE_WARN("[Task #{}] Stderr pipe error: {}. Closing.", tid,
+                     e.what());
+          h.close();
+          bool should_finish = false;
+          {
+            absl::MutexLock lock(&m_mtx_);
+            auto it = m_fwd_meta_map.find(tid);
+            if (it != m_fwd_meta_map.end() && !it->second.err_stopped) {
+              it->second.err_stopped = true;
+              should_finish = QueueStopTaskIoIfReadyNoLock_(tid, &it->second);
+            }
+          }
+          if (should_finish) on_finish();
+        });
 
         err_ph->on<uvw::close_event>(
             [tid = meta.task_id](uvw::close_event&, uvw::pipe_handle&) {
@@ -427,22 +433,22 @@ void CforedClient::CleanStdoutFwdHandlerQueueCb_() {
             }
           });
 
-      th->on<uvw::end_event>(
-          [this, task_id, on_finish](uvw::end_event&, uvw::tty_handle& h) {
-            // The remote end is closed, go to EOF process.
-            h.close();
-            bool should_finish = false;
-            {
-              absl::MutexLock lock(&m_mtx_);
-              auto it = m_fwd_meta_map.find(task_id);
-              if (it != m_fwd_meta_map.end() && !it->second.output_stopped) {
-                it->second.output_stopped = true;
-                it->second.input_stopped = true;
-                should_finish = true;
-              }
-            }
-            if (should_finish) on_finish();
-          });
+      th->on<uvw::end_event>([this, task_id, on_finish](uvw::end_event&,
+                                                        uvw::tty_handle& h) {
+        // The remote end is closed, go to EOF process.
+        h.close();
+        bool should_finish = false;
+        {
+          absl::MutexLock lock(&m_mtx_);
+          auto it = m_fwd_meta_map.find(task_id);
+          if (it != m_fwd_meta_map.end() && !it->second.output_stopped) {
+            it->second.output_stopped = true;
+            it->second.input_stopped = true;
+            should_finish = QueueStopTaskIoIfReadyNoLock_(task_id, &it->second);
+          }
+        }
+        if (should_finish) on_finish();
+      });
 
       th->on<uvw::error_event>([this, tid = meta.task_id, on_finish](
                                    uvw::error_event& e, uvw::tty_handle& h) {
@@ -455,7 +461,7 @@ void CforedClient::CleanStdoutFwdHandlerQueueCb_() {
           if (it != m_fwd_meta_map.end() && !it->second.output_stopped) {
             it->second.output_stopped = true;
             it->second.input_stopped = true;
-            should_finish = true;
+            should_finish = QueueStopTaskIoIfReadyNoLock_(tid, &it->second);
           }
         }
         if (should_finish) on_finish();
@@ -488,10 +494,22 @@ void CforedClient::CleanX11FwdHandlerQueueCb_() {
   }
 }
 
+bool CforedClient::QueueStopTaskIoIfReadyNoLock_(task_id_t task_id,
+                                                 TaskFwdMeta* meta) {
+  CRANE_ASSERT(meta != nullptr);
+  if (!meta->output_stopped || !meta->err_stopped ||
+      meta->stop_task_io_queued || meta->io_cleaned)
+    return false;
+
+  CRANE_TRACE("[Task #{}] Queued task io cleanup.", task_id);
+  meta->stop_task_io_queued = true;
+  return true;
+}
+
 void CforedClient::CleanStopTaskIOQueueCb_() {
   task_id_t task_id;
   while (m_stop_task_io_queue_.try_dequeue(task_id)) {
-    bool ok_to_free = false;
+    bool should_finalize = false;
     {
       absl::MutexLock lock(&m_mtx_);
       auto it = m_fwd_meta_map.find(task_id);
@@ -501,6 +519,8 @@ void CforedClient::CleanStopTaskIOQueueCb_() {
         continue;
       }
       auto& meta = it->second;
+      if (meta.io_cleaned) continue;
+
       auto& output_handle = it->second.out_handle;
       if (!meta.pty && output_handle.pipe) output_handle.pipe->close();
       if (meta.pty && output_handle.tty) output_handle.tty->close();
@@ -513,12 +533,11 @@ void CforedClient::CleanStopTaskIOQueueCb_() {
       meta.err_handle.reset();
       meta.stdout_read = -1;
       meta.stderr_read = -1;
+      meta.io_cleaned = true;
 
       CRANE_DEBUG("[Task #{}] Finished its output and err output.", task_id);
 
-      auto& m = m_fwd_meta_map[task_id];
-      ok_to_free = m.proc_stopped;
-      if (ok_to_free) {
+      if (meta.proc_stopped && !meta.exit_status_sent) {
         // Output and stderr fully drained and process already exited.
         // Now it is safe to send TASK_EXIT_STATUS — all TASK_OUTPUT and
         // TASK_ERR_OUTPUT messages have already been enqueued before this
@@ -526,17 +545,64 @@ void CforedClient::CleanStopTaskIOQueueCb_() {
         m_task_fwd_req_queue_.enqueue(FwdRequest{
             .type = StreamStepIORequest::TASK_EXIT_STATUS,
             .data = TaskFinishStatus{.task_id = task_id,
-                                     .exit_code = m.exit_code,
-                                     .signaled = m.signaled},
+                                     .exit_code = meta.exit_code,
+                                     .signaled = meta.signaled},
         });
+        meta.exit_status_sent = true;
+        should_finalize = true;
       }
     }
 
-    if (ok_to_free) {
+    if (should_finalize) {
       CRANE_DEBUG("[Task #{}] It's ok to unregister.", task_id);
       this->TaskEnd(task_id);
     }
   };
+}
+
+void CforedClient::ProcessStopQueueCb_() {
+  ProcessStopQueueElem elem;
+  while (m_process_stop_queue_.try_dequeue(elem)) {
+    bool should_queue_stop_io = false;
+    bool should_finalize = false;
+    {
+      absl::MutexLock lock(&m_mtx_);
+      auto it = m_fwd_meta_map.find(elem.task_id);
+      if (it == m_fwd_meta_map.end()) {
+        CRANE_WARN("[Task #{}] Cannot find fwd meta for process stop.",
+                   elem.task_id);
+        continue;
+      }
+
+      auto& meta = it->second;
+      meta.proc_stopped = true;
+      meta.exit_code = elem.exit_code;
+      meta.signaled = elem.signaled;
+
+      if (meta.io_cleaned && !meta.exit_status_sent) {
+        m_task_fwd_req_queue_.enqueue(FwdRequest{
+            .type = StreamStepIORequest::TASK_EXIT_STATUS,
+            .data = TaskFinishStatus{.task_id = elem.task_id,
+                                     .exit_code = elem.exit_code,
+                                     .signaled = elem.signaled},
+        });
+        meta.exit_status_sent = true;
+        should_finalize = true;
+      } else {
+        should_queue_stop_io =
+            QueueStopTaskIoIfReadyNoLock_(elem.task_id, &meta);
+      }
+    }
+
+    if (should_queue_stop_io) {
+      m_stop_task_io_queue_.enqueue(elem.task_id);
+      m_clean_stop_task_io_queue_async_handle_->send();
+    }
+    if (should_finalize) {
+      CRANE_DEBUG("[Task #{}] It's ok to unregister.", elem.task_id);
+      this->TaskEnd(elem.task_id);
+    }
+  }
 }
 
 void CforedClient::InitChannelAndStub(const std::string& cfored_name) {
@@ -1004,27 +1070,14 @@ void CforedClient::AsyncSendRecvThread_() {
   }
 }
 
-bool CforedClient::TaskProcessStop(task_id_t task_id, uint32_t exit_code,
+void CforedClient::TaskProcessStop(task_id_t task_id, uint32_t exit_code,
                                    bool signaled) {
   CRANE_DEBUG("[Task #{}] Process stopped with exit_code: {}, signaled: {}.",
               task_id, exit_code, signaled);
-  // Store exit info in meta. TASK_EXIT_STATUS is only enqueued after stdout and
-  // stderr are fully drained, so all output messages precede it.
-  absl::MutexLock lock(&m_mtx_);
-  auto& meta = m_fwd_meta_map[task_id];
-  meta.proc_stopped = true;
-  meta.exit_code = exit_code;
-  meta.signaled = signaled;
-  if (meta.output_stopped && meta.err_stopped) {
-    // Output and stderr already drained — safe to send EXIT_STATUS now.
-    m_task_fwd_req_queue_.enqueue(FwdRequest{
-        .type = StreamStepIORequest::TASK_EXIT_STATUS,
-        .data = TaskFinishStatus{.task_id = task_id,
-                                 .exit_code = exit_code,
-                                 .signaled = signaled},
-    });
-  }
-  return meta.output_stopped && meta.err_stopped;
+  m_process_stop_queue_.enqueue(ProcessStopQueueElem{.task_id = task_id,
+                                                     .exit_code = exit_code,
+                                                     .signaled = signaled});
+  m_process_stop_async_handle_->send();
 }
 
 void CforedClient::TaskEnd(task_id_t task_id) {

--- a/src/Craned/Supervisor/CforedClient.cpp
+++ b/src/Craned/Supervisor/CforedClient.cpp
@@ -21,7 +21,9 @@
 #include <cerrno>
 
 #include "TaskManager.h"
+#include "crane/GrpcHelper.h"
 #include "crane/String.h"
+
 namespace Craned::Supervisor {
 
 using crane::grpc::StreamStepIOReply;
@@ -491,10 +493,14 @@ void CforedClient::InitChannelAndStub(const std::string& cfored_name) {
   SetGrpcClientKeepAliveChannelArgs(&channel_args);
   // Todo: Use cfored listen config
   if (g_config.CforedListenConf.TlsConfig.Enabled) {
+    std::string cfored_fqdn = cfored_name;
+    const std::string& domain_suffix =
+        g_config.CforedListenConf.TlsConfig.DomainSuffix;
+    if (!domain_suffix.empty() && !cfored_fqdn.ends_with("." + domain_suffix))
+      cfored_fqdn += "." + domain_suffix;
     m_cfored_channel_ = CreateTcpTlsChannelByHostname(
-        cfored_name, kCforedDefaultPort,
-        g_config.CforedListenConf.TlsConfig.TlsCerts,
-        g_config.CforedListenConf.TlsConfig.DomainSuffix);
+        cfored_fqdn, kCforedDefaultPort,
+        g_config.CforedListenConf.TlsConfig.TlsCerts);
   } else {
     m_cfored_channel_ =
         CreateTcpInsecureChannel(cfored_name, kCforedDefaultPort);
@@ -746,7 +752,8 @@ void CforedClient::AsyncSendRecvThread_() {
               int(tag), ok);
           continue;
         }
-        CRANE_DEBUG("Cfored connection failed, wait reconnect...");
+        CRANE_DEBUG("Cfored connection failed, channel state: {}.",
+                    GrpcConnStateStr(m_cfored_channel_->GetState(false)));
         m_wait_reconn_ = true;
 
         // Close all active X11 proxy connections on disconnect

--- a/src/Craned/Supervisor/CforedClient.cpp
+++ b/src/Craned/Supervisor/CforedClient.cpp
@@ -281,6 +281,7 @@ void CforedClient::CleanStdoutFwdHandlerQueueCb_() {
           continue;
         }
         meta.out_handle.pipe = ph;
+        meta.stdout_read = -1;
 
         ph->on<uvw::data_event>(
             [this, task_id](uvw::data_event& e, uvw::pipe_handle&) {
@@ -294,9 +295,16 @@ void CforedClient::CleanStdoutFwdHandlerQueueCb_() {
           // EOF Received
           h.close();
           CRANE_INFO("[Task #{}] Output pipe received EOF.", tid);
-          auto& meta = this->m_fwd_meta_map.at(tid);
-          meta.output_stopped = true;
-          if (meta.err_stopped) on_finish();
+          bool should_finish = false;
+          {
+            absl::MutexLock lock(&m_mtx_);
+            auto it = m_fwd_meta_map.find(tid);
+            if (it != m_fwd_meta_map.end() && !it->second.output_stopped) {
+              it->second.output_stopped = true;
+              should_finish = it->second.err_stopped;
+            }
+          }
+          if (should_finish) on_finish();
         });
 
         ph->on<uvw::error_event>([this, tid = meta.task_id, on_finish](
@@ -304,9 +312,16 @@ void CforedClient::CleanStdoutFwdHandlerQueueCb_() {
           CRANE_WARN("[Task #{}] output pipe error: {}. Closing.", tid,
                      e.what());
           h.close();
-          auto& meta = this->m_fwd_meta_map.at(tid);
-          meta.output_stopped = true;
-          if (meta.err_stopped) on_finish();
+          bool should_finish = false;
+          {
+            absl::MutexLock lock(&m_mtx_);
+            auto it = m_fwd_meta_map.find(tid);
+            if (it != m_fwd_meta_map.end() && !it->second.output_stopped) {
+              it->second.output_stopped = true;
+              should_finish = it->second.err_stopped;
+            }
+          }
+          if (should_finish) on_finish();
         });
 
         ph->on<uvw::close_event>(
@@ -337,6 +352,7 @@ void CforedClient::CleanStdoutFwdHandlerQueueCb_() {
           continue;
         }
         meta.err_handle = err_ph;
+        meta.stderr_read = -1;
 
         err_ph->on<uvw::data_event>(
             [this](uvw::data_event& e, uvw::pipe_handle&) {
@@ -350,9 +366,16 @@ void CforedClient::CleanStdoutFwdHandlerQueueCb_() {
           CRANE_INFO("[Task #{}] Stderr pipe received EOF.", tid);
           // EOF Received
           h.close();
-          auto& meta = this->m_fwd_meta_map.at(tid);
-          meta.err_stopped = true;
-          if (meta.output_stopped) on_finish();
+          bool should_finish = false;
+          {
+            absl::MutexLock lock(&m_mtx_);
+            auto it = m_fwd_meta_map.find(tid);
+            if (it != m_fwd_meta_map.end() && !it->second.err_stopped) {
+              it->second.err_stopped = true;
+              should_finish = it->second.output_stopped;
+            }
+          }
+          if (should_finish) on_finish();
         });
 
         err_ph->on<uvw::error_event>(
@@ -361,9 +384,16 @@ void CforedClient::CleanStdoutFwdHandlerQueueCb_() {
               CRANE_WARN("[Task #{}] Stderr pipe error: {}. Closing.", tid,
                          e.what());
               h.close();
-              auto& meta = this->m_fwd_meta_map.at(tid);
-              meta.err_stopped = true;
-              if (meta.output_stopped) on_finish();
+              bool should_finish = false;
+              {
+                absl::MutexLock lock(&m_mtx_);
+                auto it = m_fwd_meta_map.find(tid);
+                if (it != m_fwd_meta_map.end() && !it->second.err_stopped) {
+                  it->second.err_stopped = true;
+                  should_finish = it->second.output_stopped;
+                }
+              }
+              if (should_finish) on_finish();
             });
 
         err_ph->on<uvw::close_event>(
@@ -388,6 +418,7 @@ void CforedClient::CleanStdoutFwdHandlerQueueCb_() {
         continue;
       }
       meta.out_handle.tty = th;
+      meta.stdout_read = -1;
 
       th->on<uvw::data_event>(
           [this, task_id](uvw::data_event& e, uvw::tty_handle&) {
@@ -396,17 +427,38 @@ void CforedClient::CleanStdoutFwdHandlerQueueCb_() {
             }
           });
 
-      th->on<uvw::end_event>([on_finish](uvw::end_event&, uvw::tty_handle& h) {
-        // The remote end is closed, go to EOF process.
-        h.close();
-        on_finish();
-      });
+      th->on<uvw::end_event>(
+          [this, task_id, on_finish](uvw::end_event&, uvw::tty_handle& h) {
+            // The remote end is closed, go to EOF process.
+            h.close();
+            bool should_finish = false;
+            {
+              absl::MutexLock lock(&m_mtx_);
+              auto it = m_fwd_meta_map.find(task_id);
+              if (it != m_fwd_meta_map.end() && !it->second.output_stopped) {
+                it->second.output_stopped = true;
+                it->second.input_stopped = true;
+                should_finish = true;
+              }
+            }
+            if (should_finish) on_finish();
+          });
 
-      th->on<uvw::error_event>([tid = meta.task_id, on_finish](
+      th->on<uvw::error_event>([this, tid = meta.task_id, on_finish](
                                    uvw::error_event& e, uvw::tty_handle& h) {
         CRANE_WARN("[Task #{}] pty read error: {}. Closing.", tid, e.what());
         h.close();
-        on_finish();
+        bool should_finish = false;
+        {
+          absl::MutexLock lock(&m_mtx_);
+          auto it = m_fwd_meta_map.find(tid);
+          if (it != m_fwd_meta_map.end() && !it->second.output_stopped) {
+            it->second.output_stopped = true;
+            it->second.input_stopped = true;
+            should_finish = true;
+          }
+        }
+        if (should_finish) on_finish();
       });
 
       th->on<uvw::close_event>(

--- a/src/Craned/Supervisor/CforedClient.cpp
+++ b/src/Craned/Supervisor/CforedClient.cpp
@@ -453,21 +453,24 @@ void CforedClient::CleanStopTaskIOQueueCb_() {
       if (!meta.pty && output_handle.pipe) output_handle.pipe->close();
       if (meta.pty && output_handle.tty) output_handle.tty->close();
       if (meta.err_handle) meta.err_handle->close();
+      // After uvw opens these fds, libuv owns their lifecycle. Closing the raw
+      // fd here can race with fd reuse while libuv still has pending epoll
+      // operations for the handle.
       output_handle.pipe.reset();
       output_handle.tty.reset();
       meta.err_handle.reset();
-
-      if (meta.stdout_read != -1) close(meta.stdout_read);
-      if (meta.stderr_read != -1) close(meta.stderr_read);
+      meta.stdout_read = -1;
+      meta.stderr_read = -1;
 
       CRANE_DEBUG("[Task #{}] Finished its output and err output.", task_id);
 
       auto& m = m_fwd_meta_map[task_id];
       ok_to_free = m.proc_stopped;
       if (ok_to_free) {
-        // Output fully drained and process already exited.
-        // Now it is safe to send TASK_EXIT_STATUS — all TASK_OUTPUT
-        // messages have already been enqueued before this point.
+        // Output and stderr fully drained and process already exited.
+        // Now it is safe to send TASK_EXIT_STATUS — all TASK_OUTPUT and
+        // TASK_ERR_OUTPUT messages have already been enqueued before this
+        // point.
         m_task_fwd_req_queue_.enqueue(FwdRequest{
             .type = StreamStepIORequest::TASK_EXIT_STATUS,
             .data = TaskFinishStatus{.task_id = task_id,
@@ -953,15 +956,15 @@ bool CforedClient::TaskProcessStop(task_id_t task_id, uint32_t exit_code,
                                    bool signaled) {
   CRANE_DEBUG("[Task #{}] Process stopped with exit_code: {}, signaled: {}.",
               task_id, exit_code, signaled);
-  // Store exit info in meta. TASK_EXIT_STATUS is only enqueued after
-  // output is fully drained, so that all TASK_OUTPUT messages precede it.
+  // Store exit info in meta. TASK_EXIT_STATUS is only enqueued after stdout and
+  // stderr are fully drained, so all output messages precede it.
   absl::MutexLock lock(&m_mtx_);
   auto& meta = m_fwd_meta_map[task_id];
   meta.proc_stopped = true;
   meta.exit_code = exit_code;
   meta.signaled = signaled;
-  if (meta.output_stopped) {
-    // Output already drained — safe to send EXIT_STATUS now.
+  if (meta.output_stopped && meta.err_stopped) {
+    // Output and stderr already drained — safe to send EXIT_STATUS now.
     m_task_fwd_req_queue_.enqueue(FwdRequest{
         .type = StreamStepIORequest::TASK_EXIT_STATUS,
         .data = TaskFinishStatus{.task_id = task_id,
@@ -969,7 +972,7 @@ bool CforedClient::TaskProcessStop(task_id_t task_id, uint32_t exit_code,
                                  .signaled = signaled},
     });
   }
-  return meta.output_stopped;
+  return meta.output_stopped && meta.err_stopped;
 }
 
 void CforedClient::TaskEnd(task_id_t task_id) {

--- a/src/Craned/Supervisor/CforedClient.h
+++ b/src/Craned/Supervisor/CforedClient.h
@@ -55,9 +55,12 @@ class CforedClient {
     bool err_stopped{false};
 
     bool proc_stopped{false};
+    bool stop_task_io_queued{false};
+    bool io_cleaned{false};
+    bool exit_status_sent{false};
 
-    // Deferred exit status: filled by TaskProcessStop(), sent after output
-    // drain to guarantee all TASK_OUTPUT precedes TASK_EXIT_STATUS.
+    // Deferred exit status: filled after SIGCHLD, sent after output drain to
+    // guarantee all TASK_OUTPUT precedes TASK_EXIT_STATUS.
     uint32_t exit_code{0};
     bool signaled{false};
   };
@@ -80,7 +83,7 @@ class CforedClient {
 
   uint16_t InitUvX11FwdHandler();
 
-  bool TaskProcessStop(task_id_t task_id, uint32_t exit_code, bool signaled);
+  void TaskProcessStop(task_id_t task_id, uint32_t exit_code, bool signaled);
   void TaskEnd(task_id_t task_id);
 
   const std::string& CforedName() const { return m_cfored_name_; }
@@ -114,6 +117,18 @@ class CforedClient {
   ConcurrentQueue<task_id_t> m_stop_task_io_queue_;
   std::shared_ptr<uvw::async_handle> m_clean_stop_task_io_queue_async_handle_;
   void CleanStopTaskIOQueueCb_();
+
+  struct ProcessStopQueueElem {
+    task_id_t task_id;
+    uint32_t exit_code;
+    bool signaled;
+  };
+  ConcurrentQueue<ProcessStopQueueElem> m_process_stop_queue_;
+  std::shared_ptr<uvw::async_handle> m_process_stop_async_handle_;
+  void ProcessStopQueueCb_();
+
+  bool QueueStopTaskIoIfReadyNoLock_(task_id_t task_id, TaskFwdMeta* meta)
+      ABSL_EXCLUSIVE_LOCKS_REQUIRED(m_mtx_);
 
   void AsyncSendRecvThread_();
 

--- a/src/Craned/Supervisor/TaskManager.cpp
+++ b/src/Craned/Supervisor/TaskManager.cpp
@@ -3204,12 +3204,8 @@ void TaskManager::EvCleanSigchldQueueCb_() {
       uint32_t exit_code = exit_info->value;
       if (exit_info->is_terminated_by_signal)
         exit_code += ExitCode::KCrunExitCodeStatusNum;
-      auto ok_to_free = m_step_.GetCforedClient()->TaskProcessStop(
+      m_step_.GetCforedClient()->TaskProcessStop(
           task_id, exit_code, exit_info.value().is_terminated_by_signal);
-      if (ok_to_free) {
-        CRANE_TRACE("It's ok to unregister task #{}", task_id);
-        m_step_.GetCforedClient()->TaskEnd(task_id);
-      }
     } else /* Batch / Calloc */ {
       FinalizeTaskAsync(task_id);
     }

--- a/src/Utilities/PublicHeader/GrpcHelper.cpp
+++ b/src/Utilities/PublicHeader/GrpcHelper.cpp
@@ -184,9 +184,8 @@ void SetGrpcClientKeepAliveChannelArgs(grpc::ChannelArguments* args) {
 }
 
 void SetTlsHostnameOverride(grpc::ChannelArguments* args,
-                            const std::string& hostname,
-                            const std::string& domain_suffix) {
-  args->SetSslTargetNameOverride(fmt::format("{}.{}", hostname, domain_suffix));
+                            const std::string& fqdn) {
+  args->SetSslTargetNameOverride(fqdn);
 }
 
 std::shared_ptr<grpc::Channel> CreateUnixInsecureChannel(
@@ -231,23 +230,22 @@ std::shared_ptr<grpc::Channel> CreateTcpTlsCustomChannelByIp(
 }
 
 std::shared_ptr<grpc::Channel> CreateTcpTlsChannelByHostname(
-    const std::string& hostname, const std::string& port,
-    const TlsCertificates& certs, const std::string& domain_suffix) {
+    const std::string& fqdn, const std::string& port,
+    const TlsCertificates& certs) {
   grpc::SslCredentialsOptions ssl_opts;
   SetSslCredOpts(&ssl_opts, certs);
 
-  std::string target = fmt::format("{}.{}:{}", hostname, domain_suffix, port);
+  std::string target = fmt::format("{}:{}", fqdn, port);
   return grpc::CreateChannel(target, grpc::SslCredentials(ssl_opts));
 }
 
 std::shared_ptr<grpc::Channel> CreateTcpTlsCustomChannelByHostname(
-    const std::string& hostname, const std::string& port,
-    const TlsCertificates& certs, const std::string& domain_suffix,
-    const grpc::ChannelArguments& args) {
+    const std::string& fqdn, const std::string& port,
+    const TlsCertificates& certs, const grpc::ChannelArguments& args) {
   grpc::SslCredentialsOptions ssl_opts;
   SetSslCredOpts(&ssl_opts, certs);
 
-  std::string target = fmt::format("{}.{}:{}", hostname, domain_suffix, port);
+  std::string target = fmt::format("{}:{}", fqdn, port);
   return grpc::CreateCustomChannel(target, grpc::SslCredentials(ssl_opts),
                                    args);
 }

--- a/src/Utilities/PublicHeader/include/crane/GrpcHelper.h
+++ b/src/Utilities/PublicHeader/include/crane/GrpcHelper.h
@@ -88,8 +88,7 @@ void ServerBuilderAddTcpTlsListeningPort(grpc::ServerBuilder* builder,
 void SetGrpcClientKeepAliveChannelArgs(grpc::ChannelArguments* args);
 
 void SetTlsHostnameOverride(grpc::ChannelArguments* args,
-                            const std::string& hostname,
-                            const std::string& domain_suffix);
+                            const std::string& fqdn);
 
 std::shared_ptr<grpc::Channel> CreateUnixInsecureChannel(
     const std::string& socket_addr);
@@ -106,10 +105,9 @@ std::shared_ptr<grpc::Channel> CreateTcpTlsCustomChannelByIp(
     const TlsCertificates& certs, const grpc::ChannelArguments& args);
 
 std::shared_ptr<grpc::Channel> CreateTcpTlsChannelByHostname(
-    const std::string& hostname, const std::string& port,
-    const TlsCertificates& certs, const std::string& domain_suffix);
+    const std::string& fqdn, const std::string& port,
+    const TlsCertificates& certs);
 
 std::shared_ptr<grpc::Channel> CreateTcpTlsCustomChannelByHostname(
-    const std::string& hostname, const std::string& port,
-    const TlsCertificates& certs, const std::string& domain_suffix,
-    const grpc::ChannelArguments& args);
+    const std::string& fqdn, const std::string& port,
+    const TlsCertificates& certs, const grpc::ChannelArguments& args);


### PR DESCRIPTION
## Summary
- make TLS hostname helper parameters explicitly represent FQDNs
- stop appending a domain suffix inside the cfored TLS channel helper path
- log the gRPC channel state when the cfored stream connection fails

## Tests
- `git diff HEAD^..HEAD --check`
- `systemd-run --scope -p MemoryMax=15G ninja -C /work/CraneSched/cmake-build-debug -j2 csupervisor`
- `systemd-run --scope -p MemoryMax=15G ninja -C /work/CraneSched/cmake-build-debug -j2 craned cranectld`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved TLS connectivity by consistently using fully qualified hostnames.
  * Prevented duplicate domain suffixes in service hostnames.
  * Improved connection-failure diagnostics with gRPC channel state details.
  * Ensured task completion status is reported only after both output streams finish draining.
* **Refactor**
  * Simplified TLS hostname configuration for more consistent service connectivity.
  * Improved task I/O cleanup during process completion.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->