### PR TITLE
fix: reject unknown nodes in job submissions

### DIFF
--- a/src/CraneCtld/CMakeLists.txt
+++ b/src/CraneCtld/CMakeLists.txt
@@ -4,6 +4,7 @@ add_executable(cranectld
         Account/AccountDefs.h
         Node/NodeDefs.h
         Node/NodeDefs.cpp
+        Node/NodeListValidation.h
         Node/CranedMetaContainer.h
         Node/CranedMetaContainer.cpp
         Database/DbClient.h

--- a/src/CraneCtld/JobScheduler.cpp
+++ b/src/CraneCtld/JobScheduler.cpp
@@ -18,9 +18,11 @@
 
 #include "JobScheduler.h"
 
+#include <absl/strings/str_join.h>
 #include <absl/time/internal/cctz/src/time_zone_if.h>
 #include <google/protobuf/util/time_util.h>
 
+#include <algorithm>
 #include <iterator>
 #include <map>
 
@@ -31,6 +33,7 @@
 #include "Database/EmbeddedDbClient.h"
 #include "Lua/LuaJobHandler.h"
 #include "Node/CranedMetaContainer.h"
+#include "Node/NodeListValidation.h"
 #include "RpcService/CranedKeeper.h"
 #include "crane/PluginClient.h"
 #include "crane/PrologEpilogExecutor.h"
@@ -8432,6 +8435,23 @@ CraneExpectedRich<void> JobScheduler::AcquireJobAttributes(JobInCtld* job) {
     for (auto&& node : nodes) job->excluded_nodes.emplace(std::move(node));
   }
 
+  auto invalid_nodes =
+      FindNodesNotInPartition(job->included_nodes, part_meta.nodes);
+  if (!invalid_nodes.empty()) {
+    return std::unexpected(FormatRichErr(
+        CraneErrCode::ERR_INVALID_NODE_LIST,
+        "Invalid --nodelist value: nodes '{}' are not in partition '{}'",
+        absl::StrJoin(invalid_nodes, ", "), job->partition_id));
+  }
+
+  invalid_nodes = FindNodesNotInPartition(job->excluded_nodes, part_meta.nodes);
+  if (!invalid_nodes.empty()) {
+    return std::unexpected(FormatRichErr(
+        CraneErrCode::ERR_INVALID_EX_NODE_LIST,
+        "Invalid --exclude value: nodes '{}' are not in partition '{}'",
+        absl::StrJoin(invalid_nodes, ", "), job->partition_id));
+  }
+
   if (!job->JobToCtld().licenses_count().empty()) {
     auto check_licenses_result = g_license_manager->CheckLicensesLegal(
         job->JobToCtld().licenses_count(), job->JobToCtld().is_licenses_or());
@@ -8839,6 +8859,28 @@ CraneExpected<void> JobScheduler::AcquireStepAttributes(StepInCtld* step) {
   auto part_it = g_config.Partitions.find(step->job->partition_id);
   if (part_it != g_config.Partitions.end()) {
     Config::Partition const& part_meta = part_it->second;
+
+    auto invalid_nodes =
+        FindNodesNotInPartition(step->included_nodes, part_meta.nodes);
+    if (!invalid_nodes.empty()) {
+      CRANE_ERROR(
+          "Invalid --nodelist value for step #{}.{}: nodes '{}' are not in "
+          "partition '{}'",
+          step->job_id, step->StepId(), absl::StrJoin(invalid_nodes, ", "),
+          step->job->partition_id);
+      return std::unexpected(CraneErrCode::ERR_INVALID_NODE_LIST);
+    }
+
+    invalid_nodes =
+        FindNodesNotInPartition(step->excluded_nodes, part_meta.nodes);
+    if (!invalid_nodes.empty()) {
+      CRANE_ERROR(
+          "Invalid --exclude value for step #{}.{}: nodes '{}' are not in "
+          "partition '{}'",
+          step->job_id, step->StepId(), absl::StrJoin(invalid_nodes, ", "),
+          step->job->partition_id);
+      return std::unexpected(CraneErrCode::ERR_INVALID_EX_NODE_LIST);
+    }
 
     bool user_set_mem_per_cpu = step->StepToCtld().has_mem_per_cpu();
     bool user_set_mem_per_node = step->StepToCtld().has_mem_per_node();

--- a/src/CraneCtld/Node/NodeListValidation.h
+++ b/src/CraneCtld/Node/NodeListValidation.h
@@ -1,0 +1,41 @@
+/**
+ * Copyright (c) 2024 Peking University and Peking University
+ * Changsha Institute for Computing and Digital Economy
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include <algorithm>
+#include <string>
+#include <unordered_set>
+#include <vector>
+
+namespace Ctld {
+
+inline std::vector<std::string> FindNodesNotInPartition(
+    const std::unordered_set<std::string>& requested_nodes,
+    const std::unordered_set<std::string>& partition_nodes) {
+  std::vector<std::string> invalid_nodes;
+  invalid_nodes.reserve(requested_nodes.size());
+  for (const auto& node : requested_nodes) {
+    if (!partition_nodes.contains(node)) invalid_nodes.emplace_back(node);
+  }
+
+  std::sort(invalid_nodes.begin(), invalid_nodes.end());
+  return invalid_nodes;
+}
+
+}  // namespace Ctld

--- a/test/CraneCtld/CMakeLists.txt
+++ b/test/CraneCtld/CMakeLists.txt
@@ -103,3 +103,15 @@ if (ENABLE_BERKELEY_DB AND BERKELEYDB_FOUND)
     target_link_libraries(ctld_public_defs_test ${BERKELEY_DB_CXX_LIBRARIES})
 endif ()
 gtest_discover_tests(ctld_public_defs_test)
+
+add_executable(node_list_validation_test
+        NodeListValidationTest.cpp
+        ${PROJECT_SOURCE_DIR}/src/CraneCtld/Node/NodeListValidation.h
+        )
+target_link_libraries(node_list_validation_test
+        GTest::gtest
+        GTest::gtest_main
+        )
+target_include_directories(node_list_validation_test PRIVATE
+        ${PROJECT_SOURCE_DIR}/src/CraneCtld)
+gtest_discover_tests(node_list_validation_test)

--- a/test/CraneCtld/NodeListValidationTest.cpp
+++ b/test/CraneCtld/NodeListValidationTest.cpp
@@ -1,0 +1,56 @@
+/**
+ * Copyright (c) 2024 Peking University and Peking University
+ * Changsha Institute for Computing and Digital Economy
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+#include <gtest/gtest.h>
+
+#include <string>
+#include <unordered_set>
+#include <vector>
+
+#include "Node/NodeListValidation.h"
+
+TEST(NodeListValidation, ReturnsNoNodesWhenAllAreInPartition) {
+  const std::unordered_set<std::string> requested{"node01", "node02"};
+  const std::unordered_set<std::string> partition{"node01", "node02", "node03"};
+
+  EXPECT_TRUE(Ctld::FindNodesNotInPartition(requested, partition).empty());
+}
+
+TEST(NodeListValidation, ReturnsAllUnknownNodesInStableOrder) {
+  const std::unordered_set<std::string> requested{"node999", "node997",
+                                                  "node998", "node997"};
+  const std::unordered_set<std::string> partition{"node001", "node998"};
+
+  EXPECT_EQ(Ctld::FindNodesNotInPartition(requested, partition),
+            (std::vector<std::string>{"node997", "node999"}));
+}
+
+TEST(NodeListValidation, ConfiguredDownNodesAreStillValid) {
+  const std::unordered_set<std::string> requested{"node-down"};
+  const std::unordered_set<std::string> partition{"node-down"};
+
+  EXPECT_TRUE(Ctld::FindNodesNotInPartition(requested, partition).empty());
+}
+
+TEST(NodeListValidation, ReturnsAllRequestedNodesForEmptyPartition) {
+  const std::unordered_set<std::string> requested{"node02", "node01"};
+  const std::unordered_set<std::string> partition;
+
+  EXPECT_EQ(Ctld::FindNodesNotInPartition(requested, partition),
+            (std::vector<std::string>{"node01", "node02"}));
+}


### PR DESCRIPTION
## Summary

- reject `--nodelist` nodes that are not members of the selected partition
- reject `--exclude` nodes that are not members of the selected partition
- apply the same validation to step node lists
- return all offending nodes, in deterministic order, in rich job-submission errors
- add focused unit tests for partition-membership validation

## Motivation

Previously, an unknown node in a submission could be silently ignored when another requested node was valid, or produce only a generic resource error. Validate against the configured partition membership before resource scheduling so users receive an actionable error. When multiple unknown nodes are supplied, the error reports the complete set instead of requiring repeated submissions.

## Verification

- `systemd-run --scope -p MemoryMax=15G ninja -C cmake-build-debug -j1 node_list_validation_test cranectld`
- `./cmake-build-debug/test/CraneCtld/node_list_validation_test --gtest_color=no` (4 tests passed)
- `ctest --test-dir cmake-build-debug -R '^NodeListValidation\.' --output-on-failure` (4/4 tests passed)
- `clang-format-20 --dry-run --Werror src/CraneCtld/JobScheduler.cpp src/CraneCtld/Node/NodeListValidation.h test/CraneCtld/NodeListValidationTest.cpp`

This PR intentionally excludes the existing hostlist parser changes in the working tree.