### PR TITLE
fix: preserve Epilog environment variables

### DIFF
--- a/src/Craned/Core/JobManager.cpp
+++ b/src/Craned/Core/JobManager.cpp
@@ -1541,9 +1541,11 @@ void JobManager::CleanUpJobEnvironment_(job_id_t job_id,
       script_lock = true;
     }
     CRANE_TRACE("[Job #{}] Running epilogs...", job_id);
+    auto epilog_env = std::move(ctx.epilog_env);
+    epilog_env.insert_or_assign("CRANE_SCRIPT_CONTEXT", "epilog");
     RunPrologEpilogArgs run_epilog_args{
         .scripts = g_config.JobLifecycleHook.Epilogs,
-        .envs = ctx.epilog_env,
+        .envs = std::move(epilog_env),
         .timeout_sec = g_config.JobLifecycleHook.EpilogTimeout,
         .run_uid = 0,
         .run_gid = 0,

--- a/src/Craned/Supervisor/TaskManager.cpp
+++ b/src/Craned/Supervisor/TaskManager.cpp
@@ -293,21 +293,21 @@ EnvMap StepInstance::GetTaskEpilogEnv(task_id_t task_id) const {
   // Keep task identifiers consistent with the environment used by task
   // processes. This environment is constructed in the supervisor parent,
   // because the task's private m_env_ is initialized only after fork().
-  env_map.emplace("CRANE_PROCID", std::to_string(task_id));
-  env_map.emplace("CRANE_PROC_ID", std::to_string(task_id));
+  env_map.insert_or_assign("CRANE_PROCID", std::to_string(task_id));
+  env_map.insert_or_assign("CRANE_PROC_ID", std::to_string(task_id));
   if (g_config.EnableSlurmCompatibleEnv) {
-    env_map.emplace("SLURM_PROCID", std::to_string(task_id));
+    env_map.insert_or_assign("SLURM_PROCID", std::to_string(task_id));
 
     task_id_t local_task_id = 0;
     const auto& task_node_list = m_step_to_supv_.task_node_list();
-    for (uint32_t index = 0; index < task_node_list.size(); ++index) {
+    for (size_t index = 0; index < task_node_list.size() && index < task_id;
+         ++index) {
       if (m_step_to_supv_.nodelist(task_node_list[index]) ==
           g_config.CranedIdOfThisNode) {
-        local_task_id = task_id - index;
-        break;
+        ++local_task_id;
       }
     }
-    env_map.emplace("SLURM_LOCALID", std::to_string(local_task_id));
+    env_map.insert_or_assign("SLURM_LOCALID", std::to_string(local_task_id));
   }
 
   env_map.insert_or_assign("CRANE_SCRIPT_CONTEXT", "task_epilog");
@@ -487,20 +487,20 @@ void ITaskInstance::InitEnvMap() {
   }
   if (g_config.EnableSlurmCompatibleEnv) {
     // Global task id
-    m_env_.emplace("SLURM_PROCID", std::to_string(task_id));
+    m_env_.insert_or_assign("SLURM_PROCID", std::to_string(task_id));
     // Local task id task_node_list()
     task_id_t local_task_id = 0;
     const auto& task_node_list =
         m_parent_step_inst_->GetStep().task_node_list();
-    for (uint32_t index = 0; index < task_node_list.size(); index++) {
+    for (size_t index = 0; index < task_node_list.size() && index < task_id;
+         ++index) {
       const std::string& hostname =
           m_parent_step_inst_->GetStep().nodelist(task_node_list[index]);
       if (hostname == g_config.CranedIdOfThisNode) {
-        local_task_id = task_id - index;
-        break;
+        ++local_task_id;
       }
     }
-    m_env_.emplace("SLURM_LOCALID", std::to_string(local_task_id));
+    m_env_.insert_or_assign("SLURM_LOCALID", std::to_string(local_task_id));
   }
 }
 
@@ -529,8 +529,8 @@ void ProcInstance::InitEnvMap() {
       m_env_["XAUTHORITY"] = m_parent_step_inst_->x11_meta->x11_auth_path;
     }
   }
-  m_env_.emplace("CRANE_PROCID", std::to_string(task_id));
-  m_env_.emplace("CRANE_PROC_ID", std::to_string(task_id));
+  m_env_.insert_or_assign("CRANE_PROCID", std::to_string(task_id));
+  m_env_.insert_or_assign("CRANE_PROC_ID", std::to_string(task_id));
 
   if (m_parent_step_inst_->IsCrun() &&
       m_parent_step_inst_->GetStep().interactive_meta().mpi() == kMpiTypePmix) {

--- a/src/Craned/Supervisor/TaskManager.cpp
+++ b/src/Craned/Supervisor/TaskManager.cpp
@@ -287,6 +287,40 @@ EnvMap StepInstance::GetStepProcessEnv() const {
   return env_map;
 }
 
+EnvMap StepInstance::GetTaskEpilogEnv(task_id_t task_id) const {
+  auto env_map = GetStepProcessEnv();
+
+  // Keep task identifiers consistent with the environment used by task
+  // processes. This environment is constructed in the supervisor parent,
+  // because the task's private m_env_ is initialized only after fork().
+  env_map.emplace("CRANE_PROCID", std::to_string(task_id));
+  env_map.emplace("CRANE_PROC_ID", std::to_string(task_id));
+  if (g_config.EnableSlurmCompatibleEnv) {
+    env_map.emplace("SLURM_PROCID", std::to_string(task_id));
+
+    task_id_t local_task_id = 0;
+    const auto& task_node_list = m_step_to_supv_.task_node_list();
+    for (uint32_t index = 0; index < task_node_list.size(); ++index) {
+      if (m_step_to_supv_.nodelist(task_node_list[index]) ==
+          g_config.CranedIdOfThisNode) {
+        local_task_id = task_id - index;
+        break;
+      }
+    }
+    env_map.emplace("SLURM_LOCALID", std::to_string(local_task_id));
+  }
+
+  env_map.insert_or_assign("CRANE_SCRIPT_CONTEXT", "task_epilog");
+  if (pwd.Valid()) {
+    // RunPrologOrEpiLog uses an explicit environment and does not inherit
+    // USER/LOGNAME from the supervisor's ambient environment.
+    env_map.insert_or_assign("USER", pwd.Username());
+    env_map.insert_or_assign("LOGNAME", pwd.Username());
+  }
+
+  return env_map;
+}
+
 void StepInstance::GotNewStatus(StepStatus new_status) {
   if (IsFinishedStepStatus(new_status)) {
     if (m_status_ == new_status) return;
@@ -2750,9 +2784,11 @@ TaskManager::~TaskManager() {
     epilog_span.SetAttribute("job_id", m_step_.job_id);
     epilog_span.SetAttribute("step_id", m_step_.step_id);
 
+    auto epilog_env = g_config.JobEnv;
+    epilog_env.insert_or_assign("CRANE_SCRIPT_CONTEXT", "epilog");
     RunPrologEpilogArgs run_epilog_args{
         .scripts = g_config.JobLifecycleHook.Epilogs,
-        .envs = g_config.JobEnv,
+        .envs = std::move(epilog_env),
         .timeout_sec = g_config.JobLifecycleHook.EpilogTimeout,
         .run_uid = 0,
         .run_gid = 0,
@@ -3330,8 +3366,7 @@ void TaskManager::EvCleanFinalizingTaskQueueCb_() {
 
       RunPrologEpilogArgs run_epilog_args{
           .scripts = std::vector<std::string>{m_step_.GetStep().task_epilog()},
-          .envs = std::unordered_map{task->GetParentStep().env().begin(),
-                                     task->GetParentStep().env().end()},
+          .envs = m_step_.GetTaskEpilogEnv(task_id),
           .timeout_sec = g_config.JobLifecycleHook.EpilogTimeout,
           .run_uid = task->GetParentStep().uid(),
           .run_gid = task->GetParentStep().gid()[0],
@@ -3361,8 +3396,7 @@ void TaskManager::EvCleanFinalizingTaskQueueCb_() {
 
       RunPrologEpilogArgs run_epilog_args{
           .scripts = g_config.JobLifecycleHook.TaskEpilogs,
-          .envs = std::unordered_map{task->GetParentStep().env().begin(),
-                                     task->GetParentStep().env().end()},
+          .envs = m_step_.GetTaskEpilogEnv(task_id),
           .timeout_sec = g_config.JobLifecycleHook.EpilogTimeout,
           .run_uid = task->GetParentStep().uid(),
           .run_gid = task->GetParentStep().gid()[0],

--- a/src/Craned/Supervisor/TaskManager.h
+++ b/src/Craned/Supervisor/TaskManager.h
@@ -220,6 +220,11 @@ class StepInstance {
 
   EnvMap GetStepProcessEnv() const;
 
+  // Build the environment visible to a task epilog in the supervisor parent.
+  // Task processes initialize their private environment after fork, so it
+  // cannot be read back when the task exits.
+  EnvMap GetTaskEpilogEnv(task_id_t task_id) const;
+
   void GotNewStatus(StepStatus new_status);
 
   // OOM monitoring methods

--- a/src/Utilities/PublicHeader/OS.cpp
+++ b/src/Utilities/PublicHeader/OS.cpp
@@ -580,6 +580,7 @@ std::expected<std::string, RunPrologEpilogStatus> RunPrologOrEpiLog(
 
     std::vector<char*> envp;
     std::vector<std::string> env_storage;
+    env_storage.reserve(args.envs.size());
     envp.reserve(args.envs.size() + 1);
     for (const auto& [name, value] : args.envs) {
       env_storage.emplace_back(name + "=" + value);


### PR DESCRIPTION
## Summary
- reserve environment storage before building exec pointers
- construct Epilog environments in the supervisor parent
- pass job, step, task, Slurm-compatible, context, and user identity variables to TaskEpilog
- leave Prolog invocation paths unchanged

## Verification
- clang 21 CMake build: craned and csupervisor
- local K3s Debug CraneTestRun reached Retained and cluster verifier succeeded
- submitted two jobs and inspected node Epilog/TaskEpilog environment output

## Notes
- the temporary validation runtime was derived from the existing issue3-s6-final image and cleaned after verification

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Improved epilog execution with task-specific environment variables.
  - Added context identifying epilog scripts and their associated tasks.
  - Epilog environments now include relevant Crane, Slurm, node, and user identity variables.

- **Bug Fixes**
  - Corrected supervisor and task epilogs to use the appropriate task environment.
  - Improved task identifier handling for local Slurm tasks.

- **Performance**
  - Streamlined environment preparation when launching child processes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->