### PR TITLE
fix: serialize crun process stop finalization

### DIFF
--- a/src/Craned/Supervisor/CforedClient.cpp
+++ b/src/Craned/Supervisor/CforedClient.cpp
@@ -66,6 +66,12 @@ CforedClient::CforedClient() {
         CleanStopTaskIOQueueCb_();
       });
 
+  m_process_stop_async_handle_ = m_loop_->resource<uvw::async_handle>();
+  m_process_stop_async_handle_->on<uvw::async_event>(
+      [this](const uvw::async_event&, uvw::async_handle&) {
+        ProcessStopQueueCb_();
+      });
+
   std::shared_ptr<uvw::idle_handle> idle_handle =
       m_loop_->resource<uvw::idle_handle>();
 
@@ -329,7 +335,7 @@ void CforedClient::CleanStdoutFwdHandlerQueueCb_() {
             auto it = m_fwd_meta_map.find(tid);
             if (it != m_fwd_meta_map.end() && !it->second.output_stopped) {
               it->second.output_stopped = true;
-              should_finish = it->second.err_stopped;
+              should_finish = QueueStopTaskIoIfReadyNoLock_(tid, &it->second);
             }
           }
           if (should_finish) on_finish();
@@ -346,7 +352,7 @@ void CforedClient::CleanStdoutFwdHandlerQueueCb_() {
             auto it = m_fwd_meta_map.find(tid);
             if (it != m_fwd_meta_map.end() && !it->second.output_stopped) {
               it->second.output_stopped = true;
-              should_finish = it->second.err_stopped;
+              should_finish = QueueStopTaskIoIfReadyNoLock_(tid, &it->second);
             }
           }
           if (should_finish) on_finish();
@@ -400,29 +406,29 @@ void CforedClient::CleanStdoutFwdHandlerQueueCb_() {
             auto it = m_fwd_meta_map.find(tid);
             if (it != m_fwd_meta_map.end() && !it->second.err_stopped) {
               it->second.err_stopped = true;
-              should_finish = it->second.output_stopped;
+              should_finish = QueueStopTaskIoIfReadyNoLock_(tid, &it->second);
             }
           }
           if (should_finish) on_finish();
         });
 
-        err_ph->on<uvw::error_event>(
-            [this, tid = meta.task_id, on_finish](uvw::error_event& e,
-                                                  uvw::pipe_handle& h) {
-              CRANE_WARN("[Task #{}] Stderr pipe error: {}. Closing.", tid,
-                         e.what());
-              h.close();
-              bool should_finish = false;
-              {
-                absl::MutexLock lock(&m_mtx_);
-                auto it = m_fwd_meta_map.find(tid);
-                if (it != m_fwd_meta_map.end() && !it->second.err_stopped) {
-                  it->second.err_stopped = true;
-                  should_finish = it->second.output_stopped;
-                }
-              }
-              if (should_finish) on_finish();
-            });
+        err_ph->on<uvw::error_event>([this, tid = meta.task_id, on_finish](
+                                         uvw::error_event& e,
+                                         uvw::pipe_handle& h) {
+          CRANE_WARN("[Task #{}] Stderr pipe error: {}. Closing.", tid,
+                     e.what());
+          h.close();
+          bool should_finish = false;
+          {
+            absl::MutexLock lock(&m_mtx_);
+            auto it = m_fwd_meta_map.find(tid);
+            if (it != m_fwd_meta_map.end() && !it->second.err_stopped) {
+              it->second.err_stopped = true;
+              should_finish = QueueStopTaskIoIfReadyNoLock_(tid, &it->second);
+            }
+          }
+          if (should_finish) on_finish();
+        });
 
         err_ph->on<uvw::close_event>(
             [tid = meta.task_id](uvw::close_event&, uvw::pipe_handle&) {
@@ -455,22 +461,22 @@ void CforedClient::CleanStdoutFwdHandlerQueueCb_() {
             }
           });
 
-      th->on<uvw::end_event>(
-          [this, task_id, on_finish](uvw::end_event&, uvw::tty_handle& h) {
-            // The remote end is closed, go to EOF process.
-            h.close();
-            bool should_finish = false;
-            {
-              absl::MutexLock lock(&m_mtx_);
-              auto it = m_fwd_meta_map.find(task_id);
-              if (it != m_fwd_meta_map.end() && !it->second.output_stopped) {
-                it->second.output_stopped = true;
-                it->second.input_stopped = true;
-                should_finish = true;
-              }
-            }
-            if (should_finish) on_finish();
-          });
+      th->on<uvw::end_event>([this, task_id, on_finish](uvw::end_event&,
+                                                        uvw::tty_handle& h) {
+        // The remote end is closed, go to EOF process.
+        h.close();
+        bool should_finish = false;
+        {
+          absl::MutexLock lock(&m_mtx_);
+          auto it = m_fwd_meta_map.find(task_id);
+          if (it != m_fwd_meta_map.end() && !it->second.output_stopped) {
+            it->second.output_stopped = true;
+            it->second.input_stopped = true;
+            should_finish = QueueStopTaskIoIfReadyNoLock_(task_id, &it->second);
+          }
+        }
+        if (should_finish) on_finish();
+      });
 
       th->on<uvw::error_event>([this, tid = meta.task_id, on_finish](
                                    uvw::error_event& e, uvw::tty_handle& h) {
@@ -483,7 +489,7 @@ void CforedClient::CleanStdoutFwdHandlerQueueCb_() {
           if (it != m_fwd_meta_map.end() && !it->second.output_stopped) {
             it->second.output_stopped = true;
             it->second.input_stopped = true;
-            should_finish = true;
+            should_finish = QueueStopTaskIoIfReadyNoLock_(tid, &it->second);
           }
         }
         if (should_finish) on_finish();
@@ -516,10 +522,22 @@ void CforedClient::CleanX11FwdHandlerQueueCb_() {
   }
 }
 
+bool CforedClient::QueueStopTaskIoIfReadyNoLock_(task_id_t task_id,
+                                                 TaskFwdMeta* meta) {
+  CRANE_ASSERT(meta != nullptr);
+  if (!meta->output_stopped || !meta->err_stopped ||
+      meta->stop_task_io_queued || meta->io_cleaned)
+    return false;
+
+  CRANE_TRACE("[Task #{}] Queued task io cleanup.", task_id);
+  meta->stop_task_io_queued = true;
+  return true;
+}
+
 void CforedClient::CleanStopTaskIOQueueCb_() {
   task_id_t task_id;
   while (m_stop_task_io_queue_.try_dequeue(task_id)) {
-    bool ok_to_free = false;
+    bool should_finalize = false;
     {
       absl::MutexLock lock(&m_mtx_);
       auto it = m_fwd_meta_map.find(task_id);
@@ -529,6 +547,8 @@ void CforedClient::CleanStopTaskIOQueueCb_() {
         continue;
       }
       auto& meta = it->second;
+      if (meta.io_cleaned) continue;
+
       auto& output_handle = it->second.out_handle;
       if (!meta.pty && output_handle.pipe) output_handle.pipe->close();
       if (meta.pty && output_handle.tty) output_handle.tty->close();
@@ -541,12 +561,11 @@ void CforedClient::CleanStopTaskIOQueueCb_() {
       meta.err_handle.reset();
       meta.stdout_read = -1;
       meta.stderr_read = -1;
+      meta.io_cleaned = true;
 
       CRANE_DEBUG("[Task #{}] Finished its output and err output.", task_id);
 
-      auto& m = m_fwd_meta_map[task_id];
-      ok_to_free = m.proc_stopped;
-      if (ok_to_free) {
+      if (meta.proc_stopped && !meta.exit_status_sent) {
         // Output and stderr fully drained and process already exited.
         // Now it is safe to send TASK_EXIT_STATUS — all TASK_OUTPUT and
         // TASK_ERR_OUTPUT messages have already been enqueued before this
@@ -554,17 +573,64 @@ void CforedClient::CleanStopTaskIOQueueCb_() {
         m_task_fwd_req_queue_.enqueue(FwdRequest{
             .type = StreamStepIORequest::TASK_EXIT_STATUS,
             .data = TaskFinishStatus{.task_id = task_id,
-                                     .exit_code = m.exit_code,
-                                     .signaled = m.signaled},
+                                     .exit_code = meta.exit_code,
+                                     .signaled = meta.signaled},
         });
+        meta.exit_status_sent = true;
+        should_finalize = true;
       }
     }
 
-    if (ok_to_free) {
+    if (should_finalize) {
       CRANE_DEBUG("[Task #{}] It's ok to unregister.", task_id);
       this->TaskEnd(task_id);
     }
   };
+}
+
+void CforedClient::ProcessStopQueueCb_() {
+  ProcessStopQueueElem elem;
+  while (m_process_stop_queue_.try_dequeue(elem)) {
+    bool should_queue_stop_io = false;
+    bool should_finalize = false;
+    {
+      absl::MutexLock lock(&m_mtx_);
+      auto it = m_fwd_meta_map.find(elem.task_id);
+      if (it == m_fwd_meta_map.end()) {
+        CRANE_WARN("[Task #{}] Cannot find fwd meta for process stop.",
+                   elem.task_id);
+        continue;
+      }
+
+      auto& meta = it->second;
+      meta.proc_stopped = true;
+      meta.exit_code = elem.exit_code;
+      meta.signaled = elem.signaled;
+
+      if (meta.io_cleaned && !meta.exit_status_sent) {
+        m_task_fwd_req_queue_.enqueue(FwdRequest{
+            .type = StreamStepIORequest::TASK_EXIT_STATUS,
+            .data = TaskFinishStatus{.task_id = elem.task_id,
+                                     .exit_code = elem.exit_code,
+                                     .signaled = elem.signaled},
+        });
+        meta.exit_status_sent = true;
+        should_finalize = true;
+      } else {
+        should_queue_stop_io =
+            QueueStopTaskIoIfReadyNoLock_(elem.task_id, &meta);
+      }
+    }
+
+    if (should_queue_stop_io) {
+      m_stop_task_io_queue_.enqueue(elem.task_id);
+      m_clean_stop_task_io_queue_async_handle_->send();
+    }
+    if (should_finalize) {
+      CRANE_DEBUG("[Task #{}] It's ok to unregister.", elem.task_id);
+      this->TaskEnd(elem.task_id);
+    }
+  }
 }
 
 void CforedClient::InitChannelAndStub(const std::string& cfored_name) {
@@ -1087,27 +1153,14 @@ void CforedClient::AsyncSendRecvThread_() {
   }
 }
 
-bool CforedClient::TaskProcessStop(task_id_t task_id, uint32_t exit_code,
+void CforedClient::TaskProcessStop(task_id_t task_id, uint32_t exit_code,
                                    bool signaled) {
   CRANE_DEBUG("[Task #{}] Process stopped with exit_code: {}, signaled: {}.",
               task_id, exit_code, signaled);
-  // Store exit info in meta. TASK_EXIT_STATUS is only enqueued after stdout and
-  // stderr are fully drained, so all output messages precede it.
-  absl::MutexLock lock(&m_mtx_);
-  auto& meta = m_fwd_meta_map[task_id];
-  meta.proc_stopped = true;
-  meta.exit_code = exit_code;
-  meta.signaled = signaled;
-  if (meta.output_stopped && meta.err_stopped) {
-    // Output and stderr already drained — safe to send EXIT_STATUS now.
-    m_task_fwd_req_queue_.enqueue(FwdRequest{
-        .type = StreamStepIORequest::TASK_EXIT_STATUS,
-        .data = TaskFinishStatus{.task_id = task_id,
-                                 .exit_code = exit_code,
-                                 .signaled = signaled},
-    });
-  }
-  return meta.output_stopped && meta.err_stopped;
+  m_process_stop_queue_.enqueue(ProcessStopQueueElem{.task_id = task_id,
+                                                     .exit_code = exit_code,
+                                                     .signaled = signaled});
+  m_process_stop_async_handle_->send();
 }
 
 void CforedClient::TaskEnd(task_id_t task_id) {

--- a/src/Craned/Supervisor/CforedClient.cpp
+++ b/src/Craned/Supervisor/CforedClient.cpp
@@ -533,21 +533,24 @@ void CforedClient::CleanStopTaskIOQueueCb_() {
       if (!meta.pty && output_handle.pipe) output_handle.pipe->close();
       if (meta.pty && output_handle.tty) output_handle.tty->close();
       if (meta.err_handle) meta.err_handle->close();
+      // After uvw opens these fds, libuv owns their lifecycle. Closing the raw
+      // fd here can race with fd reuse while libuv still has pending epoll
+      // operations for the handle.
       output_handle.pipe.reset();
       output_handle.tty.reset();
       meta.err_handle.reset();
-
-      if (meta.stdout_read != -1) close(meta.stdout_read);
-      if (meta.stderr_read != -1) close(meta.stderr_read);
+      meta.stdout_read = -1;
+      meta.stderr_read = -1;
 
       CRANE_DEBUG("[Task #{}] Finished its output and err output.", task_id);
 
       auto& m = m_fwd_meta_map[task_id];
       ok_to_free = m.proc_stopped;
       if (ok_to_free) {
-        // Output fully drained and process already exited.
-        // Now it is safe to send TASK_EXIT_STATUS — all TASK_OUTPUT
-        // messages have already been enqueued before this point.
+        // Output and stderr fully drained and process already exited.
+        // Now it is safe to send TASK_EXIT_STATUS — all TASK_OUTPUT and
+        // TASK_ERR_OUTPUT messages have already been enqueued before this
+        // point.
         m_task_fwd_req_queue_.enqueue(FwdRequest{
             .type = StreamStepIORequest::TASK_EXIT_STATUS,
             .data = TaskFinishStatus{.task_id = task_id,
@@ -1088,15 +1091,15 @@ bool CforedClient::TaskProcessStop(task_id_t task_id, uint32_t exit_code,
                                    bool signaled) {
   CRANE_DEBUG("[Task #{}] Process stopped with exit_code: {}, signaled: {}.",
               task_id, exit_code, signaled);
-  // Store exit info in meta. TASK_EXIT_STATUS is only enqueued after
-  // output is fully drained, so that all TASK_OUTPUT messages precede it.
+  // Store exit info in meta. TASK_EXIT_STATUS is only enqueued after stdout and
+  // stderr are fully drained, so all output messages precede it.
   absl::MutexLock lock(&m_mtx_);
   auto& meta = m_fwd_meta_map[task_id];
   meta.proc_stopped = true;
   meta.exit_code = exit_code;
   meta.signaled = signaled;
-  if (meta.output_stopped) {
-    // Output already drained — safe to send EXIT_STATUS now.
+  if (meta.output_stopped && meta.err_stopped) {
+    // Output and stderr already drained — safe to send EXIT_STATUS now.
     m_task_fwd_req_queue_.enqueue(FwdRequest{
         .type = StreamStepIORequest::TASK_EXIT_STATUS,
         .data = TaskFinishStatus{.task_id = task_id,
@@ -1104,7 +1107,7 @@ bool CforedClient::TaskProcessStop(task_id_t task_id, uint32_t exit_code,
                                  .signaled = signaled},
     });
   }
-  return meta.output_stopped;
+  return meta.output_stopped && meta.err_stopped;
 }
 
 void CforedClient::TaskEnd(task_id_t task_id) {

--- a/src/Craned/Supervisor/CforedClient.h
+++ b/src/Craned/Supervisor/CforedClient.h
@@ -55,9 +55,12 @@ class CforedClient {
     bool err_stopped{false};
 
     bool proc_stopped{false};
+    bool stop_task_io_queued{false};
+    bool io_cleaned{false};
+    bool exit_status_sent{false};
 
-    // Deferred exit status: filled by TaskProcessStop(), sent after output
-    // drain to guarantee all TASK_OUTPUT precedes TASK_EXIT_STATUS.
+    // Deferred exit status: filled after SIGCHLD, sent after output drain to
+    // guarantee all TASK_OUTPUT precedes TASK_EXIT_STATUS.
     uint32_t exit_code{0};
     bool signaled{false};
   };
@@ -80,7 +83,7 @@ class CforedClient {
 
   uint16_t InitUvX11FwdHandler();
 
-  bool TaskProcessStop(task_id_t task_id, uint32_t exit_code, bool signaled);
+  void TaskProcessStop(task_id_t task_id, uint32_t exit_code, bool signaled);
   void TaskEnd(task_id_t task_id);
 
   const std::string& CforedName() const { return m_cfored_name_; }
@@ -114,6 +117,18 @@ class CforedClient {
   ConcurrentQueue<task_id_t> m_stop_task_io_queue_;
   std::shared_ptr<uvw::async_handle> m_clean_stop_task_io_queue_async_handle_;
   void CleanStopTaskIOQueueCb_();
+
+  struct ProcessStopQueueElem {
+    task_id_t task_id;
+    uint32_t exit_code;
+    bool signaled;
+  };
+  ConcurrentQueue<ProcessStopQueueElem> m_process_stop_queue_;
+  std::shared_ptr<uvw::async_handle> m_process_stop_async_handle_;
+  void ProcessStopQueueCb_();
+
+  bool QueueStopTaskIoIfReadyNoLock_(task_id_t task_id, TaskFwdMeta* meta)
+      ABSL_EXCLUSIVE_LOCKS_REQUIRED(m_mtx_);
 
   void AsyncSendRecvThread_();
 

--- a/src/Craned/Supervisor/TaskManager.cpp
+++ b/src/Craned/Supervisor/TaskManager.cpp
@@ -3273,12 +3273,8 @@ void TaskManager::EvCleanSigchldQueueCb_() {
       uint32_t exit_code = exit_info->value;
       if (exit_info->is_terminated_by_signal)
         exit_code += ExitCode::KCrunExitCodeStatusNum;
-      auto ok_to_free = m_step_.GetCforedClient()->TaskProcessStop(
+      m_step_.GetCforedClient()->TaskProcessStop(
           task_id, exit_code, exit_info.value().is_terminated_by_signal);
-      if (ok_to_free) {
-        CRANE_TRACE("It's ok to unregister task #{}", task_id);
-        m_step_.GetCforedClient()->TaskEnd(task_id);
-      }
     } else /* Batch / Calloc */ {
       FinalizeTaskAsync(task_id);
     }


### PR DESCRIPTION
## Summary
- avoid supervisor output fd reuse while libuv still owns the handles
- serialize process-stop finalization on the uv loop
- report TASK_EXIT_STATUS only after stdout and stderr are drained

## Verification
- `git diff --check origin/master...HEAD`
- Existing backend build for these changes passed before creating the clean PR branch.
- A fresh configure was blocked by GitHub dependency download failure (libbpf/opentelemetry network).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved task completion handling so process exit notifications are delivered only after task output has been fully drained.
  * Reduced the risk of incomplete or duplicated exit-status notifications during task shutdown.
  * Improved cleanup coordination for tasks ending through standard process exits or terminal sessions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->