### PR TITLE
feat: expose GRES fields to Lua job submit hook

### DIFF
--- a/docs/en/deployment/configuration/lua_guide.md
+++ b/docs/en/deployment/configuration/lua_guide.md
@@ -127,6 +127,8 @@ Same as the return values of `crane_job_submit`.
 | req_node_res_view         | ResourceView | Requested resource per node              |
 | req_task_res_view         | ResourceView | Requested resource per task              |
 | req_total_res_view        | ResourceView | Total requested resource information     |
+| gres                      | table(map), read-only | Alias for `tres_per_node`; Crane's per-node GRES map |
+| tres_per_node              | table(map), read-only | Crane's per-node GRES map |
 | type                      | number  | Job type                                      |
 | uid                       | number  | UID of the job owner                          |
 | gid                       | number  | GID of the job owner                          |
@@ -150,6 +152,19 @@ Same as the return values of `crane_job_submit`.
 | begin_time                | number  | Job start time                                |
 | exclusive                 | boolean | Whether to run in exclusive node mode         |
 | licenses_count            | table(map) | License information                        |
+
+`gres` and `tres_per_node` use the same `device_map` shape as
+`ResourceView.device_map`:
+
+```lua
+local gpu = job_desc.gres.gpu
+if gpu ~= nil then
+    crane.log_info("requested GPUs: %d", gpu.total_count)
+end
+```
+
+The two fields are read-only aliases of the GRES data in
+`job_desc.req_node_res_view.device_map`.
 
 
 ---

--- a/docs/zh/deployment/configuration/lua_guide.md
+++ b/docs/zh/deployment/configuration/lua_guide.md
@@ -110,6 +110,8 @@ function crane_job_modify(job_desc, job_ptr, part_list, uid)
 | req_node_res_view       | ResourceView | 单节点需求资源信息  | 
 | req_task_res_view       | ResourceView | 单task需求资源信息 |
 | req_total_res_view      | ResourceView | 总需求资源信息     |
+| gres                    | table(map)，只读 | `tres_per_node` 的别名，鹤思的每节点 GRES 映射 |
+| tres_per_node           | table(map)，只读 | 鹤思的每节点 GRES 映射 |
 | type                    | number  | 作业类型         |
 | uid                     | number  | 作业所属uid      |
 | gid                     | number  | 作业所属gid      |
@@ -133,6 +135,17 @@ function crane_job_modify(job_desc, job_ptr, part_list, uid)
 | begin_time              | number  | 作业开始时间       |
 | exclusive               | boolean | 是否独占节点       |
 | licenses_count          | table(map) | 许可证信息     |
+
+`gres` 和 `tres_per_node` 使用与 `ResourceView.device_map` 相同的结构：
+
+```lua
+local gpu = job_desc.gres.gpu
+if gpu ~= nil then
+    crane.log_info("requested GPUs: %d", gpu.total_count)
+end
+```
+
+这两个字段是 `job_desc.req_node_res_view.device_map` 中 GRES 数据的只读别名。
 
 #### part_list
 该用户有权限使用的分区列表。

--- a/src/CraneCtld/CMakeLists.txt
+++ b/src/CraneCtld/CMakeLists.txt
@@ -115,3 +115,7 @@ endif ()
 if (CMAKE_CXX_COMPILER_ID STREQUAL "Clang")
     target_link_libraries(cranectld PRIVATE stdc++fs)
 endif ()
+
+if (${LUA_FOUND})
+    target_include_directories(cranectld PRIVATE ${LUA_INCLUDE_DIR})
+endif ()

--- a/src/CraneCtld/Lua/LuaJobHandler.cpp
+++ b/src/CraneCtld/Lua/LuaJobHandler.cpp
@@ -28,6 +28,21 @@ namespace Ctld {
 
 const std::vector<std::string> LuaJobHandler::kReqFxns = {"crane_job_submit",
                                                           "crane_job_modify"};
+
+sol::table LuaJobHandler::GresMapToLuaTable_(
+    const crane::LuaEnvironment& lua_env, const GresMap& gres_map) {
+  sol::table result = lua_env.GetLuaState().create_table();
+  for (const auto& [name, count] : gres_map) {
+    sol::table entry = lua_env.GetLuaState().create_table();
+    entry["total_count"] = count.total;
+
+    sol::table typed = lua_env.GetLuaState().create_table();
+    for (const auto& [type, value] : count.specified) typed[type] = value;
+    entry["typed"] = typed;
+    result[name] = entry;
+  }
+  return result;
+}
 #endif
 
 CraneRichError LuaJobHandler::JobSubmit(const std::string& lua_script,
@@ -193,19 +208,7 @@ void LuaJobHandler::RegisterTypes_(const crane::LuaEnvironment& lua_env) {
     }),
     "device_map", sol::property(
       [&](const ResourceView& rv) {
-        sol::table tbl = lua_env.GetLuaState().create_table();
-        for (const auto& [gres_name, gres_count] : rv.GetGresMap()) {
-          sol::table entry = lua_env.GetLuaState().create_table();
-          entry["total_count"] = gres_count.total;
-
-          sol::table typed = lua_env.GetLuaState().create_table();
-          for (const auto& [typed_name, typed_count] : gres_count.specified) {
-            typed[typed_name] = typed_count;
-          }
-          entry["typed"] = typed;
-          tbl[gres_name] = entry;
-        }
-        return tbl;
+        return LuaJobHandler::GresMapToLuaTable_(lua_env, rv.GetGresMap());
       })
   );
 
@@ -220,6 +223,16 @@ void LuaJobHandler::RegisterTypes_(const crane::LuaEnvironment& lua_env) {
     "req_node_res_view", &JobInCtld::req_node_res_view,
     "req_task_res_view", &JobInCtld::req_task_res_view,
     "req_total_res_view", &JobInCtld::req_total_res_view,
+    "gres", sol::property(
+        [&](const JobInCtld& t) {
+          return LuaJobHandler::GresMapToLuaTable_(
+              lua_env, t.req_node_res_view.GetGresMap());
+        }),
+    "tres_per_node", sol::property(
+        [&](const JobInCtld& t) {
+          return LuaJobHandler::GresMapToLuaTable_(
+              lua_env, t.req_node_res_view.GetGresMap());
+        }),
     "type", &JobInCtld::type, "uid", &JobInCtld::uid,
     "gid", &JobInCtld::gid, "account", &JobInCtld::account,
     "name", &JobInCtld::name, "qos", &JobInCtld::qos,

--- a/src/CraneCtld/Lua/LuaJobHandler.h
+++ b/src/CraneCtld/Lua/LuaJobHandler.h
@@ -45,6 +45,9 @@ class LuaJobHandler {
 #ifdef HAVE_LUA
   static const std::vector<std::string> kReqFxns;
 
+  static sol::table GresMapToLuaTable_(const crane::LuaEnvironment& lua_env,
+                                       const GresMap& gres_map);
+
   static void RegisterGlobalFunctions_(const crane::LuaEnvironment& lua_env);
   static void RegisterTypes_(const crane::LuaEnvironment& lua_env);
   static void RegisterGlobalVariables_(const crane::LuaEnvironment& lua_env);


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Lua job descriptions now provide read-only `gres` and `tres_per_node` attributes.
  * Added documentation and examples showing how to access per-node resource and GPU information.
  * Resource maps are presented consistently with total and typed resource counts in Lua.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->