### PR TITLE
fix: restore PTY terminal lifecycle and resize

### DIFF
--- a/protos/Crane.proto
+++ b/protos/Crane.proto
@@ -1003,6 +1003,7 @@ message StreamCrunRequest {
     STEP_COMPLETION_REQUEST = 1;
     TASK_IO_FORWARD = 2;
     STEP_X11_FORWARD = 3;
+    TERMINAL_RESIZE = 5;
   }
 
   message JobReq {
@@ -1032,6 +1033,11 @@ message StreamCrunRequest {
     string craned_id = 4;
   }
 
+  message TerminalResizeReq {
+    TerminalSize terminal_size = 1;
+    uint32 task_id = 2;
+  }
+
   CrunRequestType type = 1;
 
   oneof payload {
@@ -1040,6 +1046,7 @@ message StreamCrunRequest {
     StepCompleteReq payload_step_complete_req = 3;
     TaskIOForwardReq payload_task_io_forward_req = 4;
     StepX11ForwardReq payload_step_x11_forward_req = 5;
+    TerminalResizeReq payload_terminal_resize_req = 7;
   }
 }
 
@@ -1229,6 +1236,7 @@ message StreamStepIORequest {
     string craned_id = 1;
     uint32 job_id = 2;
     uint32 step_id = 3;
+    bool supports_terminal_resize = 4;
   }
 
   message TaskOutputReq {
@@ -1284,6 +1292,7 @@ message StreamStepIOReply {
     TASK_INPUT = 1;
     SUPERVISOR_UNREGISTER_REPLY = 2;
     STEP_X11_INPUT = 3;
+    TERMINAL_RESIZE = 4;
   }
 
   message SupervisorRegisterReply {
@@ -1306,6 +1315,11 @@ message StreamStepIOReply {
     uint32 local_id = 3;
   }
 
+  message TerminalResizeReq {
+    TerminalSize terminal_size = 1;
+    uint32 task_id = 2;
+  }
+
   SupervisorReplyType type = 1;
 
   oneof payload {
@@ -1313,6 +1327,7 @@ message StreamStepIOReply {
     TaskInputReq payload_task_input_req = 3;
     SupervisorUnregisterReply payload_supervisor_unregister_reply = 4;
     StepX11InputReq payload_step_x11_input_req = 5;
+    TerminalResizeReq payload_terminal_resize_req = 6;
   }
 }
 

--- a/protos/PublicDefs.proto
+++ b/protos/PublicDefs.proto
@@ -515,6 +515,11 @@ message X11Meta {
   bool enable_forwarding = 4;
 }
 
+message TerminalSize {
+  uint32 rows = 1;
+  uint32 columns = 2;
+}
+
 message InteractiveJobAdditionalMeta {
   string cfored_name = 1;
   string term_env = 3;
@@ -529,6 +534,8 @@ message InteractiveJobAdditionalMeta {
   optional uint32 input_task_id = 8;
 
   string mpi = 9;
+
+  TerminalSize terminal_size = 10;
 }
 
 message PodJobAdditionalMeta {

--- a/src/Craned/Supervisor/CforedClient.cpp
+++ b/src/Craned/Supervisor/CforedClient.cpp
@@ -18,11 +18,26 @@
 
 #include "CforedClient.h"
 
+#include <poll.h>
+#include <sys/ioctl.h>
+
+#include <atomic>
 #include <cerrno>
+#include <limits>
 
 #include "TaskManager.h"
 #include "crane/String.h"
 namespace Craned::Supervisor {
+
+namespace {
+constexpr uint32_t kTerminalResizeDiagnosticLimit = 8;
+
+bool ShouldLogTerminalResizeDiagnostic() {
+  static std::atomic_uint32_t count{0};
+  return count.fetch_add(1, std::memory_order_relaxed) <
+         kTerminalResizeDiagnosticLimit;
+}
+}  // namespace
 
 using crane::grpc::StreamStepIOReply;
 using crane::grpc::StreamStepIORequest;
@@ -221,15 +236,30 @@ uint16_t CforedClient::SetupX11forwarding_() {
 
 bool CforedClient::WriteStringToFd_(const std::string& msg, int fd,
                                     bool close_fd) {
-  ssize_t sz_sent = 0, sz_written;
-  while (sz_sent != msg.size()) {
-    sz_written = write(fd, msg.c_str() + sz_sent, msg.size() - sz_sent);
-    if (sz_written < 0) {
-      CRANE_ERROR("Pipe to Crun task was broken.");
+  size_t sz_sent = 0;
+  while (sz_sent < msg.size()) {
+    const ssize_t sz_written =
+        write(fd, msg.data() + sz_sent, msg.size() - sz_sent);
+    if (sz_written > 0) {
+      sz_sent += static_cast<size_t>(sz_written);
+      continue;
+    }
+    if (sz_written < 0 && errno == EINTR) continue;
+    if (sz_written < 0 && (errno == EAGAIN || errno == EWOULDBLOCK)) {
+      struct pollfd poll_fd{.fd = fd, .events = POLLOUT, .revents = 0};
+      int poll_result;
+      do {
+        poll_result = poll(&poll_fd, 1, 1000);
+      } while (poll_result < 0 && errno == EINTR);
+      if (poll_result > 0 && (poll_fd.revents & POLLOUT) != 0) continue;
+      CRANE_WARN("Timed out waiting for task input fd {} to become writable.",
+                 fd);
       return false;
     }
 
-    sz_sent += sz_written;
+    CRANE_ERROR("Failed to write task input to fd {}: {}", fd,
+                sz_written == 0 ? "zero-byte write" : strerror(errno));
+    return false;
   }
   if (close_fd) close(fd);
   return true;
@@ -833,6 +863,8 @@ void CforedClient::AsyncSendRecvThread_() {
             g_config.CranedIdOfThisNode);
         request.mutable_payload_register_req()->set_job_id(g_config.JobId);
         request.mutable_payload_register_req()->set_step_id(g_config.StepId);
+        request.mutable_payload_register_req()->set_supports_terminal_resize(
+            true);
 
         write_pending.store(true, std::memory_order::release);
         stream->Write(request, (void*)Tag::Write);
@@ -877,6 +909,57 @@ void CforedClient::AsyncSendRecvThread_() {
         }
 
         CRANE_ASSERT(tag == Tag::Read);
+
+        if (reply.type() == StreamStepIOReply::TERMINAL_RESIZE) {
+          const auto& resize = reply.payload_terminal_resize_req();
+          const auto& size = resize.terminal_size();
+          const bool valid_size =
+              size.rows() > 0 &&
+              size.rows() <= std::numeric_limits<uint16_t>::max() &&
+              size.columns() > 0 &&
+              size.columns() <= std::numeric_limits<uint16_t>::max();
+          if (!valid_size) {
+            if (ShouldLogTerminalResizeDiagnostic()) {
+              CRANE_WARN("Ignoring invalid terminal resize {}x{} for task #{}.",
+                         size.rows(), size.columns(), resize.task_id());
+            }
+          } else {
+            absl::MutexLock lock(&m_mtx_);
+            auto meta_it = m_fwd_meta_map.find(resize.task_id());
+            if (meta_it == m_fwd_meta_map.end()) {
+              if (ShouldLogTerminalResizeDiagnostic()) {
+                CRANE_WARN("Ignoring terminal resize for unknown task #{}.",
+                           resize.task_id());
+              }
+            } else if (!meta_it->second.pty ||
+                       meta_it->second.stdin_write == -1) {
+              if (ShouldLogTerminalResizeDiagnostic()) {
+                CRANE_WARN("Ignoring terminal resize for non-PTY task #{}.",
+                           resize.task_id());
+              }
+            } else {
+              struct winsize terminal_size{
+                  .ws_row = static_cast<uint16_t>(size.rows()),
+                  .ws_col = static_cast<uint16_t>(size.columns()),
+                  .ws_xpixel = 0,
+                  .ws_ypixel = 0,
+              };
+              if (ioctl(meta_it->second.stdin_write, TIOCSWINSZ,
+                        &terminal_size) == -1) {
+                if (ShouldLogTerminalResizeDiagnostic()) {
+                  CRANE_WARN("Failed to resize PTY for task #{} to {}x{}: {}",
+                             resize.task_id(), size.rows(), size.columns(),
+                             strerror(errno));
+                }
+              }
+            }
+          }
+
+          reply.Clear();
+          stream->Read(&reply, (void*)Tag::Read);
+          break;
+        }
+
         const std::string* msg;
 
         if (reply.type() == StreamStepIOReply::STEP_X11_INPUT) {
@@ -888,8 +971,10 @@ void CforedClient::AsyncSendRecvThread_() {
           CRANE_TRACE("TASK_INPUT len:{} EOF:{}.", msg->length(),
                       reply.payload_task_input_req().eof());
         } else [[unlikely]] {
-          CRANE_ERROR("Expect TASK_INPUT or STEP_X11_INPUT, but got {}",
-                      (int)reply.type());
+          CRANE_ERROR(
+              "Expect TASK_INPUT, STEP_X11_INPUT or TERMINAL_RESIZE, but got "
+              "{}",
+              (int)reply.type());
           break;
         }
 

--- a/src/Craned/Supervisor/TaskManager.cpp
+++ b/src/Craned/Supervisor/TaskManager.cpp
@@ -21,9 +21,11 @@
 #include <google/protobuf/util/delimited_message_util.h>
 #include <grp.h>
 #include <pty.h>
+#include <sys/ioctl.h>
 #include <sys/types.h>
 #include <sys/wait.h>
 
+#include <atomic>
 #include <iterator>
 #include <limits>
 #include <variant>
@@ -44,6 +46,16 @@
 #include "crane/Tracing.h"
 
 namespace Craned::Supervisor {
+namespace {
+constexpr uint32_t kInitialTerminalSizeDiagnosticLimit = 8;
+
+bool ShouldLogInitialTerminalSizeDiagnostic() {
+  static std::atomic_uint32_t count{0};
+  return count.fetch_add(1, std::memory_order_relaxed) <
+         kInitialTerminalSizeDiagnosticLimit;
+}
+}  // namespace
+
 using namespace std::chrono_literals;
 using Common::CgroupManager;
 using Common::kStepRequestCheckIntervalMs;
@@ -799,7 +811,28 @@ CraneExpected<pid_t> ProcInstance::ForkCrunAndInitIOfd_() {
     return std::unexpected(CraneErrCode::ERR_INVALID_PARAM);
   }
   if (m_parent_step_inst_->pty) {
-    pid = forkpty(&crun_pty_fd, nullptr, nullptr, nullptr);
+    struct winsize terminal_size{};
+    struct winsize* terminal_size_ptr = nullptr;
+    if (GetParentStep().has_interactive_meta() &&
+        GetParentStep().interactive_meta().has_terminal_size()) {
+      const auto& requested_size =
+          GetParentStep().interactive_meta().terminal_size();
+      if (requested_size.rows() > 0 &&
+          requested_size.rows() <= std::numeric_limits<uint16_t>::max() &&
+          requested_size.columns() > 0 &&
+          requested_size.columns() <= std::numeric_limits<uint16_t>::max()) {
+        terminal_size.ws_row = static_cast<uint16_t>(requested_size.rows());
+        terminal_size.ws_col = static_cast<uint16_t>(requested_size.columns());
+        terminal_size_ptr = &terminal_size;
+      } else {
+        if (ShouldLogInitialTerminalSizeDiagnostic()) {
+          CRANE_WARN("[Task #{}] Ignoring invalid initial terminal size {}x{}.",
+                     task_id, requested_size.rows(), requested_size.columns());
+        }
+      }
+    }
+
+    pid = forkpty(&crun_pty_fd, nullptr, nullptr, terminal_size_ptr);
 
     if (pid > 0) {
       meta->stdin_read = -1;


### PR DESCRIPTION
## Summary
- propagate initial PTY dimensions through the Backend/FrontEnd protocol
- forward coalesced SIGWINCH updates through a single gRPC sender
- restore terminal state and handle partial PTY input writes safely

## Verification
- Backend csupervisor build passed with Lua/BPF disabled due host toolchain limitations
- FrontEnd go test -race ./... passed
- no live cluster or PuTTY validation in this first stage

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Interactive terminal sessions now support resizing while tasks are running.
  - Terminal dimensions can be specified when starting interactive jobs and updated during execution.
  - Resize information is shared across supported streaming and supervisory connections.

- **Bug Fixes**
  - Improved handling of terminal input under partial writes, interruptions, and temporary unavailability.
  - Invalid terminal dimensions are rejected safely with clearer diagnostics.
  - Resize requests are validated to ensure they target active, writable terminal sessions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->